### PR TITLE
Do not add test dependencies when invoking mr docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ foreach (BOOST_COROSIO_DEPENDENCY ${BOOST_COROSIO_DEPENDENCIES})
 endforeach ()
 
 # Include asio and filesystem which are needed by capy's tests
-if (BOOST_COROSIO_BUILD_TESTS)
+if (BOOST_COROSIO_BUILD_TESTS AND NOT BOOST_COROSIO_MRDOCS_BUILD)
     list(APPEND BOOST_COROSIO_INCLUDE_LIBRARIES asio filesystem)
 endif ()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration to prevent unnecessary library dependencies from being included during documentation generation, resulting in more efficient builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->