### PR TITLE
Add benchmark suite comparing Corosio and Asio performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,11 @@ if (BOOST_COROSIO_BUILD_TESTS)
     list(APPEND BOOST_COROSIO_INCLUDE_LIBRARIES asio filesystem)
 endif ()
 
+# Include asio for benchmarks (comparison benchmarks)
+if (BOOST_COROSIO_BUILD_BENCH)
+    list(APPEND BOOST_COROSIO_INCLUDE_LIBRARIES asio)
+endif ()
+
 # Complete dependency list
 set(BOOST_INCLUDE_LIBRARIES ${BOOST_COROSIO_INCLUDE_LIBRARIES})
 set(BOOST_EXCLUDE_LIBRARIES corosio)
@@ -246,4 +251,13 @@ endif ()
 #-------------------------------------------------
 if (BOOST_COROSIO_BUILD_EXAMPLES)
     add_subdirectory(example)
+endif ()
+
+#-------------------------------------------------
+#
+# Benchmarks
+#
+#-------------------------------------------------
+if (BOOST_COROSIO_BUILD_BENCH)
+    add_subdirectory(bench)
 endif ()

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+# Copyright (c) 2026 Steve Gerbino
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+# Official repository: https://github.com/cppalliance/corosio
+#
+
+# Corosio benchmarks
+add_subdirectory(corosio)
+
+# Asio comparison benchmarks (only if Boost.Asio is available)
+if(TARGET Boost::asio)
+    add_subdirectory(asio)
+endif()

--- a/bench/asio/CMakeLists.txt
+++ b/bench/asio/CMakeLists.txt
@@ -1,0 +1,67 @@
+#
+# Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+# Copyright (c) 2026 Steve Gerbino
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+# Official repository: https://github.com/cppalliance/corosio
+#
+
+# Asio benchmark executables for comparison
+
+# io_context benchmark (callbacks)
+add_executable(asio_bench_io_context
+    io_context_bench.cpp)
+target_link_libraries(asio_bench_io_context
+    PRIVATE
+        Boost::asio
+        Threads::Threads)
+target_compile_features(asio_bench_io_context PUBLIC cxx_std_20)
+target_compile_options(asio_bench_io_context
+    PRIVATE
+        $<$<CXX_COMPILER_ID:GNU>:-fcoroutines>)
+set_property(TARGET asio_bench_io_context
+    PROPERTY FOLDER "benchmarks/asio")
+
+# io_context benchmark (coroutines - fair comparison with Corosio)
+add_executable(asio_bench_io_context_coro
+    io_context_coro_bench.cpp)
+target_link_libraries(asio_bench_io_context_coro
+    PRIVATE
+        Boost::asio
+        Threads::Threads)
+target_compile_features(asio_bench_io_context_coro PUBLIC cxx_std_20)
+target_compile_options(asio_bench_io_context_coro
+    PRIVATE
+        $<$<CXX_COMPILER_ID:GNU>:-fcoroutines>)
+set_property(TARGET asio_bench_io_context_coro
+    PROPERTY FOLDER "benchmarks/asio")
+
+# socket throughput benchmark
+add_executable(asio_bench_socket_throughput
+    socket_throughput_bench.cpp)
+target_link_libraries(asio_bench_socket_throughput
+    PRIVATE
+        Boost::asio
+        Threads::Threads)
+target_compile_features(asio_bench_socket_throughput PUBLIC cxx_std_20)
+target_compile_options(asio_bench_socket_throughput
+    PRIVATE
+        $<$<CXX_COMPILER_ID:GNU>:-fcoroutines>)
+set_property(TARGET asio_bench_socket_throughput
+    PROPERTY FOLDER "benchmarks/asio")
+
+# socket latency benchmark
+add_executable(asio_bench_socket_latency
+    socket_latency_bench.cpp)
+target_link_libraries(asio_bench_socket_latency
+    PRIVATE
+        Boost::asio
+        Threads::Threads)
+target_compile_features(asio_bench_socket_latency PUBLIC cxx_std_20)
+target_compile_options(asio_bench_socket_latency
+    PRIVATE
+        $<$<CXX_COMPILER_ID:GNU>:-fcoroutines>)
+set_property(TARGET asio_bench_socket_latency
+    PROPERTY FOLDER "benchmarks/asio")

--- a/bench/asio/io_context_bench.cpp
+++ b/bench/asio/io_context_bench.cpp
@@ -1,0 +1,225 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
+#include <atomic>
+#include <iomanip>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+#include "../common/benchmark.hpp"
+
+namespace asio = boost::asio;
+
+// Benchmark: Single-threaded handler posting rate
+void bench_single_threaded_post(int num_handlers)
+{
+    bench::print_header("Single-threaded Handler Post (Asio)");
+
+    asio::io_context ioc;
+    int counter = 0;
+
+    bench::stopwatch sw;
+
+    for (int i = 0; i < num_handlers; ++i)
+    {
+        asio::post(ioc, [&counter]() { ++counter; });
+    }
+
+    ioc.run();
+
+    double elapsed = sw.elapsed_seconds();
+    double ops_per_sec = static_cast<double>(num_handlers) / elapsed;
+
+    std::cout << "  Handlers:    " << num_handlers << "\n";
+    std::cout << "  Elapsed:     " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "  Throughput:  " << bench::format_rate(ops_per_sec) << "\n";
+
+    if (counter != num_handlers)
+    {
+        std::cerr << "  ERROR: counter mismatch! Expected " << num_handlers
+                  << ", got " << counter << "\n";
+    }
+}
+
+// Benchmark: Multi-threaded scaling
+void bench_multithreaded_scaling(int num_handlers, int max_threads)
+{
+    bench::print_header("Multi-threaded Scaling (Asio)");
+
+    std::cout << "  Handlers per test: " << num_handlers << "\n\n";
+
+    for (int num_threads = 1; num_threads <= max_threads; num_threads *= 2)
+    {
+        asio::io_context ioc;
+        std::atomic<int> counter{0};
+
+        // Post all handlers first
+        for (int i = 0; i < num_handlers; ++i)
+        {
+            asio::post(ioc, [&counter]() {
+                counter.fetch_add(1, std::memory_order_relaxed);
+            });
+        }
+
+        bench::stopwatch sw;
+
+        // Run with multiple threads
+        std::vector<std::thread> runners;
+        for (int t = 0; t < num_threads; ++t)
+            runners.emplace_back([&ioc]() { ioc.run(); });
+
+        for (auto& t : runners)
+            t.join();
+
+        double elapsed = sw.elapsed_seconds();
+        double ops_per_sec = static_cast<double>(num_handlers) / elapsed;
+
+        std::cout << "  " << num_threads << " thread(s): "
+                  << bench::format_rate(ops_per_sec);
+
+        if (num_threads > 1)
+        {
+            static double baseline_ops = 0;
+            if (num_threads == 1)
+                baseline_ops = ops_per_sec;
+            else if (baseline_ops > 0)
+                std::cout << " (speedup: " << std::fixed << std::setprecision(2)
+                          << (ops_per_sec / baseline_ops) << "x)";
+        }
+        std::cout << "\n";
+
+        if (counter.load() != num_handlers)
+        {
+            std::cerr << "  ERROR: counter mismatch! Expected " << num_handlers
+                      << ", got " << counter.load() << "\n";
+        }
+    }
+}
+
+// Benchmark: Post and run interleaved
+void bench_interleaved_post_run(int iterations, int handlers_per_iteration)
+{
+    bench::print_header("Interleaved Post/Run (Asio)");
+
+    asio::io_context ioc;
+    int counter = 0;
+    int total_handlers = iterations * handlers_per_iteration;
+
+    bench::stopwatch sw;
+
+    for (int iter = 0; iter < iterations; ++iter)
+    {
+        for (int i = 0; i < handlers_per_iteration; ++i)
+        {
+            asio::post(ioc, [&counter]() { ++counter; });
+        }
+
+        ioc.poll();
+        ioc.restart();
+    }
+
+    // Run any remaining handlers
+    ioc.run();
+
+    double elapsed = sw.elapsed_seconds();
+    double ops_per_sec = static_cast<double>(total_handlers) / elapsed;
+
+    std::cout << "  Iterations:        " << iterations << "\n";
+    std::cout << "  Handlers/iter:     " << handlers_per_iteration << "\n";
+    std::cout << "  Total handlers:    " << total_handlers << "\n";
+    std::cout << "  Elapsed:           " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "  Throughput:        " << bench::format_rate(ops_per_sec) << "\n";
+
+    if (counter != total_handlers)
+    {
+        std::cerr << "  ERROR: counter mismatch! Expected " << total_handlers
+                  << ", got " << counter << "\n";
+    }
+}
+
+// Benchmark: Multi-threaded concurrent posting and running
+void bench_concurrent_post_run(int num_threads, int handlers_per_thread)
+{
+    bench::print_header("Concurrent Post and Run (Asio)");
+
+    asio::io_context ioc;
+    std::atomic<int> counter{0};
+    int total_handlers = num_threads * handlers_per_thread;
+
+    bench::stopwatch sw;
+
+    // Launch threads that both post and run
+    std::vector<std::thread> workers;
+    for (int t = 0; t < num_threads; ++t)
+    {
+        workers.emplace_back([&ioc, &counter, handlers_per_thread]()
+        {
+            for (int i = 0; i < handlers_per_thread; ++i)
+            {
+                asio::post(ioc, [&counter]() {
+                    counter.fetch_add(1, std::memory_order_relaxed);
+                });
+            }
+            ioc.run();
+        });
+    }
+
+    for (auto& t : workers)
+        t.join();
+
+    double elapsed = sw.elapsed_seconds();
+    double ops_per_sec = static_cast<double>(total_handlers) / elapsed;
+
+    std::cout << "  Threads:           " << num_threads << "\n";
+    std::cout << "  Handlers/thread:   " << handlers_per_thread << "\n";
+    std::cout << "  Total handlers:    " << total_handlers << "\n";
+    std::cout << "  Elapsed:           " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "  Throughput:        " << bench::format_rate(ops_per_sec) << "\n";
+
+    if (counter.load() != total_handlers)
+    {
+        std::cerr << "  ERROR: counter mismatch! Expected " << total_handlers
+                  << ", got " << counter.load() << "\n";
+    }
+}
+
+int main()
+{
+    std::cout << "Boost.Asio io_context Benchmarks\n";
+    std::cout << "=================================\n";
+
+    // Warm up
+    {
+        asio::io_context ioc;
+        int counter = 0;
+        for (int i = 0; i < 1000; ++i)
+            asio::post(ioc, [&counter]() { ++counter; });
+        ioc.run();
+    }
+
+    // Run benchmarks
+    bench_single_threaded_post(1000000);
+    bench_multithreaded_scaling(1000000, 8);
+    bench_interleaved_post_run(10000, 100);
+    bench_concurrent_post_run(4, 250000);
+
+    std::cout << "\nBenchmarks complete.\n";
+    return 0;
+}

