### PR TITLE
fix: set cmake versions correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 # Project
 #
 #-------------------------------------------------
-cmake_minimum_required(VERSION 3.8...3.20)
+cmake_minimum_required(VERSION 3.8...3.31)
 set(BOOST_COROSIO_VERSION 1)
 if (BOOST_SUPERPROJECT_VERSION)
     set(BOOST_COROSIO_VERSION ${BOOST_SUPERPROJECT_VERSION})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CMake version requirement to support newer versions (up to 3.31). This change improves compatibility with recent CMake releases while maintaining support for earlier versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->