### PR TITLE
Disable codecov automatic plugins to fix coverage filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -759,6 +759,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true
+          disable_search: true
+          plugins: ''
 
       - name: Coverage Summary
         if: ${{ matrix.coverage }}


### PR DESCRIPTION
The lcov command was correctly filtering coverage to only include files from corosio's include/ and src/ directories, but the codecov action was running its own gcov plugin which generated coverage data from ALL .gcno files in the build directory (including capy, url, system headers, etc.).

Adding disable_search and empty plugins options ensures codecov only uploads the pre-filtered coverage.info file from lcov.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for improved codecov integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->