--- a/bench/asio/io_context_coro_bench.cpp
+++ b/bench/asio/io_context_coro_bench.cpp
@@ -1,0 +1,308 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+// This benchmark uses coroutines (like Corosio) for a fair comparison,
+// rather than plain callbacks.
+
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
+#include <atomic>
+#include <coroutine>
+#include <iomanip>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+#include "../common/benchmark.hpp"
+
+namespace asio = boost::asio;
+
+// Minimal coroutine that increments a counter when it completes
+// This mirrors the counter_coro pattern used in Corosio benchmarks
+struct counter_coro
+{
+    struct promise_type
+    {
+        int* counter_ = nullptr;
+
+        counter_coro get_return_object()
+        {
+            return {std::coroutine_handle<promise_type>::from_promise(*this)};
+        }
+
+        std::suspend_always initial_suspend() noexcept { return {}; }
+        std::suspend_never final_suspend() noexcept { return {}; }
+
+        void return_void()
+        {
+            if (counter_)
+                ++(*counter_);
+        }
+
+        void unhandled_exception() { std::terminate(); }
+    };
+
+    std::coroutine_handle<promise_type> h;
+};
+
+inline counter_coro make_coro(int& counter)
+{
+    auto c = []() -> counter_coro { co_return; }();
+    c.h.promise().counter_ = &counter;
+    return c;
+}
+
+// Atomic version for multi-threaded benchmarks
+struct atomic_counter_coro
+{
+    struct promise_type
+    {
+        std::atomic<int>* counter_ = nullptr;
+
+        atomic_counter_coro get_return_object()
+        {
+            return {std::coroutine_handle<promise_type>::from_promise(*this)};
+        }
+
+        std::suspend_always initial_suspend() noexcept { return {}; }
+        std::suspend_never final_suspend() noexcept { return {}; }
+
+        void return_void()
+        {
+            if (counter_)
+                counter_->fetch_add(1, std::memory_order_relaxed);
+        }
+
+        void unhandled_exception() { std::terminate(); }
+    };
+
+    std::coroutine_handle<promise_type> h;
+};
+
+inline atomic_counter_coro make_atomic_coro(std::atomic<int>& counter)
+{
+    auto c = []() -> atomic_counter_coro { co_return; }();
+    c.h.promise().counter_ = &counter;
+    return c;
+}
+
+// Post a coroutine handle to the io_context
+// This mimics how Corosio posts coroutines
+inline void post_coro(asio::io_context& ioc, std::coroutine_handle<> h)
+{
+    asio::post(ioc, [h]() { h.resume(); });
+}
+
+// Benchmark: Single-threaded coroutine posting rate
+void bench_single_threaded_post(int num_handlers)
+{
+    bench::print_header("Single-threaded Coroutine Post (Asio)");
+
+    asio::io_context ioc;
+    int counter = 0;
+
+    bench::stopwatch sw;
+
+    for (int i = 0; i < num_handlers; ++i)
+    {
+        auto coro = make_coro(counter);
+        post_coro(ioc, coro.h);
+    }
+
+    ioc.run();
+
+    double elapsed = sw.elapsed_seconds();
+    double ops_per_sec = static_cast<double>(num_handlers) / elapsed;
+
+    std::cout << "  Handlers:    " << num_handlers << "\n";
+    std::cout << "  Elapsed:     " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "  Throughput:  " << bench::format_rate(ops_per_sec) << "\n";
+
+    if (counter != num_handlers)
+    {
+        std::cerr << "  ERROR: counter mismatch! Expected " << num_handlers
+                  << ", got " << counter << "\n";
+    }
+}
+
+// Benchmark: Multi-threaded scaling with coroutines
+void bench_multithreaded_scaling(int num_handlers, int max_threads)
+{
+    bench::print_header("Multi-threaded Scaling (Asio Coroutines)");
+
+    std::cout << "  Handlers per test: " << num_handlers << "\n\n";
+
+    double baseline_ops = 0;
+
+    for (int num_threads = 1; num_threads <= max_threads; num_threads *= 2)
+    {
+        asio::io_context ioc;
+        std::atomic<int> counter{0};
+
+        // Post all coroutines first
+        for (int i = 0; i < num_handlers; ++i)
+        {
+            auto coro = make_atomic_coro(counter);
+            post_coro(ioc, coro.h);
+        }
+
+        bench::stopwatch sw;
+
+        // Run with multiple threads
+        std::vector<std::thread> runners;
+        for (int t = 0; t < num_threads; ++t)
+            runners.emplace_back([&ioc]() { ioc.run(); });
+
+        for (auto& t : runners)
+            t.join();
+
+        double elapsed = sw.elapsed_seconds();
+        double ops_per_sec = static_cast<double>(num_handlers) / elapsed;
+
+        std::cout << "  " << num_threads << " thread(s): "
+                  << bench::format_rate(ops_per_sec);
+
+        if (num_threads == 1)
+            baseline_ops = ops_per_sec;
+        else if (baseline_ops > 0)
+            std::cout << " (speedup: " << std::fixed << std::setprecision(2)
+                      << (ops_per_sec / baseline_ops) << "x)";
+
+        std::cout << "\n";
+
+        if (counter.load() != num_handlers)
+        {
+            std::cerr << "  ERROR: counter mismatch! Expected " << num_handlers
+                      << ", got " << counter.load() << "\n";
+        }
+    }
+}
+
+// Benchmark: Interleaved post and run with coroutines
+void bench_interleaved_post_run(int iterations, int handlers_per_iteration)
+{
+    bench::print_header("Interleaved Post/Run (Asio Coroutines)");
+
+    asio::io_context ioc;
+    int counter = 0;
+    int total_handlers = iterations * handlers_per_iteration;
+
+    bench::stopwatch sw;
+
+    for (int iter = 0; iter < iterations; ++iter)
+    {
+        for (int i = 0; i < handlers_per_iteration; ++i)
+        {
+            auto coro = make_coro(counter);
+            post_coro(ioc, coro.h);
+        }
+
+        ioc.poll();
+        ioc.restart();
+    }
+
+    // Run any remaining handlers
+    ioc.run();
+
+    double elapsed = sw.elapsed_seconds();
+    double ops_per_sec = static_cast<double>(total_handlers) / elapsed;
+
+    std::cout << "  Iterations:        " << iterations << "\n";
+    std::cout << "  Handlers/iter:     " << handlers_per_iteration << "\n";
+    std::cout << "  Total handlers:    " << total_handlers << "\n";
+    std::cout << "  Elapsed:           " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "  Throughput:        " << bench::format_rate(ops_per_sec) << "\n";
+
+    if (counter != total_handlers)
+    {
+        std::cerr << "  ERROR: counter mismatch! Expected " << total_handlers
+                  << ", got " << counter << "\n";
+    }
+}
+
+// Benchmark: Concurrent posting and running with coroutines
+void bench_concurrent_post_run(int num_threads, int handlers_per_thread)
+{
+    bench::print_header("Concurrent Post and Run (Asio Coroutines)");
+
+    asio::io_context ioc;
+    std::atomic<int> counter{0};
+    int total_handlers = num_threads * handlers_per_thread;
+
+    bench::stopwatch sw;
+
+    // Launch threads that both post and run
+    std::vector<std::thread> workers;
+    for (int t = 0; t < num_threads; ++t)
+    {
+        workers.emplace_back([&ioc, &counter, handlers_per_thread]()
+        {
+            for (int i = 0; i < handlers_per_thread; ++i)
+            {
+                auto coro = make_atomic_coro(counter);
+                post_coro(ioc, coro.h);
+            }
+            ioc.run();
+        });
+    }
+
+    for (auto& t : workers)
+        t.join();
+
+    double elapsed = sw.elapsed_seconds();
+    double ops_per_sec = static_cast<double>(total_handlers) / elapsed;
+
+    std::cout << "  Threads:           " << num_threads << "\n";
+    std::cout << "  Handlers/thread:   " << handlers_per_thread << "\n";
+    std::cout << "  Total handlers:    " << total_handlers << "\n";
+    std::cout << "  Elapsed:           " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "  Throughput:        " << bench::format_rate(ops_per_sec) << "\n";
+
+    if (counter.load() != total_handlers)
+    {
+        std::cerr << "  ERROR: counter mismatch! Expected " << total_handlers
+                  << ", got " << counter.load() << "\n";
+    }
+}
+
+int main()
+{
+    std::cout << "Boost.Asio io_context Benchmarks (Coroutine Version)\n";
+    std::cout << "====================================================\n";
+    std::cout << "Using coroutines for fair comparison with Corosio\n";
+
+    // Warm up
+    {
+        asio::io_context ioc;
+        int counter = 0;
+        for (int i = 0; i < 1000; ++i)
+        {
+            auto coro = make_coro(counter);
+            post_coro(ioc, coro.h);
+        }
+        ioc.run();
+    }
+
+    // Run benchmarks
+    bench_single_threaded_post(1000000);
+    bench_multithreaded_scaling(1000000, 8);
+    bench_interleaved_post_run(10000, 100);
+    bench_concurrent_post_run(4, 250000);
+
+    std::cout << "\nBenchmarks complete.\n";
+    return 0;
+}

