### PR TITLE
CodeCov improvements

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,6 +12,16 @@ codecov:
     after_n_builds: 1
     wait_for_ci: yes
 
+# Make coverage checks informational (report but never fail CI)
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
 # Change how pull request comments look
 comment:
   layout: "reach,diff,flags,files,footer"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -733,10 +733,8 @@ jobs:
           echo ""
           echo "=== Diagnostic complete ==="
 
-      - name: Codecov
+      - name: Generate Coverage Report
         if: ${{ matrix.coverage }}
-        env:
-            CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           set -x
 
@@ -749,14 +747,21 @@ jobs:
           fi
           lcov -c -q -o "boost-root/__build_cmake_test__/coverage.info" -d "boost-root/__build_cmake_test__" --include "$(pwd)/boost-root/libs/${{steps.patch.outputs.module}}/*" --gcov-tool "$gcov_tool"
 
-          # Upload to codecov
-          bash <(curl -s https://codecov.io/bash) -f "boost-root/__build_cmake_test__/coverage.info"
+      - name: Upload to Codecov
+        if: ${{ matrix.coverage }}
+        uses: codecov/codecov-action@v5
+        with:
+          files: boost-root/__build_cmake_test__/coverage.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          verbose: true
 
-          # Summary
+      - name: Coverage Summary
+        if: ${{ matrix.coverage }}
+        run: |
           echo "# Coverage" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "[![codecov](https://codecov.io/github/$GITHUB_REPOSITORY/commit/$GITHUB_SHA/graphs/sunburst.svg)](https://codecov.io/github/$GITHUB_REPOSITORY/commit/$GITHUB_SHA)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Commit: [![codecov](https://codecov.io/github/$GITHUB_REPOSITORY/commit/$GITHUB_SHA/graph/badge.svg)](https://codecov.io/github/$GITHUB_REPOSITORY/commit/$GITHUB_SHA)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Use CodeCov actions to generate coverage report for branches like `develop`. Don't fail CI based on coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated coverage status checks to be informational—coverage reports no longer fail CI workflows
* Migrated coverage reporting to an improved GitHub Action-based integration for better reliability and maintainability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->