### PR TITLE
socket::shutdown with tests and documentation

### DIFF
--- a/include/boost/corosio/io_stream.hpp
+++ b/include/boost/corosio/io_stream.hpp
@@ -43,10 +43,12 @@ public:
         @return An awaitable that completes with a pair of
             `{error_code, bytes_transferred}`. Returns success with the
             number of bytes read, or an error code on failure including:
-            - capy::error::eof: End of stream reached.
-                Check `ec == cond::eof` for portable comparison.
-            - operation_canceled: Cancelled via stop_token or cancel().
-                Check `ec == cond::canceled` for portable comparison.
+            - cond::eof: The peer closed their send direction by calling
+                shutdown or close, sending a TCP FIN. Use the portable
+                condition test: `if (ec == capy::cond::eof)`
+            - cond::canceled: Cancelled via stop_token or cancel().
+                Use the portable condition test:
+                `if (ec == capy::cond::canceled)`
 
         @par Preconditions
         The socket must be open and connected.

--- a/src/corosio/src/detail/epoll/sockets.hpp
+++ b/src/corosio/src/detail/epoll/sockets.hpp
@@ -137,6 +137,22 @@ public:
         system::error_code*,
         std::size_t*) override;
 
+    system::error_code shutdown(socket::shutdown_type what) noexcept override
+    {
+        int how;
+        switch (what)
+        {
+        case socket::shutdown_receive: how = SHUT_RD;   break;
+        case socket::shutdown_send:    how = SHUT_WR;   break;
+        case socket::shutdown_both:    how = SHUT_RDWR; break;
+        default:
+            return make_err(EINVAL);
+        }
+        if (::shutdown(fd_, how) != 0)
+            return make_err(errno);
+        return {};
+    }
+
     int native_handle() const noexcept { return fd_; }
     bool is_open() const noexcept { return fd_ >= 0; }
     void cancel() noexcept;

--- a/src/corosio/src/detail/iocp/sockets.hpp
+++ b/src/corosio/src/detail/iocp/sockets.hpp
@@ -225,6 +225,22 @@ public:
         internal_->write_some(h, d, buf, token, ec, bytes);
     }
 
+    system::error_code shutdown(socket::shutdown_type what) noexcept override
+    {
+        int how;
+        switch (what)
+        {
+        case socket::shutdown_receive: how = SD_RECEIVE; break;
+        case socket::shutdown_send:    how = SD_SEND;    break;
+        case socket::shutdown_both:    how = SD_BOTH;    break;
+        default:
+            return make_err(WSAEINVAL);
+        }
+        if (::shutdown(internal_->native_handle(), how) != 0)
+            return make_err(WSAGetLastError());
+        return {};
+    }
+
     win_socket_impl_internal* get_internal() const noexcept { return internal_.get(); }
 };
 

--- a/src/corosio/src/socket.cpp
+++ b/src/corosio/src/socket.cpp
@@ -51,7 +51,7 @@ socket::
 open()
 {
     if (impl_)
-        return; // Already open
+        return;
 
     auto& svc = ctx_->use_service<socket_service>();
     auto& wrapper = svc.create_impl();
@@ -75,7 +75,7 @@ socket::
 close()
 {
     if (!impl_)
-        return; // Already closed
+        return;
 
     auto* wrapper = static_cast<socket_impl_type*>(impl_);
     wrapper->release();
@@ -92,6 +92,14 @@ cancel()
 #elif defined(BOOST_COROSIO_BACKEND_EPOLL)
     static_cast<socket_impl_type*>(impl_)->cancel();
 #endif
+}
+
+void
+socket::
+shutdown(shutdown_type what)
+{
+    if (impl_)
+        get().shutdown(what);
 }
 
 } // namespace corosio


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added socket shutdown functionality to disable sends, receives, or both on active connections.

* **Documentation**
  * Clarified read-operation error guidance and portable tests for EOF and operation-canceled conditions.

* **Tests**
  * Added unit tests validating shutdown behaviors (send, receive, both, and shutdown on closed sockets).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->