--- a/bench/asio/socket_latency_bench.cpp
+++ b/bench/asio/socket_latency_bench.cpp
@@ -1,0 +1,200 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include <boost/asio/buffer.hpp>
+
+#include <iostream>
+#include <vector>
+
+#include "../common/benchmark.hpp"
+
+namespace asio = boost::asio;
+using tcp = asio::ip::tcp;
+
+// Create a connected socket pair using TCP loopback
+std::pair<tcp::socket, tcp::socket> make_socket_pair(asio::io_context& ioc)
+{
+    tcp::acceptor acceptor(ioc, tcp::endpoint(tcp::v4(), 0));
+    acceptor.set_option(tcp::acceptor::reuse_address(true));
+
+    tcp::socket client(ioc);
+    tcp::socket server(ioc);
+
+    auto endpoint = acceptor.local_endpoint();
+    client.connect(endpoint);
+    server = acceptor.accept();
+
+    // Disable Nagle's algorithm for low latency
+    client.set_option(tcp::no_delay(true));
+    server.set_option(tcp::no_delay(true));
+
+    return {std::move(client), std::move(server)};
+}
+
+// Ping-pong coroutine task
+asio::awaitable<void> pingpong_task(
+    tcp::socket& client,
+    tcp::socket& server,
+    std::size_t message_size,
+    int iterations,
+    bench::statistics& stats)
+{
+    std::vector<char> send_buf(message_size, 'P');
+    std::vector<char> recv_buf(message_size);
+
+    try
+    {
+        for (int i = 0; i < iterations; ++i)
+        {
+            bench::stopwatch sw;
+
+            // Client sends ping
+            co_await client.async_write_some(
+                asio::buffer(send_buf.data(), send_buf.size()),
+                asio::use_awaitable);
+
+            // Server receives ping
+            auto n = co_await server.async_read_some(
+                asio::buffer(recv_buf.data(), recv_buf.size()),
+                asio::use_awaitable);
+
+            // Server sends pong
+            co_await server.async_write_some(
+                asio::buffer(recv_buf.data(), n),
+                asio::use_awaitable);
+
+            // Client receives pong
+            co_await client.async_read_some(
+                asio::buffer(recv_buf.data(), recv_buf.size()),
+                asio::use_awaitable);
+
+            double rtt_us = sw.elapsed_us();
+            stats.add(rtt_us);
+        }
+    }
+    catch (std::exception const&) {}
+}
+
+// Benchmark: Ping-pong latency measurement
+void bench_pingpong_latency(std::size_t message_size, int iterations)
+{
+    std::cout << "  Message size: " << message_size << " bytes, ";
+    std::cout << "Iterations: " << iterations << "\n";
+
+    asio::io_context ioc;
+    auto [client, server] = make_socket_pair(ioc);
+
+    bench::statistics latency_stats;
+
+    asio::co_spawn(ioc,
+        pingpong_task(client, server, message_size, iterations, latency_stats),
+        asio::detached);
+    ioc.run();
+
+    bench::print_latency_stats(latency_stats, "Round-trip latency");
+    std::cout << "\n";
+
+    client.close();
+    server.close();
+}
+
+// Benchmark: Multiple concurrent socket pairs
+void bench_concurrent_latency(int num_pairs, std::size_t message_size, int iterations)
+{
+    std::cout << "  Concurrent pairs: " << num_pairs << ", ";
+    std::cout << "Message size: " << message_size << " bytes, ";
+    std::cout << "Iterations: " << iterations << "\n";
+
+    asio::io_context ioc;
+
+    // Store sockets and stats separately for safe reference passing
+    std::vector<tcp::socket> clients;
+    std::vector<tcp::socket> servers;
+    std::vector<bench::statistics> stats(num_pairs);
+
+    clients.reserve(num_pairs);
+    servers.reserve(num_pairs);
+
+    for (int i = 0; i < num_pairs; ++i)
+    {
+        auto [c, s] = make_socket_pair(ioc);
+        clients.push_back(std::move(c));
+        servers.push_back(std::move(s));
+    }
+
+    // Launch concurrent ping-pong tasks
+    for (int p = 0; p < num_pairs; ++p)
+    {
+        asio::co_spawn(ioc,
+            pingpong_task(clients[p], servers[p], message_size, iterations, stats[p]),
+            asio::detached);
+    }
+
+    ioc.run();
+
+    std::cout << "  Per-pair results:\n";
+    for (int i = 0; i < num_pairs && i < 3; ++i)
+    {
+        std::cout << "    Pair " << i << ": mean="
+                  << bench::format_latency(stats[i].mean())
+                  << ", p99=" << bench::format_latency(stats[i].p99())
+                  << "\n";
+    }
+    if (num_pairs > 3)
+        std::cout << "    ... (" << (num_pairs - 3) << " more pairs)\n";
+
+    // Calculate average across all pairs
+    double total_mean = 0;
+    double total_p99 = 0;
+    for (auto& s : stats)
+    {
+        total_mean += s.mean();
+        total_p99 += s.p99();
+    }
+    std::cout << "  Average mean latency: "
+              << bench::format_latency(total_mean / num_pairs) << "\n";
+    std::cout << "  Average p99 latency:  "
+              << bench::format_latency(total_p99 / num_pairs) << "\n\n";
+
+    for (auto& c : clients)
+        c.close();
+    for (auto& s : servers)
+        s.close();
+}
+
+int main()
+{
+    std::cout << "Boost.Asio Socket Latency Benchmarks\n";
+    std::cout << "====================================\n";
+
+    bench::print_header("Ping-Pong Round-Trip Latency (Asio)");
+
+    // Variable message sizes
+    std::vector<std::size_t> message_sizes = {1, 64, 1024};
+    int iterations = 1000;
+
+    for (auto size : message_sizes)
+        bench_pingpong_latency(size, iterations);
+
+    bench::print_header("Concurrent Socket Pairs Latency (Asio)");
+
+    // Multiple concurrent connections
+    bench_concurrent_latency(1, 64, 1000);
+    bench_concurrent_latency(4, 64, 500);
+    bench_concurrent_latency(16, 64, 250);
+
+    std::cout << "\nBenchmarks complete.\n";
+    return 0;
+}

