### PR TITLE
Add reverse DNS resolution support to resolver

### DIFF
--- a/include/boost/corosio/resolver_results.hpp
+++ b/include/boost/corosio/resolver_results.hpp
@@ -200,6 +200,65 @@ public:
     }
 };
 
+//------------------------------------------------------------------------------
+
+/** The result of a reverse DNS resolution.
+
+    This class holds the result of resolving an endpoint
+    into a hostname and service name.
+
+    @par Thread Safety
+    Distinct objects: Safe.@n
+    Shared objects: Safe.
+*/
+class reverse_resolver_result
+{
+    corosio::endpoint ep_;
+    std::string host_;
+    std::string service_;
+
+public:
+    /** Default constructor. */
+    reverse_resolver_result() = default;
+
+    /** Construct with endpoint, host name, and service name.
+
+        @param ep The endpoint that was resolved.
+        @param host The resolved host name.
+        @param service The resolved service name.
+    */
+    reverse_resolver_result(
+        corosio::endpoint ep,
+        std::string host,
+        std::string service)
+        : ep_(ep)
+        , host_(std::move(host))
+        , service_(std::move(service))
+    {
+    }
+
+    /** Get the endpoint that was resolved. */
+    corosio::endpoint
+    endpoint() const noexcept
+    {
+        return ep_;
+    }
+
+    /** Get the resolved host name. */
+    std::string const&
+    host_name() const noexcept
+    {
+        return host_;
+    }
+
+    /** Get the resolved service name. */
+    std::string const&
+    service_name() const noexcept
+    {
+        return service_;
+    }
+};
+
 } // namespace corosio
 } // namespace boost
 


### PR DESCRIPTION
Implement reverse DNS lookup capability for the resolver class, enabling hostname lookups from IP addresses using getnameinfo() on POSIX and GetNameInfoW() on Windows.

New API:
- resolve(endpoint) - reverse resolve with default flags
- resolve(endpoint, reverse_flags) - reverse resolve with custom flags
- reverse_flags enum (numeric_host, numeric_service, name_required, datagram_service)
- reverse_resolver_result class with endpoint(), host_name(), service_name()

Implementation uses worker threads on both platforms since the underlying APIs (getnameinfo/GetNameInfoW) are synchronous. Thread lifetime is managed via shared_ptr to prevent use-after-free during shutdown.

Resolves #64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reverse DNS resolution: resolve endpoints to host and service names.
  * Configurable reverse-resolution flags for fine-grained lookup behavior.
  * Async/await-compatible reverse lookups on Windows and POSIX platforms.

* **Chores**
  * Improved resolver lifetime, thread tracking, and graceful shutdown so in-flight lookups complete or cancel cleanly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->