### PR TITLE
Use ephemeral ports in make_socket_pair and make_mockets

### DIFF
--- a/src/corosio/src/test/mocket.cpp
+++ b/src/corosio/src/test/mocket.cpp
@@ -19,7 +19,6 @@
 #include <boost/capy/task.hpp>
 #include <boost/capy/test/fuse.hpp>
 
-#include <boost/corosio/detail/platform.hpp>
 #include "src/detail/resume_coro.hpp"
 
 #include <algorithm>
@@ -27,12 +26,6 @@
 #include <cstring>
 #include <span>
 #include <stdexcept>
-
-#if BOOST_COROSIO_POSIX
-#include <unistd.h>   // getpid()
-#else
-#include <process.h>  // _getpid()
-#endif
 
 namespace boost::corosio::test {
 
@@ -435,36 +428,6 @@ is_open() const noexcept
 
 //------------------------------------------------------------------------------
 
-namespace {
-
-// Use atomic for thread safety when tests run in parallel
-std::atomic<std::uint16_t> next_test_port{0};
-
-std::uint16_t
-get_test_port() noexcept
-{
-    // Use a wide port range in the dynamic/ephemeral range (49152-65535)
-    constexpr std::uint16_t port_base = 49152;
-    constexpr std::uint16_t port_range = 16383;
-
-    // Include PID to avoid port collisions between parallel test processes.
-    // On Windows with SO_REUSEADDR, multiple processes can bind the same port,
-    // causing connections to go to the wrong listener ("port stealing").
-    // By using different port ranges per process, we avoid this issue.
-#if BOOST_COROSIO_POSIX
-    auto pid = static_cast<std::uint32_t>(getpid());
-#else
-    auto pid = static_cast<std::uint32_t>(_getpid());
-#endif
-    // Mix the PID bits to spread processes across the port range
-    auto pid_offset = static_cast<std::uint16_t>((pid * 7919) % port_range);
-
-    auto offset = next_test_port.fetch_add(1, std::memory_order_relaxed);
-    return static_cast<std::uint16_t>(port_base + ((pid_offset + offset) % port_range));
-}
-
-} // namespace
-
 std::pair<mocket, mocket>
 make_mockets(capy::execution_context& ctx, capy::test::fuse& f)
 {
@@ -486,30 +449,10 @@ make_mockets(capy::execution_context& ctx, capy::test::fuse& f)
     bool accept_done = false;
     bool connect_done = false;
 
-    // Try multiple ports in case of conflicts (TIME_WAIT, parallel tests, etc.)
-    std::uint16_t port = 0;
+    // Use ephemeral port (0) - OS assigns an available port
     acceptor acc(ctx);
-    bool listening = false;
-    for (int attempt = 0; attempt < 20; ++attempt)
-    {
-        port = get_test_port();
-        try
-        {
-            acc.listen(endpoint(ipv4_address::loopback(), port));
-            listening = true;
-            break;
-        }
-        catch (const std::system_error&)
-        {
-            acc.close();
-            acc = acceptor(ctx);
-        }
-    }
-    if (!listening)
-    {
-        std::fprintf(stderr, "make_mockets: failed to find available port after 20 attempts\n");
-        throw std::runtime_error("make_mockets: failed to find available port");
-    }
+    acc.listen(endpoint(ipv4_address::loopback(), 0));
+    auto port = acc.local_endpoint().port();
 
     // Open impl2's socket for connect
     impl2.get_socket().open();

--- a/src/corosio/src/test/socket_pair.cpp
+++ b/src/corosio/src/test/socket_pair.cpp
@@ -15,48 +15,10 @@
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/task.hpp>
 
-#include <atomic>
-#include <cstdint>
 #include <cstdio>
 #include <stdexcept>
 
-#if BOOST_COROSIO_POSIX
-#include <unistd.h>   // getpid()
-#else
-#include <process.h>  // _getpid()
-#endif
-
 namespace boost::corosio::test {
-
-namespace {
-
-// Use atomic for thread safety when tests run in parallel
-std::atomic<std::uint16_t> next_test_port{0};
-
-std::uint16_t
-get_test_port() noexcept
-{
-    // Use a wide port range in the dynamic/ephemeral range (49152-65535)
-    constexpr std::uint16_t port_base = 49152;
-    constexpr std::uint16_t port_range = 16383;  // 49152-65535
-
-    // Include PID to avoid port collisions between parallel test processes.
-    // On Windows with SO_REUSEADDR, multiple processes can bind the same port,
-    // causing connections to go to the wrong listener ("port stealing").
-    // By using different port ranges per process, we avoid this issue.
-#if BOOST_COROSIO_POSIX
-    auto pid = static_cast<std::uint32_t>(getpid());
-#else
-    auto pid = static_cast<std::uint32_t>(_getpid());
-#endif
-    // Mix the PID bits to spread processes across the port range
-    auto pid_offset = static_cast<std::uint16_t>((pid * 7919) % port_range);
-
-    auto offset = next_test_port.fetch_add(1, std::memory_order_relaxed);
-    return static_cast<std::uint16_t>(port_base + ((pid_offset + offset) % port_range));
-}
-
-} // namespace
 
 std::pair<socket, socket>
 make_socket_pair(basic_io_context& ctx)
@@ -68,31 +30,10 @@ make_socket_pair(basic_io_context& ctx)
     bool accept_done = false;
     bool connect_done = false;
 
-    // Try multiple ports in case of conflicts (TIME_WAIT, parallel tests, etc.)
-    std::uint16_t port = 0;
+    // Use ephemeral port (0) - OS assigns an available port
     acceptor acc(ctx);
-    bool listening = false;
-    for (int attempt = 0; attempt < 20; ++attempt)
-    {
-        port = get_test_port();
-        try
-        {
-            acc.listen(endpoint(ipv4_address::loopback(), port));
-            listening = true;
-            break;
-        }
-        catch (const std::system_error&)
-        {
-            // Port in use, try another
-            acc.close();
-            acc = acceptor(ctx);
-        }
-    }
-    if (!listening)
-    {
-        std::fprintf(stderr, "socket_pair: failed to find available port after 20 attempts\n");
-        throw std::runtime_error("socket_pair: failed to find available port");
-    }
+    acc.listen(endpoint(ipv4_address::loopback(), 0));
+    auto port = acc.local_endpoint().port();
 
     socket s1(ctx);
     socket s2(ctx);


### PR DESCRIPTION
Replace the iterative port-search approach with OS-assigned ephemeral ports (port 0). This eliminates intermittent failures from port conflicts by using acceptor::local_endpoint() to discover the assigned port.