--- a/bench/asio/socket_throughput_bench.cpp
+++ b/bench/asio/socket_throughput_bench.cpp
@@ -1,0 +1,252 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include <boost/asio/write.hpp>
+#include <boost/asio/read.hpp>
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/connect.hpp>
+
+#include <iostream>
+#include <vector>
+
+#include "../common/benchmark.hpp"
+
+namespace asio = boost::asio;
+using tcp = asio::ip::tcp;
+
+// Create a connected socket pair using TCP loopback
+std::pair<tcp::socket, tcp::socket> make_socket_pair(asio::io_context& ioc)
+{
+    tcp::acceptor acceptor(ioc, tcp::endpoint(tcp::v4(), 0));
+    acceptor.set_option(tcp::acceptor::reuse_address(true));
+
+    tcp::socket client(ioc);
+    tcp::socket server(ioc);
+
+    auto endpoint = acceptor.local_endpoint();
+    client.connect(endpoint);
+    server = acceptor.accept();
+
+    // Disable Nagle's algorithm for low latency
+    client.set_option(tcp::no_delay(true));
+    server.set_option(tcp::no_delay(true));
+
+    return {std::move(client), std::move(server)};
+}
+
+// Benchmark: Socket throughput with varying buffer sizes
+void bench_throughput(std::size_t chunk_size, std::size_t total_bytes)
+{
+    std::cout << "  Buffer size: " << chunk_size << " bytes, ";
+    std::cout << "Transfer: " << (total_bytes / (1024 * 1024)) << " MB\n";
+
+    asio::io_context ioc;
+    auto [writer, reader] = make_socket_pair(ioc);
+
+    std::vector<char> write_buf(chunk_size, 'x');
+    std::vector<char> read_buf(chunk_size);
+
+    std::size_t total_written = 0;
+    std::size_t total_read = 0;
+
+    // Writer coroutine
+    auto write_task = [&]() -> asio::awaitable<void>
+    {
+        try
+        {
+            while (total_written < total_bytes)
+            {
+                std::size_t to_write = std::min(chunk_size, total_bytes - total_written);
+                auto n = co_await writer.async_write_some(
+                    asio::buffer(write_buf.data(), to_write),
+                    asio::use_awaitable);
+                total_written += n;
+            }
+            writer.shutdown(tcp::socket::shutdown_send);
+        }
+        catch (std::exception const&) {}
+    };
+
+    // Reader coroutine
+    auto read_task = [&]() -> asio::awaitable<void>
+    {
+        try
+        {
+            while (total_read < total_bytes)
+            {
+                auto n = co_await reader.async_read_some(
+                    asio::buffer(read_buf.data(), read_buf.size()),
+                    asio::use_awaitable);
+                if (n == 0)
+                    break;
+                total_read += n;
+            }
+        }
+        catch (std::exception const&) {}
+    };
+
+    bench::stopwatch sw;
+
+    asio::co_spawn(ioc, write_task(), asio::detached);
+    asio::co_spawn(ioc, read_task(), asio::detached);
+    ioc.run();
+
+    double elapsed = sw.elapsed_seconds();
+    double throughput = static_cast<double>(total_read) / elapsed;
+
+    std::cout << "    Written:    " << total_written << " bytes\n";
+    std::cout << "    Read:       " << total_read << " bytes\n";
+    std::cout << "    Elapsed:    " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "    Throughput: " << bench::format_throughput(throughput) << "\n\n";
+
+    writer.close();
+    reader.close();
+}
+
+// Benchmark: Bidirectional throughput
+void bench_bidirectional_throughput(std::size_t chunk_size, std::size_t total_bytes)
+{
+    std::cout << "  Buffer size: " << chunk_size << " bytes, ";
+    std::cout << "Transfer: " << (total_bytes / (1024 * 1024)) << " MB each direction\n";
+
+    asio::io_context ioc;
+    auto [sock1, sock2] = make_socket_pair(ioc);
+
+    std::vector<char> buf1(chunk_size, 'a');
+    std::vector<char> buf2(chunk_size, 'b');
+
+    std::size_t written1 = 0, read1 = 0;
+    std::size_t written2 = 0, read2 = 0;
+
+    // Socket 1 writes to socket 2
+    auto write1_task = [&]() -> asio::awaitable<void>
+    {
+        try
+        {
+            while (written1 < total_bytes)
+            {
+                std::size_t to_write = std::min(chunk_size, total_bytes - written1);
+                auto n = co_await sock1.async_write_some(
+                    asio::buffer(buf1.data(), to_write),
+                    asio::use_awaitable);
+                written1 += n;
+            }
+            sock1.shutdown(tcp::socket::shutdown_send);
+        }
+        catch (std::exception const&) {}
+    };
+
+    // Socket 2 reads from socket 1
+    auto read1_task = [&]() -> asio::awaitable<void>
+    {
+        try
+        {
+            std::vector<char> rbuf(chunk_size);
+            while (read1 < total_bytes)
+            {
+                auto n = co_await sock2.async_read_some(
+                    asio::buffer(rbuf.data(), rbuf.size()),
+                    asio::use_awaitable);
+                if (n == 0) break;
+                read1 += n;
+            }
+        }
+        catch (std::exception const&) {}
+    };
+
+    // Socket 2 writes to socket 1
+    auto write2_task = [&]() -> asio::awaitable<void>
+    {
+        try
+        {
+            while (written2 < total_bytes)
+            {
+                std::size_t to_write = std::min(chunk_size, total_bytes - written2);
+                auto n = co_await sock2.async_write_some(
+                    asio::buffer(buf2.data(), to_write),
+                    asio::use_awaitable);
+                written2 += n;
+            }
+            sock2.shutdown(tcp::socket::shutdown_send);
+        }
+        catch (std::exception const&) {}
+    };
+
+    // Socket 1 reads from socket 2
+    auto read2_task = [&]() -> asio::awaitable<void>
+    {
+        try
+        {
+            std::vector<char> rbuf(chunk_size);
+            while (read2 < total_bytes)
+            {
+                auto n = co_await sock1.async_read_some(
+                    asio::buffer(rbuf.data(), rbuf.size()),
+                    asio::use_awaitable);
+                if (n == 0) break;
+                read2 += n;
+            }
+        }
+        catch (std::exception const&) {}
+    };
+
+    bench::stopwatch sw;
+
+    asio::co_spawn(ioc, write1_task(), asio::detached);
+    asio::co_spawn(ioc, read1_task(), asio::detached);
+    asio::co_spawn(ioc, write2_task(), asio::detached);
+    asio::co_spawn(ioc, read2_task(), asio::detached);
+    ioc.run();
+
+    double elapsed = sw.elapsed_seconds();
+    std::size_t total_transferred = read1 + read2;
+    double throughput = static_cast<double>(total_transferred) / elapsed;
+
+    std::cout << "    Direction 1: " << read1 << " bytes\n";
+    std::cout << "    Direction 2: " << read2 << " bytes\n";
+    std::cout << "    Total:       " << total_transferred << " bytes\n";
+    std::cout << "    Elapsed:     " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "    Throughput:  " << bench::format_throughput(throughput)
+              << " (combined)\n\n";
+
+    sock1.close();
+    sock2.close();
+}
+
+int main()
+{
+    std::cout << "Boost.Asio Socket Throughput Benchmarks\n";
+    std::cout << "=======================================\n";
+
+    bench::print_header("Unidirectional Throughput (Asio)");
+
+    // Variable buffer sizes
+    std::vector<std::size_t> buffer_sizes = {1024, 4096, 16384, 65536};
+    std::size_t transfer_size = 64 * 1024 * 1024; // 64 MB
+
+    for (auto size : buffer_sizes)
+        bench_throughput(size, transfer_size);
+
+    bench::print_header("Bidirectional Throughput (Asio)");
+
+    // Bidirectional with different buffer sizes
+    for (auto size : buffer_sizes)
+        bench_bidirectional_throughput(size, transfer_size / 2);
+
+    std::cout << "\nBenchmarks complete.\n";
+    return 0;
+}

