### PR TITLE
Implement socket options API with named methods

### DIFF
--- a/include/boost/corosio/acceptor.hpp
+++ b/include/boost/corosio/acceptor.hpp
@@ -22,7 +22,6 @@
 
 #include <boost/system/error_code.hpp>
 
-#include <cassert>
 #include <concepts>
 #include <coroutine>
 #include <cstddef>
@@ -253,7 +252,8 @@ public:
     */
     auto accept(socket& peer)
     {
-        assert(impl_ != nullptr);
+        if (!impl_)
+            detail::throw_logic_error("accept: acceptor not listening");
         return accept_awaitable(*this, peer);
     }
 

--- a/src/corosio/src/acceptor.cpp
+++ b/src/corosio/src/acceptor.cpp
@@ -19,8 +19,6 @@
 
 #include <boost/corosio/detail/except.hpp>
 
-#include <cassert>
-
 namespace boost {
 namespace corosio {
 namespace {
@@ -89,7 +87,8 @@ void
 acceptor::
 cancel()
 {
-    assert(impl_ != nullptr);
+    if (!impl_)
+        return;
 #if defined(BOOST_COROSIO_BACKEND_IOCP)
     static_cast<acceptor_impl_type*>(impl_)->get_internal()->cancel();
 #elif defined(BOOST_COROSIO_BACKEND_EPOLL)

--- a/src/corosio/src/detail/epoll/sockets.hpp
+++ b/src/corosio/src/detail/epoll/sockets.hpp
@@ -128,6 +128,22 @@ public:
     system::error_code shutdown(socket::shutdown_type what) noexcept override;
 
     native_handle_type native_handle() const noexcept override { return fd_; }
+
+    // Socket options
+    system::error_code set_no_delay(bool value) noexcept override;
+    bool no_delay(system::error_code& ec) const noexcept override;
+
+    system::error_code set_keep_alive(bool value) noexcept override;
+    bool keep_alive(system::error_code& ec) const noexcept override;
+
+    system::error_code set_receive_buffer_size(int size) noexcept override;
+    int receive_buffer_size(system::error_code& ec) const noexcept override;
+
+    system::error_code set_send_buffer_size(int size) noexcept override;
+    int send_buffer_size(system::error_code& ec) const noexcept override;
+
+    system::error_code set_linger(bool enabled, int timeout) noexcept override;
+    socket::linger_options linger(system::error_code& ec) const noexcept override;
     bool is_open() const noexcept { return fd_ >= 0; }
     void cancel() noexcept;
     void cancel_single_op(epoll_op& op) noexcept;

--- a/src/corosio/src/socket.cpp
+++ b/src/corosio/src/socket.cpp
@@ -18,8 +18,6 @@
 #include "src/detail/epoll/sockets.hpp"
 #endif
 
-#include <cassert>
-
 namespace boost {
 namespace corosio {
 
@@ -86,7 +84,8 @@ void
 socket::
 cancel()
 {
-    assert(impl_ != nullptr);
+    if (!impl_)
+        return;
 #if defined(BOOST_COROSIO_BACKEND_IOCP)
     static_cast<socket_impl_type*>(impl_)->get_internal()->cancel();
 #elif defined(BOOST_COROSIO_BACKEND_EPOLL)
@@ -115,6 +114,130 @@ native_handle() const noexcept
 #endif
     }
     return get().native_handle();
+}
+
+//------------------------------------------------------------------------------
+// Socket Options
+//------------------------------------------------------------------------------
+
+void
+socket::
+set_no_delay(bool value)
+{
+    if (!impl_)
+        detail::throw_logic_error("set_no_delay: socket not open");
+    system::error_code ec = get().set_no_delay(value);
+    if (ec)
+        detail::throw_system_error(ec, "socket::set_no_delay");
+}
+
+bool
+socket::
+no_delay() const
+{
+    if (!impl_)
+        detail::throw_logic_error("no_delay: socket not open");
+    system::error_code ec;
+    bool result = get().no_delay(ec);
+    if (ec)
+        detail::throw_system_error(ec, "socket::no_delay");
+    return result;
+}
+
+void
+socket::
+set_keep_alive(bool value)
+{
+    if (!impl_)
+        detail::throw_logic_error("set_keep_alive: socket not open");
+    system::error_code ec = get().set_keep_alive(value);
+    if (ec)
+        detail::throw_system_error(ec, "socket::set_keep_alive");
+}
+
+bool
+socket::
+keep_alive() const
+{
+    if (!impl_)
+        detail::throw_logic_error("keep_alive: socket not open");
+    system::error_code ec;
+    bool result = get().keep_alive(ec);
+    if (ec)
+        detail::throw_system_error(ec, "socket::keep_alive");
+    return result;
+}
+
+void
+socket::
+set_receive_buffer_size(int size)
+{
+    if (!impl_)
+        detail::throw_logic_error("set_receive_buffer_size: socket not open");
+    system::error_code ec = get().set_receive_buffer_size(size);
+    if (ec)
+        detail::throw_system_error(ec, "socket::set_receive_buffer_size");
+}
+
+int
+socket::
+receive_buffer_size() const
+{
+    if (!impl_)
+        detail::throw_logic_error("receive_buffer_size: socket not open");
+    system::error_code ec;
+    int result = get().receive_buffer_size(ec);
+    if (ec)
+        detail::throw_system_error(ec, "socket::receive_buffer_size");
+    return result;
+}
+
+void
+socket::
+set_send_buffer_size(int size)
+{
+    if (!impl_)
+        detail::throw_logic_error("set_send_buffer_size: socket not open");
+    system::error_code ec = get().set_send_buffer_size(size);
+    if (ec)
+        detail::throw_system_error(ec, "socket::set_send_buffer_size");
+}
+
+int
+socket::
+send_buffer_size() const
+{
+    if (!impl_)
+        detail::throw_logic_error("send_buffer_size: socket not open");
+    system::error_code ec;
+    int result = get().send_buffer_size(ec);
+    if (ec)
+        detail::throw_system_error(ec, "socket::send_buffer_size");
+    return result;
+}
+
+void
+socket::
+set_linger(bool enabled, int timeout)
+{
+    if (!impl_)
+        detail::throw_logic_error("set_linger: socket not open");
+    system::error_code ec = get().set_linger(enabled, timeout);
+    if (ec)
+        detail::throw_system_error(ec, "socket::set_linger");
+}
+
+socket::linger_options
+socket::
+linger() const
+{
+    if (!impl_)
+        detail::throw_logic_error("linger: socket not open");
+    system::error_code ec;
+    linger_options result = get().linger(ec);
+    if (ec)
+        detail::throw_system_error(ec, "socket::linger");
+    return result;
 }
 
 } // namespace corosio


### PR DESCRIPTION
Add a cross-platform socket options API using simple named getter/setter methods. This approach was chosen over the Asio-style template-based API for better discoverability and simplicity.

New socket methods:
- set_no_delay(bool) / no_delay() - TCP_NODELAY (disable Nagle's algorithm)
- set_keep_alive(bool) / keep_alive() - SO_KEEPALIVE
- set_receive_buffer_size(int) / receive_buffer_size() - SO_RCVBUF
- set_send_buffer_size(int) / send_buffer_size() - SO_SNDBUF
- set_linger(bool, int) / linger() - SO_LINGER

Resolves #73.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a comprehensive socket options API to configure TCP behavior (no-delay, keep-alive), receive/send buffer sizes, and linger settings.
  * Introduces a public linger options type for finer control over connection termination.

* **Bug Fixes**
  * Replaces debug-time assertions with runtime error handling and defensive null-checks when socket or acceptor backends are uninitialized.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->