### PR TITLE
Initial C++20 module implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ option(BOOST_COROSIO_BUILD_BENCH "Build boost::corosio benchmarks" ${BOOST_COROS
 option(BOOST_COROSIO_BUILD_EXAMPLES "Build boost::corosio examples" ${BOOST_COROSIO_IS_ROOT})
 option(BOOST_COROSIO_BUILD_DOCS "Build boost::corosio documentation" OFF)
 option(BOOST_COROSIO_MRDOCS_BUILD "Building for MrDocs documentation generation" OFF)
+option(BOOST_COROSIO_USE_MODULES "Whether to build boost::corosio using C++20 modules or not" OFF)
 
 # Check if environment variable BOOST_SRC_DIR is set
 if (NOT DEFINED BOOST_SRC_DIR AND DEFINED ENV{BOOST_SRC_DIR})
@@ -184,6 +185,11 @@ endif()
 add_library(boost_corosio ${BOOST_COROSIO_HEADERS} ${BOOST_COROSIO_SOURCES})
 add_library(Boost::corosio ALIAS boost_corosio)
 boost_corosio_setup_properties(boost_corosio)
+
+if (BOOST_COROSIO_USE_MODULES)
+    target_sources(boost_corosio PUBLIC FILE_SET CXX_MODULES BASE_DIRS modules FILES modules/boost_corosio.cppm)
+    target_compile_definitions(boost_corosio PUBLIC BOOST_COROSIO_USE_MODULES)
+endif()
 
 #-------------------------------------------------
 #

--- a/include/boost/corosio/acceptor.hpp
+++ b/include/boost/corosio/acceptor.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_ACCEPTOR_HPP
 #define BOOST_COROSIO_ACCEPTOR_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/detail/config.hpp>
 #include <boost/corosio/detail/except.hpp>
 #include <boost/corosio/io_object.hpp>
@@ -285,4 +289,5 @@ private:
 } // namespace corosio
 } // namespace boost
 
+#endif
 #endif

--- a/include/boost/corosio/endpoint.hpp
+++ b/include/boost/corosio/endpoint.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_ENDPOINT_HPP
 #define BOOST_COROSIO_ENDPOINT_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/detail/config.hpp>
 #include <boost/url/ipv4_address.hpp>
 #include <boost/url/ipv6_address.hpp>
@@ -186,4 +190,5 @@ private:
 } // namespace corosio
 } // namespace boost
 
+#endif
 #endif

--- a/include/boost/corosio/io_buffer_param.hpp
+++ b/include/boost/corosio/io_buffer_param.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_IO_BUFFER_PARAM_HPP
 #define BOOST_COROSIO_IO_BUFFER_PARAM_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/detail/config.hpp>
 #include <boost/capy/buffers.hpp>
 
@@ -382,4 +386,5 @@ private:
 } // namespace corosio
 } // namespace boost
 
+#endif
 #endif

--- a/include/boost/corosio/io_context.hpp
+++ b/include/boost/corosio/io_context.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_IO_CONTEXT_HPP
 #define BOOST_COROSIO_IO_CONTEXT_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/detail/config.hpp>
 #include <boost/corosio/detail/scheduler.hpp>
 #include <boost/corosio/detail/unique_ptr.hpp>
@@ -432,4 +436,5 @@ get_executor() const noexcept ->
 } // namespace corosio
 } // namespace boost
 
+#endif
 #endif

--- a/include/boost/corosio/io_object.hpp
+++ b/include/boost/corosio/io_object.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_IO_OBJECT_HPP
 #define BOOST_COROSIO_IO_OBJECT_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/detail/config.hpp>
 #include <boost/capy/ex/execution_context.hpp>
 
@@ -69,4 +73,5 @@ protected:
 } // namespace corosio
 } // namespace boost
 
+#endif
 #endif

--- a/include/boost/corosio/io_stream.hpp
+++ b/include/boost/corosio/io_stream.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_IO_STREAM_HPP
 #define BOOST_COROSIO_IO_STREAM_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/detail/config.hpp>
 #include <boost/corosio/io_object.hpp>
 #include <boost/capy/io_result.hpp>