--- a/bench/common/benchmark.hpp
+++ b/bench/common/benchmark.hpp
@@ -1,0 +1,240 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_BENCH_BENCHMARK_HPP
+#define BOOST_COROSIO_BENCH_BENCHMARK_HPP
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace bench {
+
+// RAII timer using steady_clock
+class stopwatch
+{
+public:
+    using clock = std::chrono::steady_clock;
+    using time_point = clock::time_point;
+    using duration = clock::duration;
+
+    stopwatch()
+        : start_(clock::now())
+    {
+    }
+
+    void reset()
+    {
+        start_ = clock::now();
+    }
+
+    duration elapsed() const
+    {
+        return clock::now() - start_;
+    }
+
+    double elapsed_seconds() const
+    {
+        return std::chrono::duration<double>(elapsed()).count();
+    }
+
+    double elapsed_ms() const
+    {
+        return std::chrono::duration<double, std::milli>(elapsed()).count();
+    }
+
+    double elapsed_us() const
+    {
+        return std::chrono::duration<double, std::micro>(elapsed()).count();
+    }
+
+private:
+    time_point start_;
+};
+
+// Statistics collector
+class statistics
+{
+public:
+    void add(double value)
+    {
+        samples_.push_back(value);
+    }
+
+    void clear()
+    {
+        samples_.clear();
+    }
+
+    std::size_t count() const
+    {
+        return samples_.size();
+    }
+
+    double sum() const
+    {
+        return std::accumulate(samples_.begin(), samples_.end(), 0.0);
+    }
+
+    double mean() const
+    {
+        if (samples_.empty())
+            return 0.0;
+        return sum() / static_cast<double>(samples_.size());
+    }
+
+    double variance() const
+    {
+        if (samples_.size() < 2)
+            return 0.0;
+        double m = mean();
+        double sq_sum = 0.0;
+        for (double v : samples_)
+            sq_sum += (v - m) * (v - m);
+        return sq_sum / static_cast<double>(samples_.size() - 1);
+    }
+
+    double stddev() const
+    {
+        return std::sqrt(variance());
+    }
+
+    double min() const
+    {
+        if (samples_.empty())
+            return 0.0;
+        return *std::min_element(samples_.begin(), samples_.end());
+    }
+
+    double max() const
+    {
+        if (samples_.empty())
+            return 0.0;
+        return *std::max_element(samples_.begin(), samples_.end());
+    }
+
+    // Returns the p-th percentile (p in [0, 1])
+    double percentile(double p) const
+    {
+        if (samples_.empty())
+            return 0.0;
+
+        std::vector<double> sorted = samples_;
+        std::sort(sorted.begin(), sorted.end());
+
+        double index = p * static_cast<double>(sorted.size() - 1);
+        std::size_t lower = static_cast<std::size_t>(std::floor(index));
+        std::size_t upper = static_cast<std::size_t>(std::ceil(index));
+
+        if (lower == upper)
+            return sorted[lower];
+
+        double frac = index - static_cast<double>(lower);
+        return sorted[lower] * (1.0 - frac) + sorted[upper] * frac;
+    }
+
+    double p50() const { return percentile(0.50); }
+    double p90() const { return percentile(0.90); }
+    double p99() const { return percentile(0.99); }
+    double p999() const { return percentile(0.999); }
+
+private:
+    std::vector<double> samples_;
+};
+
+// Format operations per second
+inline std::string format_rate(double ops_per_sec)
+{
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(2);
+
+    if (ops_per_sec >= 1e9)
+        oss << (ops_per_sec / 1e9) << " Gops/s";
+    else if (ops_per_sec >= 1e6)
+        oss << (ops_per_sec / 1e6) << " Mops/s";
+    else if (ops_per_sec >= 1e3)
+        oss << (ops_per_sec / 1e3) << " Kops/s";
+    else
+        oss << ops_per_sec << " ops/s";
+
+    return oss.str();
+}
+
+// Format bytes per second
+inline std::string format_throughput(double bytes_per_sec)
+{
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(2);
+
+    if (bytes_per_sec >= 1e9)
+        oss << (bytes_per_sec / 1e9) << " GB/s";
+    else if (bytes_per_sec >= 1e6)
+        oss << (bytes_per_sec / 1e6) << " MB/s";
+    else if (bytes_per_sec >= 1e3)
+        oss << (bytes_per_sec / 1e3) << " KB/s";
+    else
+        oss << bytes_per_sec << " B/s";
+
+    return oss.str();
+}
+
+// Format latency in appropriate units
+inline std::string format_latency(double microseconds)
+{
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(2);
+
+    if (microseconds >= 1e6)
+        oss << (microseconds / 1e6) << " s";
+    else if (microseconds >= 1e3)
+        oss << (microseconds / 1e3) << " ms";
+    else if (microseconds >= 1.0)
+        oss << microseconds << " us";
+    else
+        oss << (microseconds * 1e3) << " ns";
+
+    return oss.str();
+}
+
+// Print a benchmark result header
+inline void print_header(char const* name)
+{
+    std::cout << "\n=== " << name << " ===\n";
+}
+
+// Print a benchmark result
+inline void print_result(char const* label, double value, char const* unit)
+{
+    std::cout << "  " << std::left << std::setw(30) << label
+              << std::right << std::setw(15) << std::fixed << std::setprecision(2)
+              << value << " " << unit << "\n";
+}
+
+// Print latency statistics
+inline void print_latency_stats(statistics const& stats, char const* label)
+{
+    std::cout << "  " << label << ":\n";
+    std::cout << "    mean:  " << format_latency(stats.mean()) << "\n";
+    std::cout << "    p50:   " << format_latency(stats.p50()) << "\n";
+    std::cout << "    p90:   " << format_latency(stats.p90()) << "\n";
+    std::cout << "    p99:   " << format_latency(stats.p99()) << "\n";
+    std::cout << "    p99.9: " << format_latency(stats.p999()) << "\n";
+    std::cout << "    min:   " << format_latency(stats.min()) << "\n";
+    std::cout << "    max:   " << format_latency(stats.max()) << "\n";
+}
+
+} // namespace bench
+
+#endif

--- a/bench/corosio/CMakeLists.txt
+++ b/bench/corosio/CMakeLists.txt
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+# Copyright (c) 2026 Steve Gerbino
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+# Official repository: https://github.com/cppalliance/corosio
+#
+
+# Corosio benchmark executables
+
+# io_context benchmark
+add_executable(corosio_bench_io_context
+    io_context_bench.cpp)
+target_link_libraries(corosio_bench_io_context
+    PRIVATE
+        Boost::corosio
+        Threads::Threads)
+set_property(TARGET corosio_bench_io_context
+    PROPERTY FOLDER "benchmarks/corosio")
+
+# socket throughput benchmark
+add_executable(corosio_bench_socket_throughput
+    socket_throughput_bench.cpp)
+target_link_libraries(corosio_bench_socket_throughput
+    PRIVATE
+        Boost::corosio
+        Threads::Threads)
+set_property(TARGET corosio_bench_socket_throughput
+    PROPERTY FOLDER "benchmarks/corosio")
+
+# socket latency benchmark
+add_executable(corosio_bench_socket_latency
+    socket_latency_bench.cpp)
+target_link_libraries(corosio_bench_socket_latency
+    PRIVATE
+        Boost::corosio
+        Threads::Threads)
+set_property(TARGET corosio_bench_socket_latency
+    PROPERTY FOLDER "benchmarks/corosio")

