### PR TITLE
Add socket endpoint query methods (local_endpoint/remote_endpoint)

### DIFF
--- a/example/echo-server/echo_server.cpp
+++ b/example/echo-server/echo_server.cpp
@@ -10,6 +10,7 @@
 #include <boost/corosio/tcp_server.hpp>
 #include <boost/capy/task.hpp>
 #include <boost/capy/buffers.hpp>
+#include <boost/capy/write.hpp>
 
 #include <cstdlib>
 #include <iostream>
@@ -60,7 +61,7 @@ class echo_server : public corosio::tcp_server
                 buf_.resize(n);
 
                 // Echo it back
-                auto [wec, wn] = co_await corosio::write(
+                auto [wec, wn] = co_await capy::write(
                     sock_, capy::const_buffer(buf_.data(), buf_.size()));
 
                 if (wec)

--- a/include/boost/corosio/acceptor.hpp
+++ b/include/boost/corosio/acceptor.hpp
@@ -264,6 +264,24 @@ public:
     */
     void cancel();
 
+    /** Get the local endpoint of the acceptor.
+
+        Returns the local address and port to which the acceptor is bound.
+        This is useful when binding to port 0 (ephemeral port) to discover
+        the OS-assigned port number. The endpoint is cached when listen()
+        is called.
+
+        @return The local endpoint, or a default endpoint (0.0.0.0:0) if
+            the acceptor is not listening.
+
+        @par Thread Safety
+        The cached endpoint value is set during listen() and cleared
+        during close(). This function may be called concurrently with
+        accept operations, but must not be called concurrently with
+        listen() or close().
+    */
+    endpoint local_endpoint() const noexcept;
+
     struct acceptor_impl : io_object_impl
     {
         virtual void accept(
@@ -272,6 +290,9 @@ public:
             std::stop_token,
             system::error_code*,
             io_object_impl**) = 0;
+
+        /// Returns the cached local endpoint.
+        virtual endpoint local_endpoint() const noexcept = 0;
     };
 
 private:

--- a/include/boost/corosio/socket.hpp
+++ b/include/boost/corosio/socket.hpp
@@ -117,6 +117,12 @@ public:
 
         virtual system::error_code set_linger(bool enabled, int timeout) noexcept = 0;
         virtual linger_options linger(system::error_code& ec) const noexcept = 0;
+
+        /// Returns the cached local endpoint.
+        virtual endpoint local_endpoint() const noexcept = 0;
+
+        /// Returns the cached remote endpoint.
+        virtual endpoint remote_endpoint() const noexcept = 0;
     };
 
     struct connect_awaitable
@@ -469,6 +475,39 @@ public:
         @throws std::system_error on failure.
     */
     linger_options linger() const;
+
+    /** Get the local endpoint of the socket.
+
+        Returns the local address and port to which the socket is bound.
+        For a connected socket, this is the local side of the connection.
+        The endpoint is cached when the connection is established.
+
+        @return The local endpoint, or a default endpoint (0.0.0.0:0) if
+            the socket is not connected.
+
+        @par Thread Safety
+        The cached endpoint value is set during connect/accept completion
+        and cleared during close(). This function may be called concurrently
+        with I/O operations, but must not be called concurrently with
+        connect(), accept(), or close().
+    */
+    endpoint local_endpoint() const noexcept;
+
+    /** Get the remote endpoint of the socket.
+
+        Returns the remote address and port to which the socket is connected.
+        The endpoint is cached when the connection is established.
+
+        @return The remote endpoint, or a default endpoint (0.0.0.0:0) if
+            the socket is not connected.
+
+        @par Thread Safety
+        The cached endpoint value is set during connect/accept completion
+        and cleared during close(). This function may be called concurrently
+        with I/O operations, but must not be called concurrently with
+        connect(), accept(), or close().
+    */
+    endpoint remote_endpoint() const noexcept;
 
 private:
     friend class acceptor;

--- a/src/corosio/src/acceptor.cpp
+++ b/src/corosio/src/acceptor.cpp
@@ -96,5 +96,14 @@ cancel()
 #endif
 }
 