@@ -246,4 +250,5 @@ private:
 } // namespace corosio
 } // namespace boost
 
+#endif
 #endif

--- a/include/boost/corosio/read.hpp
+++ b/include/boost/corosio/read.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_READ_HPP
 #define BOOST_COROSIO_READ_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/detail/config.hpp>
 #include <boost/corosio/io_stream.hpp>
 #include <boost/capy/io_result.hpp>
@@ -217,4 +221,5 @@ read(io_stream& ios, std::string& s)
 } // namespace corosio
 } // namespace boost
 
+#endif
 #endif

--- a/include/boost/corosio/resolver.hpp
+++ b/include/boost/corosio/resolver.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_RESOLVER_HPP
 #define BOOST_COROSIO_RESOLVER_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/detail/config.hpp>
 #include <boost/corosio/detail/except.hpp>
 #include <boost/corosio/io_object.hpp>
@@ -340,4 +344,5 @@ private:
 } // namespace corosio
 } // namespace boost
 
+#endif
 #endif

--- a/include/boost/corosio/resolver_results.hpp
+++ b/include/boost/corosio/resolver_results.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_RESOLVER_RESULTS_HPP
 #define BOOST_COROSIO_RESOLVER_RESULTS_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/detail/config.hpp>
 #include <boost/corosio/endpoint.hpp>
 
@@ -205,4 +209,5 @@ public:
 } // namespace corosio
 } // namespace boost
 
+#endif
 #endif

--- a/include/boost/corosio/signal_set.hpp
+++ b/include/boost/corosio/signal_set.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_SIGNAL_SET_HPP
 #define BOOST_COROSIO_SIGNAL_SET_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/detail/config.hpp>
 #include <boost/corosio/detail/except.hpp>
 #include <boost/corosio/io_object.hpp>
@@ -354,4 +358,5 @@ private:
 } // namespace corosio
 } // namespace boost
 
+#endif
 #endif

--- a/include/boost/corosio/socket.hpp
+++ b/include/boost/corosio/socket.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_SOCKET_HPP
 #define BOOST_COROSIO_SOCKET_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/detail/config.hpp>
 #include <boost/corosio/detail/except.hpp>
 #include <boost/corosio/io_stream.hpp>
@@ -334,4 +338,5 @@ private:
 } // namespace corosio
 } // namespace boost
 
+#endif
 #endif

--- a/include/boost/corosio/tcp_server.hpp
+++ b/include/boost/corosio/tcp_server.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_TCP_SERVER_HPP
 #define BOOST_COROSIO_TCP_SERVER_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/detail/config.hpp>
 #include <boost/corosio/acceptor.hpp>
 #include <boost/corosio/socket.hpp>
@@ -334,4 +338,5 @@ public:
 } // corosio
 } // boost
 
+#endif
 #endif

--- a/include/boost/corosio/timer.hpp
+++ b/include/boost/corosio/timer.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_TIMER_HPP
 #define BOOST_COROSIO_TIMER_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/detail/config.hpp>
 #include <boost/corosio/detail/except.hpp>
 #include <boost/corosio/io_object.hpp>
@@ -217,4 +221,5 @@ private:
 } // namespace corosio
 } // namespace boost
 
+#endif
 #endif

--- a/include/boost/corosio/tls/context.hpp
+++ b/include/boost/corosio/tls/context.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_TLS_CONTEXT_HPP
 #define BOOST_COROSIO_TLS_CONTEXT_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/detail/config.hpp>
 #include <boost/system/result.hpp>
 
@@ -864,4 +868,5 @@ public:
 } // namespace corosio
 } // namespace boost
 
+#endif
 #endif

--- a/include/boost/corosio/tls/openssl_stream.hpp
+++ b/include/boost/corosio/tls/openssl_stream.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_TLS_OPENSSL_STREAM_HPP
 #define BOOST_COROSIO_TLS_OPENSSL_STREAM_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/tls/context.hpp>
 #include <boost/corosio/tls/tls_stream.hpp>
 
@@ -68,4 +72,5 @@ public:
 } // namespace corosio
 } // namespace boost
 