--- a/bench/corosio/io_context_bench.cpp
+++ b/bench/corosio/io_context_bench.cpp
@@ -1,0 +1,287 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#include <boost/corosio/io_context.hpp>
+
+#include <atomic>
+#include <coroutine>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+#include "../common/benchmark.hpp"
+
+namespace corosio = boost::corosio;
+namespace capy = boost::capy;
+
+// Coroutine that increments a counter when resumed
+struct counter_coro
+{
+    struct promise_type
+    {
+        int* counter_ = nullptr;
+
+        counter_coro get_return_object()
+        {
+            return {std::coroutine_handle<promise_type>::from_promise(*this)};
+        }
+
+        std::suspend_always initial_suspend() noexcept { return {}; }
+        std::suspend_never final_suspend() noexcept { return {}; }
+
+        void return_void()
+        {
+            if (counter_)
+                ++(*counter_);
+        }
+
+        void unhandled_exception() { std::terminate(); }
+    };
+
+    std::coroutine_handle<promise_type> h;
+
+    operator capy::coro() const { return h; }
+};
+
+inline counter_coro make_coro(int& counter)
+{
+    auto c = []() -> counter_coro { co_return; }();
+    c.h.promise().counter_ = &counter;
+    return c;
+}
+
+// Coroutine that increments an atomic counter when resumed
+struct atomic_counter_coro
+{
+    struct promise_type
+    {
+        std::atomic<int>* counter_ = nullptr;
+
+        atomic_counter_coro get_return_object()
+        {
+            return {std::coroutine_handle<promise_type>::from_promise(*this)};
+        }
+
+        std::suspend_always initial_suspend() noexcept { return {}; }
+        std::suspend_never final_suspend() noexcept { return {}; }
+
+        void return_void()
+        {
+            if (counter_)
+                counter_->fetch_add(1, std::memory_order_relaxed);
+        }
+
+        void unhandled_exception() { std::terminate(); }
+    };
+
+    std::coroutine_handle<promise_type> h;
+
+    operator capy::coro() const { return h; }
+};
+
+inline atomic_counter_coro make_atomic_coro(std::atomic<int>& counter)
+{
+    auto c = []() -> atomic_counter_coro { co_return; }();
+    c.h.promise().counter_ = &counter;
+    return c;
+}
+
+// Benchmark: Single-threaded handler posting rate
+void bench_single_threaded_post(int num_handlers)
+{
+    bench::print_header("Single-threaded Handler Post");
+
+    corosio::io_context ioc;
+    auto ex = ioc.get_executor();
+    int counter = 0;
+
+    bench::stopwatch sw;
+
+    for (int i = 0; i < num_handlers; ++i)
+        ex.post(make_coro(counter));
+
+    ioc.run();
+
+    double elapsed = sw.elapsed_seconds();
+    double ops_per_sec = static_cast<double>(num_handlers) / elapsed;
+
+    std::cout << "  Handlers:    " << num_handlers << "\n";
+    std::cout << "  Elapsed:     " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "  Throughput:  " << bench::format_rate(ops_per_sec) << "\n";
+
+    if (counter != num_handlers)
+    {
+        std::cerr << "  ERROR: counter mismatch! Expected " << num_handlers
+                  << ", got " << counter << "\n";
+    }
+}
+
+// Benchmark: Multi-threaded scaling
+void bench_multithreaded_scaling(int num_handlers, int max_threads)
+{
+    bench::print_header("Multi-threaded Scaling");
+
+    std::cout << "  Handlers per test: " << num_handlers << "\n\n";
+
+    for (int num_threads = 1; num_threads <= max_threads; num_threads *= 2)
+    {
+        corosio::io_context ioc;
+        auto ex = ioc.get_executor();
+        std::atomic<int> counter{0};
+
+        // Post all handlers first
+        for (int i = 0; i < num_handlers; ++i)
+            ex.post(make_atomic_coro(counter));
+
+        bench::stopwatch sw;
+
+        // Run with multiple threads
+        std::vector<std::thread> runners;
+        for (int t = 0; t < num_threads; ++t)
+            runners.emplace_back([&ioc]() { ioc.run(); });
+
+        for (auto& t : runners)
+            t.join();
+
+        double elapsed = sw.elapsed_seconds();
+        double ops_per_sec = static_cast<double>(num_handlers) / elapsed;
+
+        std::cout << "  " << num_threads << " thread(s): "
+                  << bench::format_rate(ops_per_sec);
+
+        if (num_threads > 1)
+        {
+            // Calculate speedup vs single-threaded baseline
+            static double baseline_ops = 0;
+            if (num_threads == 1)
+                baseline_ops = ops_per_sec;
+            else if (baseline_ops > 0)
+                std::cout << " (speedup: " << std::fixed << std::setprecision(2)
+                          << (ops_per_sec / baseline_ops) << "x)";
+        }
+        std::cout << "\n";
+
+        if (counter.load() != num_handlers)
+        {
+            std::cerr << "  ERROR: counter mismatch! Expected " << num_handlers
+                      << ", got " << counter.load() << "\n";
+        }
+    }
+}
+
+// Benchmark: Post and run interleaved
+void bench_interleaved_post_run(int iterations, int handlers_per_iteration)
+{
+    bench::print_header("Interleaved Post/Run");
+
+    corosio::io_context ioc;
+    auto ex = ioc.get_executor();
+    int counter = 0;
+    int total_handlers = iterations * handlers_per_iteration;
+
+    bench::stopwatch sw;
+
+    for (int iter = 0; iter < iterations; ++iter)
+    {
+        for (int i = 0; i < handlers_per_iteration; ++i)
+            ex.post(make_coro(counter));
+
+        ioc.poll();
+        ioc.restart();
+    }
+
+    // Run any remaining handlers
+    ioc.run();
+
+    double elapsed = sw.elapsed_seconds();
+    double ops_per_sec = static_cast<double>(total_handlers) / elapsed;
+
+    std::cout << "  Iterations:        " << iterations << "\n";
+    std::cout << "  Handlers/iter:     " << handlers_per_iteration << "\n";
+    std::cout << "  Total handlers:    " << total_handlers << "\n";
+    std::cout << "  Elapsed:           " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "  Throughput:        " << bench::format_rate(ops_per_sec) << "\n";
+
+    if (counter != total_handlers)
+    {
+        std::cerr << "  ERROR: counter mismatch! Expected " << total_handlers
+                  << ", got " << counter << "\n";
+    }
+}
+
+// Benchmark: Multi-threaded concurrent posting and running
+void bench_concurrent_post_run(int num_threads, int handlers_per_thread)
+{
+    bench::print_header("Concurrent Post and Run");
+
+    corosio::io_context ioc;
+    auto ex = ioc.get_executor();
+    std::atomic<int> counter{0};
+    int total_handlers = num_threads * handlers_per_thread;
+
+    bench::stopwatch sw;
+
+    // Launch threads that both post and run
+    std::vector<std::thread> workers;
+    for (int t = 0; t < num_threads; ++t)
+    {
+        workers.emplace_back([&ex, &ioc, &counter, handlers_per_thread]()
+        {
+            for (int i = 0; i < handlers_per_thread; ++i)
+                ex.post(make_atomic_coro(counter));
+            ioc.run();
+        });
+    }
+
+    for (auto& t : workers)
+        t.join();
+
+    double elapsed = sw.elapsed_seconds();
+    double ops_per_sec = static_cast<double>(total_handlers) / elapsed;
+
+    std::cout << "  Threads:           " << num_threads << "\n";
+    std::cout << "  Handlers/thread:   " << handlers_per_thread << "\n";
+    std::cout << "  Total handlers:    " << total_handlers << "\n";
+    std::cout << "  Elapsed:           " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "  Throughput:        " << bench::format_rate(ops_per_sec) << "\n";
+
+    if (counter.load() != total_handlers)
+    {
+        std::cerr << "  ERROR: counter mismatch! Expected " << total_handlers
+                  << ", got " << counter.load() << "\n";
+    }
+}
+
+int main()
+{
+    std::cout << "Boost.Corosio io_context Benchmarks\n";
+    std::cout << "====================================\n";
+
+    // Warm up
+    {
+        corosio::io_context ioc;
+        auto ex = ioc.get_executor();
+        int counter = 0;
+        for (int i = 0; i < 1000; ++i)
+            ex.post(make_coro(counter));
+        ioc.run();
+    }
+
+    // Run benchmarks
+    bench_single_threaded_post(1000000);
+    bench_multithreaded_scaling(1000000, 8);
+    bench_interleaved_post_run(10000, 100);
+    bench_concurrent_post_run(4, 250000);
+
+    std::cout << "\nBenchmarks complete.\n";
+    return 0;
+}