+endpoint
+acceptor::
+local_endpoint() const noexcept
+{
+    if (!impl_)
+        return endpoint{};
+    return get().local_endpoint();
+}
+
 } // namespace corosio
 } // namespace boost

--- a/src/corosio/src/detail/epoll/sockets.hpp
+++ b/src/corosio/src/detail/epoll/sockets.hpp
@@ -144,11 +144,19 @@ public:
 
     system::error_code set_linger(bool enabled, int timeout) noexcept override;
     socket::linger_options linger(system::error_code& ec) const noexcept override;
+
+    endpoint local_endpoint() const noexcept override { return local_endpoint_; }
+    endpoint remote_endpoint() const noexcept override { return remote_endpoint_; }
     bool is_open() const noexcept { return fd_ >= 0; }
     void cancel() noexcept;
     void cancel_single_op(epoll_op& op) noexcept;
     void close_socket() noexcept;
     void set_socket(int fd) noexcept { fd_ = fd; }
+    void set_endpoints(endpoint local, endpoint remote) noexcept
+    {
+        local_endpoint_ = local;
+        remote_endpoint_ = remote;
+    }
 
     epoll_connect_op conn_;
     epoll_read_op rd_;
@@ -157,6 +165,8 @@ public:
 private:
     epoll_sockets& svc_;
     int fd_ = -1;
+    endpoint local_endpoint_;
+    endpoint remote_endpoint_;
 };
 
 //------------------------------------------------------------------------------
@@ -181,16 +191,19 @@ public:
         io_object::io_object_impl**) override;
 
     int native_handle() const noexcept { return fd_; }
+    endpoint local_endpoint() const noexcept override { return local_endpoint_; }
     bool is_open() const noexcept { return fd_ >= 0; }
     void cancel() noexcept;
     void cancel_single_op(epoll_op& op) noexcept;
     void close_socket() noexcept;
+    void set_local_endpoint(endpoint ep) noexcept { local_endpoint_ = ep; }
 
     epoll_accept_op acc_;
 
 private:
     epoll_sockets& svc_;
     int fd_ = -1;
+    endpoint local_endpoint_;
 };
 
 //------------------------------------------------------------------------------

--- a/src/corosio/src/socket.cpp
+++ b/src/corosio/src/socket.cpp
@@ -240,5 +240,23 @@ linger() const
     return result;
 }
 
+endpoint
+socket::
+local_endpoint() const noexcept
+{
+    if (!impl_)
+        return endpoint{};
+    return get().local_endpoint();
+}
+
+endpoint
+socket::
+remote_endpoint() const noexcept
+{
+    if (!impl_)
+        return endpoint{};
+    return get().remote_endpoint();
+}
+
 } // namespace corosio
 } // namespace boost


### PR DESCRIPTION
Implement local_endpoint() and remote_endpoint() methods for the socket class, and local_endpoint() for the acceptor class, following the caching approach recommended in issue #63.

Design:
- Cache endpoint values when connection is established (connect/accept)
- Return cached values on query, enabling noexcept access
- Return default endpoint (0.0.0.0:0) when socket is not connected
- Clear cached endpoints on close

Implementation:
- socket.hpp/cpp: Add public methods and virtual interface
- acceptor.hpp/cpp: Add local_endpoint() for ephemeral port support
- epoll backend: Cache endpoints in epoll_socket_impl/epoll_acceptor_impl
- IOCP backend: Cache endpoints in win_socket_impl_internal/win_acceptor_impl_internal

Tests:
- Ephemeral port (port 0) with OS-assigned port discovery
- Specified port binding verification
- Closed/unconnected socket returns default endpoint
- Connect failure leaves endpoints as default
- Move semantics preserve endpoints
- Consistent reads return cached values
- Close and reopen resets endpoints

Closes #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expose socket getters for local and remote endpoints and an acceptor getter for the listening local endpoint.
  * Accessors document thread-safety and return sensible defaults when not connected.

* **Bug Fixes**
  * Cache endpoints on connect/accept and clear them on close to avoid stale values.

* **Chores**
  * Example server updated to use the newer write utility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->