+#endif
 #endif

--- a/include/boost/corosio/tls/tls_stream.hpp
+++ b/include/boost/corosio/tls/tls_stream.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_TLS_TLS_STREAM_HPP
 #define BOOST_COROSIO_TLS_TLS_STREAM_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/detail/config.hpp>
 #include <boost/capy/io_result.hpp>
 #include <boost/corosio/io_stream.hpp>
@@ -262,4 +266,5 @@ private:
 } // namespace corosio
 } // namespace boost
 
+#endif
 #endif

--- a/include/boost/corosio/tls/wolfssl_stream.hpp
+++ b/include/boost/corosio/tls/wolfssl_stream.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_TLS_WOLFSSL_STREAM_HPP
 #define BOOST_COROSIO_TLS_WOLFSSL_STREAM_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/detail/config.hpp>
 #include <boost/corosio/tls/context.hpp>
 #include <boost/corosio/tls/tls_stream.hpp>
@@ -70,4 +74,5 @@ public:
 } // namespace corosio
 } // namespace boost
 
+#endif
 #endif

--- a/include/boost/corosio/write.hpp
+++ b/include/boost/corosio/write.hpp
@@ -10,6 +10,10 @@
 #ifndef BOOST_COROSIO_WRITE_HPP
 #define BOOST_COROSIO_WRITE_HPP
 
+#if !defined(BOOST_COROSIO_SOURCE) && defined(BOOST_COROSIO_USE_MODULES)
+import boost.corosio;
+#else
+
 #include <boost/corosio/detail/config.hpp>
 #include <boost/corosio/io_stream.hpp>
 #include <boost/capy/io_result.hpp>
@@ -98,4 +102,5 @@ write(io_stream& ios, ConstBufferSequence const& buffers)
 } // namespace corosio
 } // namespace boost
 
+#endif
 #endif

--- a/modules/boost_corosio.cppm
+++ b/modules/boost_corosio.cppm
@@ -1,0 +1,48 @@
+module;
+
+#include <boost/corosio.hpp>
+
+export module boost.corosio;
+
+export namespace boost::corosio {
+
+using corosio::acceptor;
+using corosio::endpoint;
+using corosio::io_buffer_param;
+using corosio::io_context;
+using corosio::io_object;
+using corosio::io_stream;
+using corosio::read;
+using corosio::resolve_flags;
+using corosio::resolver;
+using corosio::resolver_entry;
+using corosio::resolver_results;
+using corosio::signal_set;
+using corosio::socket;
+using corosio::tcp_server;
+using corosio::timer;
+using corosio::write;
+using corosio::operator|;
+using corosio::operator&;
+using corosio::operator&=;
+using corosio::operator|=;
+
+// I think this should be in tls
+using corosio::tls_stream;
+using corosio::openssl_stream;
+using corosio::wolfssl_stream;
+
+namespace tls {
+using corosio::tls::context;
+using corosio::tls::file_format;
+using corosio::tls::password_purpose;
+using corosio::tls::revocation_policy;
+using corosio::tls::role;
+using corosio::tls::verify_mode;
+using corosio::tls::version;
+} // namespace tls
+
+
+} // namespace boost::corosio
+
+

--- a/test/unit/io_context.cpp
+++ b/test/unit/io_context.cpp
@@ -11,6 +11,7 @@
 #include <boost/corosio/io_context.hpp>
 
 #include <boost/capy/concept/executor.hpp>
+#include <boost/capy/coro.hpp>
 
 #include <atomic>
 #include <chrono>

--- a/test/unit/resolver.cpp
+++ b/test/unit/resolver.cpp
@@ -21,6 +21,8 @@
 #include <boost/capy/cond.hpp>
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/task.hpp>
+#include <boost/url/ipv4_address.hpp>
+#include <boost/url/ipv6_address.hpp>
 
 #include "test_suite.hpp"
 


### PR DESCRIPTION
Closes #70.
Resolves #26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added optional C++20 modules support to the library. Users can now build and consume the library using standard C++20 modules instead of traditional headers by enabling the new build option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->