--- a/bench/corosio/socket_latency_bench.cpp
+++ b/bench/corosio/socket_latency_bench.cpp
@@ -1,0 +1,217 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#include <boost/corosio/io_context.hpp>
+#include <boost/corosio/socket.hpp>
+#include <boost/corosio/test/socket_pair.hpp>
+#include <boost/capy/buffers.hpp>
+#include <boost/capy/ex/run_async.hpp>
+#include <boost/capy/task.hpp>
+
+#include <iostream>
+#include <vector>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#endif
+
+#include "../common/benchmark.hpp"
+
+namespace corosio = boost::corosio;
+namespace capy = boost::capy;
+
+// Helper to set TCP_NODELAY on a socket for low latency
+inline void set_nodelay(corosio::socket& s)
+{
+    int flag = 1;
+#ifdef _WIN32
+    ::setsockopt(static_cast<SOCKET>(s.native_handle()), IPPROTO_TCP, TCP_NODELAY,
+                 reinterpret_cast<const char*>(&flag), sizeof(flag));
+#else
+    ::setsockopt(s.native_handle(), IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
+#endif
+}
+
+// Ping-pong coroutine task
+capy::task<> pingpong_task(
+    corosio::socket& client,
+    corosio::socket& server,
+    std::size_t message_size,
+    int iterations,
+    bench::statistics& stats)
+{
+    std::vector<char> send_buf(message_size, 'P');
+    std::vector<char> recv_buf(message_size);
+
+    for (int i = 0; i < iterations; ++i)
+    {
+        bench::stopwatch sw;
+
+        // Client sends ping
+        auto [ec1, n1] = co_await client.write_some(
+            capy::const_buffer(send_buf.data(), send_buf.size()));
+        if (ec1)
+        {
+            std::cerr << "    Write error: " << ec1.message() << "\n";
+            co_return;
+        }
+
+        // Server receives ping
+        auto [ec2, n2] = co_await server.read_some(
+            capy::mutable_buffer(recv_buf.data(), recv_buf.size()));
+        if (ec2)
+        {
+            std::cerr << "    Server read error: " << ec2.message() << "\n";
+            co_return;
+        }
+
+        // Server sends pong
+        auto [ec3, n3] = co_await server.write_some(
+            capy::const_buffer(recv_buf.data(), n2));
+        if (ec3)
+        {
+            std::cerr << "    Server write error: " << ec3.message() << "\n";
+            co_return;
+        }
+
+        // Client receives pong
+        auto [ec4, n4] = co_await client.read_some(
+            capy::mutable_buffer(recv_buf.data(), recv_buf.size()));
+        if (ec4)
+        {
+            std::cerr << "    Client read error: " << ec4.message() << "\n";
+            co_return;
+        }
+
+        double rtt_us = sw.elapsed_us();
+        stats.add(rtt_us);
+    }
+}
+
+// Benchmark: Ping-pong latency measurement
+void bench_pingpong_latency(std::size_t message_size, int iterations)
+{
+    std::cout << "  Message size: " << message_size << " bytes, ";
+    std::cout << "Iterations: " << iterations << "\n";
+
+    corosio::io_context ioc;
+    auto [client, server] = corosio::test::make_socket_pair(ioc);
+
+    // Disable Nagle's algorithm for low latency
+    set_nodelay(client);
+    set_nodelay(server);
+
+    bench::statistics latency_stats;
+
+    capy::run_async(ioc.get_executor())(
+        pingpong_task(client, server, message_size, iterations, latency_stats));
+    ioc.run();
+
+    bench::print_latency_stats(latency_stats, "Round-trip latency");
+    std::cout << "\n";
+
+    client.close();
+    server.close();
+}
+
+// Benchmark: Multiple concurrent socket pairs
+void bench_concurrent_latency(int num_pairs, std::size_t message_size, int iterations)
+{
+    std::cout << "  Concurrent pairs: " << num_pairs << ", ";
+    std::cout << "Message size: " << message_size << " bytes, ";
+    std::cout << "Iterations: " << iterations << "\n";
+
+    corosio::io_context ioc;
+
+    // Store sockets and stats separately for safe reference passing
+    std::vector<corosio::socket> clients;
+    std::vector<corosio::socket> servers;
+    std::vector<bench::statistics> stats(num_pairs);
+
+    clients.reserve(num_pairs);
+    servers.reserve(num_pairs);
+
+    for (int i = 0; i < num_pairs; ++i)
+    {
+        auto [c, s] = corosio::test::make_socket_pair(ioc);
+        // Disable Nagle's algorithm for low latency
+        set_nodelay(c);
+        set_nodelay(s);
+        clients.push_back(std::move(c));
+        servers.push_back(std::move(s));
+    }
+
+    // Launch concurrent ping-pong tasks
+    for (int p = 0; p < num_pairs; ++p)
+    {
+        capy::run_async(ioc.get_executor())(
+            pingpong_task(clients[p], servers[p], message_size, iterations, stats[p]));
+    }
+
+    ioc.run();
+
+    std::cout << "  Per-pair results:\n";
+    for (int i = 0; i < num_pairs && i < 3; ++i)
+    {
+        std::cout << "    Pair " << i << ": mean="
+                  << bench::format_latency(stats[i].mean())
+                  << ", p99=" << bench::format_latency(stats[i].p99())
+                  << "\n";
+    }
+    if (num_pairs > 3)
+        std::cout << "    ... (" << (num_pairs - 3) << " more pairs)\n";
+
+    // Calculate average across all pairs
+    double total_mean = 0;
+    double total_p99 = 0;
+    for (auto& s : stats)
+    {
+        total_mean += s.mean();
+        total_p99 += s.p99();
+    }
+    std::cout << "  Average mean latency: "
+              << bench::format_latency(total_mean / num_pairs) << "\n";
+    std::cout << "  Average p99 latency:  "
+              << bench::format_latency(total_p99 / num_pairs) << "\n\n";
+
+    for (auto& c : clients)
+        c.close();
+    for (auto& s : servers)
+        s.close();
+}
+
+int main()
+{
+    std::cout << "Boost.Corosio Socket Latency Benchmarks\n";
+    std::cout << "=======================================\n";
+
+    bench::print_header("Ping-Pong Round-Trip Latency");
+
+    // Variable message sizes
+    std::vector<std::size_t> message_sizes = {1, 64, 1024};
+    int iterations = 1000;
+
+    for (auto size : message_sizes)
+        bench_pingpong_latency(size, iterations);
+
+    bench::print_header("Concurrent Socket Pairs Latency");
+
+    // Multiple concurrent connections
+    bench_concurrent_latency(1, 64, 1000);
+    bench_concurrent_latency(4, 64, 500);
+    bench_concurrent_latency(16, 64, 250);
+
+    std::cout << "\nBenchmarks complete.\n";
+    return 0;
+}

--- a/bench/corosio/socket_throughput_bench.cpp
+++ b/bench/corosio/socket_throughput_bench.cpp
@@ -1,0 +1,244 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#include <boost/corosio/io_context.hpp>
+#include <boost/corosio/socket.hpp>
+#include <boost/corosio/test/socket_pair.hpp>
+#include <boost/capy/buffers.hpp>
+#include <boost/capy/ex/run_async.hpp>
+#include <boost/capy/task.hpp>
+
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#endif
+
+#include "../common/benchmark.hpp"
+
+namespace corosio = boost::corosio;
+namespace capy = boost::capy;
+
+// Helper to set TCP_NODELAY on a socket for low latency
+inline void set_nodelay(corosio::socket& s)
+{
+    int flag = 1;
+#ifdef _WIN32
+    ::setsockopt(static_cast<SOCKET>(s.native_handle()), IPPROTO_TCP, TCP_NODELAY,
+                 reinterpret_cast<const char*>(&flag), sizeof(flag));
+#else
+    ::setsockopt(s.native_handle(), IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
+#endif
+}
+
+// Benchmark: Socket throughput with varying buffer sizes
+void bench_throughput(std::size_t chunk_size, std::size_t total_bytes)
+{
+    std::cout << "  Buffer size: " << chunk_size << " bytes, ";
+    std::cout << "Transfer: " << (total_bytes / (1024 * 1024)) << " MB\n";
+
+    corosio::io_context ioc;
+    auto [writer, reader] = corosio::test::make_socket_pair(ioc);
+
+    // Disable Nagle's algorithm for fair comparison with Asio
+    set_nodelay(writer);
+    set_nodelay(reader);
+
+    std::vector<char> write_buf(chunk_size, 'x');
+    std::vector<char> read_buf(chunk_size);
+
+    std::size_t total_written = 0;
+    std::size_t total_read = 0;
+    bool writer_done = false;
+
+    // Writer coroutine
+    auto write_task = [&]() -> capy::task<>
+    {
+        while (total_written < total_bytes)
+        {
+            std::size_t to_write = std::min(chunk_size, total_bytes - total_written);
+            auto [ec, n] = co_await writer.write_some(
+                capy::const_buffer(write_buf.data(), to_write));
+            if (ec)
+            {
+                std::cerr << "    Write error: " << ec.message() << "\n";
+                break;
+            }
+            total_written += n;
+        }
+        writer_done = true;
+        writer.shutdown(corosio::socket::shutdown_send);
+    };
+
+    // Reader coroutine
+    auto read_task = [&]() -> capy::task<>
+    {
+        while (total_read < total_bytes)
+        {
+            auto [ec, n] = co_await reader.read_some(
+                capy::mutable_buffer(read_buf.data(), read_buf.size()));
+            if (ec)
+            {
+                if (writer_done && total_read >= total_bytes)
+                    break;
+                std::cerr << "    Read error: " << ec.message() << "\n";
+                break;
+            }
+            if (n == 0)
+                break;
+            total_read += n;
+        }
+    };
+
+    bench::stopwatch sw;
+
+    capy::run_async(ioc.get_executor())(write_task());
+    capy::run_async(ioc.get_executor())(read_task());
+    ioc.run();
+
+    double elapsed = sw.elapsed_seconds();
+    double throughput = static_cast<double>(total_read) / elapsed;
+
+    std::cout << "    Written:    " << total_written << " bytes\n";
+    std::cout << "    Read:       " << total_read << " bytes\n";
+    std::cout << "    Elapsed:    " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "    Throughput: " << bench::format_throughput(throughput) << "\n\n";
+
+    writer.close();
+    reader.close();
+}
+
+// Benchmark: Bidirectional throughput
+void bench_bidirectional_throughput(std::size_t chunk_size, std::size_t total_bytes)
+{
+    std::cout << "  Buffer size: " << chunk_size << " bytes, ";
+    std::cout << "Transfer: " << (total_bytes / (1024 * 1024)) << " MB each direction\n";
+
+    corosio::io_context ioc;
+    auto [sock1, sock2] = corosio::test::make_socket_pair(ioc);
+
+    // Disable Nagle's algorithm for fair comparison with Asio
+    set_nodelay(sock1);
+    set_nodelay(sock2);
+
+    std::vector<char> buf1(chunk_size, 'a');
+    std::vector<char> buf2(chunk_size, 'b');
+
+    std::size_t written1 = 0, read1 = 0;
+    std::size_t written2 = 0, read2 = 0;
+
+    // Socket 1 writes to socket 2
+    auto write1_task = [&]() -> capy::task<>
+    {
+        while (written1 < total_bytes)
+        {
+            std::size_t to_write = std::min(chunk_size, total_bytes - written1);
+            auto [ec, n] = co_await sock1.write_some(
+                capy::const_buffer(buf1.data(), to_write));
+            if (ec) break;
+            written1 += n;
+        }
+        sock1.shutdown(corosio::socket::shutdown_send);
+    };
+
+    // Socket 2 reads from socket 1
+    auto read1_task = [&]() -> capy::task<>
+    {
+        std::vector<char> rbuf(chunk_size);
+        while (read1 < total_bytes)
+        {
+            auto [ec, n] = co_await sock2.read_some(
+                capy::mutable_buffer(rbuf.data(), rbuf.size()));
+            if (ec || n == 0) break;
+            read1 += n;
+        }
+    };
+
+    // Socket 2 writes to socket 1
+    auto write2_task = [&]() -> capy::task<>
+    {
+        while (written2 < total_bytes)
+        {
+            std::size_t to_write = std::min(chunk_size, total_bytes - written2);
+            auto [ec, n] = co_await sock2.write_some(
+                capy::const_buffer(buf2.data(), to_write));
+            if (ec) break;
+            written2 += n;
+        }
+        sock2.shutdown(corosio::socket::shutdown_send);
+    };
+
+    // Socket 1 reads from socket 2
+    auto read2_task = [&]() -> capy::task<>
+    {
+        std::vector<char> rbuf(chunk_size);
+        while (read2 < total_bytes)
+        {
+            auto [ec, n] = co_await sock1.read_some(
+                capy::mutable_buffer(rbuf.data(), rbuf.size()));
+            if (ec || n == 0) break;
+            read2 += n;
+        }
+    };
+
+    bench::stopwatch sw;
+
+    capy::run_async(ioc.get_executor())(write1_task());
+    capy::run_async(ioc.get_executor())(read1_task());
+    capy::run_async(ioc.get_executor())(write2_task());
+    capy::run_async(ioc.get_executor())(read2_task());
+    ioc.run();
+
+    double elapsed = sw.elapsed_seconds();
+    std::size_t total_transferred = read1 + read2;
+    double throughput = static_cast<double>(total_transferred) / elapsed;
+
+    std::cout << "    Direction 1: " << read1 << " bytes\n";
+    std::cout << "    Direction 2: " << read2 << " bytes\n";
+    std::cout << "    Total:       " << total_transferred << " bytes\n";
+    std::cout << "    Elapsed:     " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "    Throughput:  " << bench::format_throughput(throughput)
+              << " (combined)\n\n";
+
+    sock1.close();
+    sock2.close();
+}
+
+int main()
+{
+    std::cout << "Boost.Corosio Socket Throughput Benchmarks\n";
+    std::cout << "==========================================\n";
+
+    bench::print_header("Unidirectional Throughput");
+
+    // Variable buffer sizes
+    std::vector<std::size_t> buffer_sizes = {1024, 4096, 16384, 65536};
+    std::size_t transfer_size = 64 * 1024 * 1024; // 64 MB
+
+    for (auto size : buffer_sizes)
+        bench_throughput(size, transfer_size);
+
+    bench::print_header("Bidirectional Throughput");
+
+    // Bidirectional with different buffer sizes
+    for (auto size : buffer_sizes)
+        bench_bidirectional_throughput(size, transfer_size / 2);
+
+    std::cout << "\nBenchmarks complete.\n";
+    return 0;
+}

--- a/include/boost/corosio/socket.hpp
+++ b/include/boost/corosio/socket.hpp
@@ -34,6 +34,12 @@
 namespace boost {
 namespace corosio {
 
+#ifdef _WIN32
+using native_handle_type = std::uintptr_t;  // SOCKET
+#else
+using native_handle_type = int;
+#endif
+
 /** An asynchronous TCP socket for coroutine I/O.
 
     This class provides asynchronous TCP socket operations that return
@@ -92,6 +98,8 @@ public:
             system::error_code*) = 0;
 
         virtual system::error_code shutdown(shutdown_type) noexcept = 0;
+
+        virtual native_handle_type native_handle() const noexcept = 0;
     };
 
     struct connect_awaitable
@@ -280,6 +288,19 @@ public:
         Check `ec == cond::canceled` for portable comparison.
     */
     void cancel();
+
+    /** Get the native socket handle.
+
+        Returns the underlying platform-specific socket descriptor.
+        On POSIX systems this is an `int` file descriptor.
+        On Windows this is a `SOCKET` handle.
+
+        @return The native socket handle, or -1/INVALID_SOCKET if not open.
+
+        @par Preconditions
+        None. May be called on closed sockets.
+    */
+    native_handle_type native_handle() const noexcept;
 
     /** Disable sends or receives on the socket.
 

--- a/src/corosio/src/detail/epoll/sockets.hpp
+++ b/src/corosio/src/detail/epoll/sockets.hpp
@@ -128,7 +128,7 @@ public:
 
     system::error_code shutdown(socket::shutdown_type what) noexcept override;
 
-    int native_handle() const noexcept { return fd_; }
+    native_handle_type native_handle() const noexcept override { return fd_; }
     bool is_open() const noexcept { return fd_ >= 0; }
     void cancel() noexcept;
     void close_socket() noexcept;

--- a/src/corosio/src/detail/iocp/sockets.hpp
+++ b/src/corosio/src/detail/iocp/sockets.hpp
@@ -241,6 +241,11 @@ public:
         return {};
     }
 
+    native_handle_type native_handle() const noexcept override
+    {
+        return static_cast<native_handle_type>(internal_->native_handle());
+    }
+
     win_socket_impl_internal* get_internal() const noexcept { return internal_.get(); }
 };
 

--- a/src/corosio/src/socket.cpp
+++ b/src/corosio/src/socket.cpp
@@ -102,5 +102,20 @@ shutdown(shutdown_type what)
         get().shutdown(what);
 }
 
+native_handle_type
+socket::
+native_handle() const noexcept
+{
+    if (!impl_)
+    {
+#if defined(BOOST_COROSIO_BACKEND_IOCP)
+        return static_cast<native_handle_type>(~0ull);  // INVALID_SOCKET
+#else
+        return -1;
+#endif
+    }
+    return get().native_handle();
+}
+
 } // namespace corosio
 } // namespace boost


### PR DESCRIPTION
Implement comprehensive benchmarks for scheduler and socket I/O operations, with equivalent Asio implementations for fair comparison.

Benchmarks added:
- io_context: handler posting throughput, multi-threaded scaling
- socket throughput: unidirectional and bidirectional transfer rates
- socket latency: ping-pong round-trip times and concurrent connections

Directory structure:
  bench/
  ├── common/benchmark.hpp    - Shared timing utilities and statistics
  ├── corosio/                - Corosio benchmarks using capy::task<>
  └── asio/                   - Asio benchmarks using asio::awaitable<>

Both benchmark suites use coroutines for apples-to-apples comparison. TCP_NODELAY is enabled on all sockets to ensure fair latency measurements.

Also adds socket::native_handle() to expose the underlying file descriptor, enabling socket option configuration (e.g., TCP_NODELAY) from user code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public API to access underlying native socket handles, enabling advanced use cases requiring direct interaction with platform-specific socket descriptors.

* **Chores**
  * Enhanced build system to support benchmark compilation configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->