### PR TITLE
Edge-Triggered Epoll and Backend Improvements

### DIFF
--- a/bench/asio/CMakeLists.txt
+++ b/bench/asio/CMakeLists.txt
@@ -65,3 +65,17 @@ target_compile_options(asio_bench_socket_latency
         $<$<CXX_COMPILER_ID:GNU>:-fcoroutines>)
 set_property(TARGET asio_bench_socket_latency
     PROPERTY FOLDER "benchmarks/asio")
+
+# http server benchmark
+add_executable(asio_bench_http_server
+    http_server_bench.cpp)
+target_link_libraries(asio_bench_http_server
+    PRIVATE
+        Boost::asio
+        Threads::Threads)
+target_compile_features(asio_bench_http_server PUBLIC cxx_std_20)
+target_compile_options(asio_bench_http_server
+    PRIVATE
+        $<$<CXX_COMPILER_ID:GNU>:-fcoroutines>)
+set_property(TARGET asio_bench_http_server
+    PROPERTY FOLDER "benchmarks/asio")

--- a/bench/asio/http_server_bench.cpp
+++ b/bench/asio/http_server_bench.cpp
@@ -1,0 +1,461 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/read.hpp>
+#include <boost/asio/read_until.hpp>
+#include <boost/asio/write.hpp>
+
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "../common/benchmark.hpp"
+#include "../common/http_protocol.hpp"
+
+namespace asio = boost::asio;
+using tcp = asio::ip::tcp;
+
+// Create a connected socket pair using TCP loopback
+std::pair<tcp::socket, tcp::socket> make_socket_pair(asio::io_context& ioc)
+{
+    tcp::acceptor acceptor(ioc, tcp::endpoint(tcp::v4(), 0));
+    acceptor.set_option(tcp::acceptor::reuse_address(true));
+
+    tcp::socket client(ioc);
+    tcp::socket server(ioc);
+
+    auto endpoint = acceptor.local_endpoint();
+    client.connect(endpoint);
+    server = acceptor.accept();
+
+    client.set_option(tcp::no_delay(true));
+    server.set_option(tcp::no_delay(true));
+
+    return {std::move(client), std::move(server)};
+}
+
+// Server coroutine: reads requests and sends responses
+asio::awaitable<void> server_task(
+    tcp::socket& sock,
+    int num_requests,
+    int& completed_requests)
+{
+    std::string buf;
+
+    try
+    {
+        while (completed_requests < num_requests)
+        {
+            // Read until end of HTTP headers
+            std::size_t n = co_await asio::async_read_until(
+                sock,
+                asio::dynamic_buffer(buf),
+                "\r\n\r\n",
+                asio::use_awaitable);
+
+            // Send response
+            co_await asio::async_write(
+                sock,
+                asio::buffer(bench::http::small_response, bench::http::small_response_size),
+                asio::use_awaitable);
+
+            ++completed_requests;
+            buf.erase(0, n);
+        }
+    }
+    catch (std::exception const&) {}
+}
+
+// Client coroutine: sends requests and reads responses
+asio::awaitable<void> client_task(
+    tcp::socket& sock,
+    int num_requests,
+    bench::statistics& latency_stats)
+{
+    std::string buf;
+
+    try
+    {
+        for (int i = 0; i < num_requests; ++i)
+        {
+            bench::stopwatch sw;
+
+            // Send request
+            co_await asio::async_write(
+                sock,
+                asio::buffer(bench::http::small_request, bench::http::small_request_size),
+                asio::use_awaitable);
+
+            // Read response headers
+            std::size_t header_end = co_await asio::async_read_until(
+                sock,
+                asio::dynamic_buffer(buf),
+                "\r\n\r\n",
+                asio::use_awaitable);
+
+            // Parse Content-Length from headers and read body if needed
+            std::string_view headers(buf.data(), header_end);
+            std::size_t content_length = 0;
+            auto pos = headers.find("Content-Length: ");
+            if (pos != std::string_view::npos)
+            {
+                pos += 16;
+                while (pos < headers.size() && headers[pos] >= '0' && headers[pos] <= '9')
+                {
+                    content_length = content_length * 10 + (headers[pos] - '0');
+                    ++pos;
+                }
+            }
+
+            // Read body if not already in buffer
+            std::size_t total_size = header_end + content_length;
+            if (buf.size() < total_size)
+            {
+                std::size_t need = total_size - buf.size();
+                std::size_t old_size = buf.size();
+                buf.resize(total_size);
+                co_await asio::async_read(
+                    sock,
+                    asio::buffer(buf.data() + old_size, need),
+                    asio::use_awaitable);
+            }
+
+            double latency_us = sw.elapsed_us();
+            latency_stats.add(latency_us);
+
+            buf.erase(0, total_size);
+        }
+    }
+    catch (std::exception const&) {}
+}
+
+// Single connection benchmark
+bench::benchmark_result bench_single_connection(int num_requests)
+{
+    std::cout << "  Requests: " << num_requests << "\n";
+
+    asio::io_context ioc;
+    auto [client, server] = make_socket_pair(ioc);
+
+    int completed_requests = 0;
+    bench::statistics latency_stats;
+
+    bench::stopwatch total_sw;
+
+    asio::co_spawn(ioc,
+        server_task(server, num_requests, completed_requests),
+        asio::detached);
+    asio::co_spawn(ioc,
+        client_task(client, num_requests, latency_stats),
+        asio::detached);
+
+    ioc.run();
+
+    double elapsed = total_sw.elapsed_seconds();
+    double requests_per_sec = static_cast<double>(num_requests) / elapsed;
+
+    std::cout << "    Completed: " << num_requests << " requests\n";
+    std::cout << "    Elapsed: " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "    Throughput: " << bench::format_rate(requests_per_sec) << "\n";
+    bench::print_latency_stats(latency_stats, "Request latency");
+    std::cout << "\n";
+
+    client.close();
+    server.close();
+
+    return bench::benchmark_result("single_conn")
+        .add("num_requests", num_requests)
+        .add("num_connections", 1)
+        .add("requests_per_sec", requests_per_sec)
+        .add_latency_stats("request_latency", latency_stats);
+}
+
+// Concurrent connections benchmark
+bench::benchmark_result bench_concurrent_connections(int num_connections, int requests_per_conn)
+{
+    int total_requests = num_connections * requests_per_conn;
+    std::cout << "  Connections: " << num_connections
+              << ", Requests per connection: " << requests_per_conn
+              << ", Total: " << total_requests << "\n";
+
+    asio::io_context ioc;
+
+    std::vector<tcp::socket> clients;
+    std::vector<tcp::socket> servers;
+    std::vector<int> completed(num_connections, 0);
+    std::vector<bench::statistics> stats(num_connections);
+
+    clients.reserve(num_connections);
+    servers.reserve(num_connections);
+
+    for (int i = 0; i < num_connections; ++i)
+    {
+        auto [c, s] = make_socket_pair(ioc);
+        clients.push_back(std::move(c));
+        servers.push_back(std::move(s));
+    }
+
+    bench::stopwatch total_sw;
+
+    for (int i = 0; i < num_connections; ++i)
+    {
+        asio::co_spawn(ioc,
+            server_task(servers[i], requests_per_conn, completed[i]),
+            asio::detached);
+        asio::co_spawn(ioc,
+            client_task(clients[i], requests_per_conn, stats[i]),
+            asio::detached);
+    }
+
+    ioc.run();
+
+    double elapsed = total_sw.elapsed_seconds();
+    double requests_per_sec = static_cast<double>(total_requests) / elapsed;
+
+    // Aggregate latency stats
+    double total_mean = 0;
+    double total_p99 = 0;
+    for (auto& s : stats)
+    {
+        total_mean += s.mean();
+        total_p99 += s.p99();
+    }
+
+    std::cout << "    Completed: " << total_requests << " requests\n";
+    std::cout << "    Elapsed: " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "    Throughput: " << bench::format_rate(requests_per_sec) << "\n";
+    std::cout << "    Avg mean latency: "
+              << bench::format_latency(total_mean / num_connections) << "\n";
+    std::cout << "    Avg p99 latency: "
+              << bench::format_latency(total_p99 / num_connections) << "\n\n";
+
+    for (auto& c : clients)
+        c.close();
+    for (auto& s : servers)
+        s.close();
+
+    return bench::benchmark_result("concurrent_" + std::to_string(num_connections))
+        .add("num_connections", num_connections)
+        .add("requests_per_conn", requests_per_conn)
+        .add("total_requests", total_requests)
+        .add("requests_per_sec", requests_per_sec)
+        .add("avg_mean_latency_us", total_mean / num_connections)
+        .add("avg_p99_latency_us", total_p99 / num_connections);
+}
+
+// Multi-threaded benchmark: multiple threads calling run()
+bench::benchmark_result bench_multithread(int num_threads, int num_connections, int requests_per_conn)
+{
+    int total_requests = num_connections * requests_per_conn;
+    std::cout << "  Threads: " << num_threads
+              << ", Connections: " << num_connections
+              << ", Requests per connection: " << requests_per_conn
+              << ", Total: " << total_requests << "\n";
+
+    asio::io_context ioc(num_threads);
+
+    std::vector<tcp::socket> clients;
+    std::vector<tcp::socket> servers;
+    std::vector<int> completed(num_connections, 0);
+    std::vector<bench::statistics> stats(num_connections);
+
+    clients.reserve(num_connections);
+    servers.reserve(num_connections);
+
+    for (int i = 0; i < num_connections; ++i)
+    {
+        auto [c, s] = make_socket_pair(ioc);
+        clients.push_back(std::move(c));
+        servers.push_back(std::move(s));
+    }
+
+    // Spawn all coroutines before starting threads
+    for (int i = 0; i < num_connections; ++i)
+    {
+        asio::co_spawn(ioc,
+            server_task(servers[i], requests_per_conn, completed[i]),
+            asio::detached);
+        asio::co_spawn(ioc,
+            client_task(clients[i], requests_per_conn, stats[i]),
+            asio::detached);
+    }
+
+    bench::stopwatch total_sw;
+
+    // Launch worker threads
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads - 1);
+    for (int i = 1; i < num_threads; ++i)
+        threads.emplace_back([&ioc] { ioc.run(); });
+
+    // Main thread also runs
+    ioc.run();
+
+    // Wait for all threads
+    for (auto& t : threads)
+        t.join();
+
+    double elapsed = total_sw.elapsed_seconds();
+    double requests_per_sec = static_cast<double>(total_requests) / elapsed;
+
+    // Aggregate latency stats
+    double total_mean = 0;
+    double total_p99 = 0;
+    for (auto& s : stats)
+    {
+        total_mean += s.mean();
+        total_p99 += s.p99();
+    }
+
+    std::cout << "    Completed: " << total_requests << " requests\n";
+    std::cout << "    Elapsed: " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "    Throughput: " << bench::format_rate(requests_per_sec) << "\n";
+    std::cout << "    Avg mean latency: "
+              << bench::format_latency(total_mean / num_connections) << "\n";
+    std::cout << "    Avg p99 latency: "
+              << bench::format_latency(total_p99 / num_connections) << "\n\n";
+
+    for (auto& c : clients)
+        c.close();
+    for (auto& s : servers)
+        s.close();
+
+    return bench::benchmark_result("multithread_" + std::to_string(num_threads) + "t")
+        .add("num_threads", num_threads)
+        .add("num_connections", num_connections)
+        .add("requests_per_conn", requests_per_conn)
+        .add("total_requests", total_requests)
+        .add("requests_per_sec", requests_per_sec)
+        .add("avg_mean_latency_us", total_mean / num_connections)
+        .add("avg_p99_latency_us", total_p99 / num_connections);
+}
+
+void run_benchmarks(char const* output_file, char const* bench_filter)
+{
+    std::cout << "Boost.Asio HTTP Server Benchmarks\n";
+    std::cout << "=================================\n";
+
+    bench::result_collector collector("asio");
+
+    bool run_all = !bench_filter || std::strcmp(bench_filter, "all") == 0;
+
+    if (run_all || std::strcmp(bench_filter, "single_conn") == 0)
+    {
+        bench::print_header("Single Connection (Sequential Requests)");
+        collector.add(bench_single_connection(10000));
+    }
+
+    if (run_all || std::strcmp(bench_filter, "concurrent") == 0)
+    {
+        if (run_all)
+            std::this_thread::sleep_for(std::chrono::seconds(5));
+        bench::print_header("Concurrent Connections");
+        collector.add(bench_concurrent_connections(1, 10000));
+        collector.add(bench_concurrent_connections(4, 2500));
+        collector.add(bench_concurrent_connections(16, 625));
+        collector.add(bench_concurrent_connections(32, 312));
+    }
+
+    if (run_all || std::strcmp(bench_filter, "multithread") == 0)
+    {
+        if (run_all)
+            std::this_thread::sleep_for(std::chrono::seconds(5));
+        bench::print_header("Multi-threaded (32 connections, varying threads)");
+        collector.add(bench_multithread(1, 32, 312));
+        collector.add(bench_multithread(2, 32, 312));
+        collector.add(bench_multithread(4, 32, 312));
+        collector.add(bench_multithread(8, 32, 312));
+    }
+
+    std::cout << "\nBenchmarks complete.\n";
+
+    if (output_file)
+    {
+        if (collector.write_json(output_file))
+            std::cout << "Results written to: " << output_file << "\n";
+        else
+            std::cerr << "Error: Failed to write results to: " << output_file << "\n";
+    }
+}
+
+void print_usage(char const* program_name)
+{
+    std::cout << "Usage: " << program_name << " [OPTIONS]\n\n";
+    std::cout << "Options:\n";
+    std::cout << "  --bench <name>     Run only the specified benchmark\n";
+    std::cout << "  --output <file>    Write JSON results to file\n";
+    std::cout << "  --help             Show this help message\n";
+    std::cout << "\n";
+    std::cout << "Available benchmarks:\n";
+    std::cout << "  single_conn        Single connection, sequential requests\n";
+    std::cout << "  concurrent         Multiple concurrent connections\n";
+    std::cout << "  multithread        Multi-threaded with varying thread counts\n";
+    std::cout << "  all                Run all benchmarks (default)\n";
+}
+
+int main(int argc, char* argv[])
+{
+    char const* output_file = nullptr;
+    char const* bench_filter = nullptr;
+
+    for (int i = 1; i < argc; ++i)
+    {
+        if (std::strcmp(argv[i], "--bench") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                bench_filter = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --bench requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--output") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                output_file = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --output requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0)
+        {
+            print_usage(argv[0]);
+            return 0;
+        }
+        else
+        {
+            std::cerr << "Unknown option: " << argv[i] << "\n";
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    run_benchmarks(output_file, bench_filter);
+    return 0;
+}

--- a/bench/asio/io_context_bench.cpp
+++ b/bench/asio/io_context_bench.cpp
@@ -15,6 +15,7 @@
 #include <boost/asio/use_awaitable.hpp>
 
 #include <atomic>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 #include <thread>
@@ -24,8 +25,11 @@
 
 namespace asio = boost::asio;
 
-// Benchmark: Single-threaded handler posting rate
-void bench_single_threaded_post(int num_handlers)
+// Measures the raw throughput of posting and executing handlers from a single
+// thread. Establishes a baseline for Asio's scheduler performance without any
+// synchronization overhead. Useful for comparing against Corosio's coroutine-based
+// approach to understand the overhead difference between callbacks and coroutines.
+bench::benchmark_result bench_single_threaded_post(int num_handlers)
 {
     bench::print_header("Single-threaded Handler Post (Asio)");
 
@@ -54,15 +58,28 @@ void bench_single_threaded_post(int num_handlers)
         std::cerr << "  ERROR: counter mismatch! Expected " << num_handlers
                   << ", got " << counter << "\n";
     }
+
+    return bench::benchmark_result("single_threaded_post")
+        .add("handlers", num_handlers)
+        .add("elapsed_s", elapsed)
+        .add("ops_per_sec", ops_per_sec);
 }
 
-// Benchmark: Multi-threaded scaling
-void bench_multithreaded_scaling(int num_handlers, int max_threads)
+// Measures how Asio's throughput scales when multiple threads call run() on the
+// same io_context. Asio uses a mutex-protected queue, so this reveals contention
+// characteristics. Compare against Corosio to evaluate different synchronization
+// strategies. Sub-linear scaling is expected; the question is how gracefully
+// performance degrades under thread pressure.
+bench::benchmark_result bench_multithreaded_scaling(int num_handlers, int max_threads)
 {
     bench::print_header("Multi-threaded Scaling (Asio)");
 
     std::cout << "  Handlers per test: " << num_handlers << "\n\n";
 
+    bench::benchmark_result result("multithreaded_scaling");
+    result.add("handlers", num_handlers);
+
+    double baseline_ops = 0;
     for (int num_threads = 1; num_threads <= max_threads; num_threads *= 2)
     {
         asio::io_context ioc;
@@ -92,16 +109,14 @@ void bench_multithreaded_scaling(int num_handlers, int max_threads)
         std::cout << "  " << num_threads << " thread(s): "
                   << bench::format_rate(ops_per_sec);
 
-        if (num_threads > 1)
-        {
-            static double baseline_ops = 0;
-            if (num_threads == 1)
-                baseline_ops = ops_per_sec;
-            else if (baseline_ops > 0)
-                std::cout << " (speedup: " << std::fixed << std::setprecision(2)
-                          << (ops_per_sec / baseline_ops) << "x)";
-        }
+        if (num_threads == 1)
+            baseline_ops = ops_per_sec;
+        else if (baseline_ops > 0)
+            std::cout << " (speedup: " << std::fixed << std::setprecision(2)
+                      << (ops_per_sec / baseline_ops) << "x)";
         std::cout << "\n";
+
+        result.add("threads_" + std::to_string(num_threads) + "_ops_per_sec", ops_per_sec);
 
         if (counter.load() != num_handlers)
         {
@@ -109,10 +124,15 @@ void bench_multithreaded_scaling(int num_handlers, int max_threads)
                       << ", got " << counter.load() << "\n";
         }
     }
+
+    return result;
 }
 
-// Benchmark: Post and run interleaved
-void bench_interleaved_post_run(int iterations, int handlers_per_iteration)
+// Measures Asio performance when posting and polling are interleaved, simulating
+// a game loop or GUI event pump. Tests poll() efficiency with small work batches
+// and frequent restarts. Compare against Corosio to evaluate which framework
+// handles this latency-sensitive pattern more efficiently.
+bench::benchmark_result bench_interleaved_post_run(int iterations, int handlers_per_iteration)
 {
     bench::print_header("Interleaved Post/Run (Asio)");
 
@@ -151,10 +171,20 @@ void bench_interleaved_post_run(int iterations, int handlers_per_iteration)
         std::cerr << "  ERROR: counter mismatch! Expected " << total_handlers
                   << ", got " << counter << "\n";
     }
+
+    return bench::benchmark_result("interleaved_post_run")
+        .add("iterations", iterations)
+        .add("handlers_per_iteration", handlers_per_iteration)
+        .add("total_handlers", total_handlers)
+        .add("elapsed_s", elapsed)
+        .add("ops_per_sec", ops_per_sec);
 }
 
-// Benchmark: Multi-threaded concurrent posting and running
-void bench_concurrent_post_run(int num_threads, int handlers_per_thread)
+// Measures Asio performance under realistic concurrent load where multiple threads
+// simultaneously post and execute work. This stresses Asio's synchronization
+// primitives. Compare against Corosio to evaluate which framework handles
+// producer-consumer workloads more efficiently.
+bench::benchmark_result bench_concurrent_post_run(int num_threads, int handlers_per_thread)
 {
     bench::print_header("Concurrent Post and Run (Asio)");
 
@@ -198,12 +228,24 @@ void bench_concurrent_post_run(int num_threads, int handlers_per_thread)
         std::cerr << "  ERROR: counter mismatch! Expected " << total_handlers
                   << ", got " << counter.load() << "\n";
     }
+
+    return bench::benchmark_result("concurrent_post_run")
+        .add("threads", num_threads)
+        .add("handlers_per_thread", handlers_per_thread)
+        .add("total_handlers", total_handlers)
+        .add("elapsed_s", elapsed)
+        .add("ops_per_sec", ops_per_sec);
 }
 
-int main()
+// Run benchmarks
+void run_benchmarks(const char* output_file, const char* bench_filter)
 {
     std::cout << "Boost.Asio io_context Benchmarks\n";
     std::cout << "=================================\n";
+
+    bench::result_collector collector("asio");
+
+    bool run_all = !bench_filter || std::strcmp(bench_filter, "all") == 0;
 
     // Warm up
     {
@@ -214,12 +256,90 @@ int main()
         ioc.run();
     }
 
-    // Run benchmarks
-    bench_single_threaded_post(1000000);
-    bench_multithreaded_scaling(1000000, 8);
-    bench_interleaved_post_run(10000, 100);
-    bench_concurrent_post_run(4, 250000);
+    // Run selected benchmarks
+    if (run_all || std::strcmp(bench_filter, "single_threaded") == 0)
+        collector.add(bench_single_threaded_post(1000000));
+
+    if (run_all || std::strcmp(bench_filter, "multithreaded") == 0)
+        collector.add(bench_multithreaded_scaling(1000000, 8));
+
+    if (run_all || std::strcmp(bench_filter, "interleaved") == 0)
+        collector.add(bench_interleaved_post_run(10000, 100));
+
+    if (run_all || std::strcmp(bench_filter, "concurrent") == 0)
+        collector.add(bench_concurrent_post_run(4, 250000));
 
     std::cout << "\nBenchmarks complete.\n";
+
+    if (output_file)
+    {
+        if (collector.write_json(output_file))
+            std::cout << "Results written to: " << output_file << "\n";
+        else
+            std::cerr << "Error: Failed to write results to: " << output_file << "\n";
+    }
+}
+
+void print_usage(const char* program_name)
+{
+    std::cout << "Usage: " << program_name << " [OPTIONS]\n\n";
+    std::cout << "Options:\n";
+    std::cout << "  --bench <name>     Run only the specified benchmark\n";
+    std::cout << "  --output <file>    Write JSON results to file\n";
+    std::cout << "  --help             Show this help message\n";
+    std::cout << "\n";
+    std::cout << "Available benchmarks:\n";
+    std::cout << "  single_threaded    Single-threaded handler post throughput\n";
+    std::cout << "  multithreaded      Multi-threaded scaling test\n";
+    std::cout << "  interleaved        Interleaved post/poll pattern\n";
+    std::cout << "  concurrent         Concurrent post and run\n";
+    std::cout << "  all                Run all benchmarks (default)\n";
+}
+
+int main(int argc, char* argv[])
+{
+    const char* output_file = nullptr;
+    const char* bench_filter = nullptr;
+
+    for (int i = 1; i < argc; ++i)
+    {
+        if (std::strcmp(argv[i], "--bench") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                bench_filter = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --bench requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--output") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                output_file = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --output requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0)
+        {
+            print_usage(argv[0]);
+            return 0;
+        }
+        else
+        {
+            std::cerr << "Unknown option: " << argv[i] << "\n";
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    run_benchmarks(output_file, bench_filter);
     return 0;
 }

--- a/bench/asio/io_context_coro_bench.cpp
+++ b/bench/asio/io_context_coro_bench.cpp
@@ -16,6 +16,7 @@
 #include <boost/asio/awaitable.hpp>
 
 #include <atomic>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 #include <thread>
@@ -39,8 +40,11 @@ asio::awaitable<void> atomic_increment_task(std::atomic<int>& counter)
     co_return;
 }
 
-// Benchmark: Single-threaded coroutine posting rate
-void bench_single_threaded_post(int num_handlers)
+// Measures single-threaded coroutine throughput using Asio's awaitable/co_spawn.
+// This is a direct apples-to-apples comparison with Corosio since both use C++20
+// coroutines. Differences reveal the overhead of each framework's coroutine
+// integration rather than callback vs. coroutine differences.
+bench::benchmark_result bench_single_threaded_post(int num_handlers)
 {
     bench::print_header("Single-threaded Coroutine Post (Asio)");
 
@@ -67,14 +71,24 @@ void bench_single_threaded_post(int num_handlers)
         std::cerr << "  ERROR: counter mismatch! Expected " << num_handlers
                   << ", got " << counter << "\n";
     }
+
+    return bench::benchmark_result("single_threaded_post")
+        .add("handlers", num_handlers)
+        .add("elapsed_s", elapsed)
+        .add("ops_per_sec", ops_per_sec);
 }
 
-// Benchmark: Multi-threaded scaling with coroutines
-void bench_multithreaded_scaling(int num_handlers, int max_threads)
+// Measures multi-threaded scaling using Asio coroutines. Tests how Asio's
+// scheduler handles coroutine resumption across threads. Compare against Corosio
+// to evaluate coroutine dispatch efficiency under thread contention.
+bench::benchmark_result bench_multithreaded_scaling(int num_handlers, int max_threads)
 {
     bench::print_header("Multi-threaded Scaling (Asio Coroutines)");
 
     std::cout << "  Handlers per test: " << num_handlers << "\n\n";
+
+    bench::benchmark_result result("multithreaded_scaling");
+    result.add("handlers", num_handlers);
 
     double baseline_ops = 0;
 
@@ -111,16 +125,22 @@ void bench_multithreaded_scaling(int num_handlers, int max_threads)
 
         std::cout << "\n";
 
+        result.add("threads_" + std::to_string(num_threads) + "_ops_per_sec", ops_per_sec);
+
         if (counter.load() != num_handlers)
         {
             std::cerr << "  ERROR: counter mismatch! Expected " << num_handlers
                       << ", got " << counter.load() << "\n";
         }
     }
+
+    return result;
 }
 
-// Benchmark: Interleaved post and run with coroutines
-void bench_interleaved_post_run(int iterations, int handlers_per_iteration)
+// Measures poll() efficiency with Asio coroutines in a game-loop pattern.
+// Tests how Asio handles frequent context restarts with coroutine-based work.
+// Compare against Corosio for latency-sensitive polling scenarios.
+bench::benchmark_result bench_interleaved_post_run(int iterations, int handlers_per_iteration)
 {
     bench::print_header("Interleaved Post/Run (Asio Coroutines)");
 
@@ -157,10 +177,19 @@ void bench_interleaved_post_run(int iterations, int handlers_per_iteration)
         std::cerr << "  ERROR: counter mismatch! Expected " << total_handlers
                   << ", got " << counter << "\n";
     }
+
+    return bench::benchmark_result("interleaved_post_run")
+        .add("iterations", iterations)
+        .add("handlers_per_iteration", handlers_per_iteration)
+        .add("total_handlers", total_handlers)
+        .add("elapsed_s", elapsed)
+        .add("ops_per_sec", ops_per_sec);
 }
 
-// Benchmark: Concurrent posting and running with coroutines
-void bench_concurrent_post_run(int num_threads, int handlers_per_thread)
+// Measures Asio coroutine performance under concurrent producer-consumer load.
+// Multiple threads spawn and execute coroutines simultaneously. Compare against
+// Corosio to evaluate coroutine dispatch under realistic server workloads.
+bench::benchmark_result bench_concurrent_post_run(int num_threads, int handlers_per_thread)
 {
     bench::print_header("Concurrent Post and Run (Asio Coroutines)");
 
@@ -200,13 +229,25 @@ void bench_concurrent_post_run(int num_threads, int handlers_per_thread)
         std::cerr << "  ERROR: counter mismatch! Expected " << total_handlers
                   << ", got " << counter.load() << "\n";
     }
+
+    return bench::benchmark_result("concurrent_post_run")
+        .add("threads", num_threads)
+        .add("handlers_per_thread", handlers_per_thread)
+        .add("total_handlers", total_handlers)
+        .add("elapsed_s", elapsed)
+        .add("ops_per_sec", ops_per_sec);
 }
 
-int main()
+// Run benchmarks
+void run_benchmarks(const char* output_file, const char* bench_filter)
 {
     std::cout << "Boost.Asio io_context Benchmarks (Coroutine Version)\n";
     std::cout << "====================================================\n";
     std::cout << "Using coroutines for fair comparison with Corosio\n";
+
+    bench::result_collector collector("asio_coro");
+
+    bool run_all = !bench_filter || std::strcmp(bench_filter, "all") == 0;
 
     // Warm up
     {
@@ -217,12 +258,90 @@ int main()
         ioc.run();
     }
 
-    // Run benchmarks
-    bench_single_threaded_post(1000000);
-    bench_multithreaded_scaling(1000000, 8);
-    bench_interleaved_post_run(10000, 100);
-    bench_concurrent_post_run(4, 250000);
+    // Run selected benchmarks
+    if (run_all || std::strcmp(bench_filter, "single_threaded") == 0)
+        collector.add(bench_single_threaded_post(1000000));
+
+    if (run_all || std::strcmp(bench_filter, "multithreaded") == 0)
+        collector.add(bench_multithreaded_scaling(1000000, 8));
+
+    if (run_all || std::strcmp(bench_filter, "interleaved") == 0)
+        collector.add(bench_interleaved_post_run(10000, 100));
+
+    if (run_all || std::strcmp(bench_filter, "concurrent") == 0)
+        collector.add(bench_concurrent_post_run(4, 250000));
 
     std::cout << "\nBenchmarks complete.\n";
+
+    if (output_file)
+    {
+        if (collector.write_json(output_file))
+            std::cout << "Results written to: " << output_file << "\n";
+        else
+            std::cerr << "Error: Failed to write results to: " << output_file << "\n";
+    }
+}
+
+void print_usage(const char* program_name)
+{
+    std::cout << "Usage: " << program_name << " [OPTIONS]\n\n";
+    std::cout << "Options:\n";
+    std::cout << "  --bench <name>     Run only the specified benchmark\n";
+    std::cout << "  --output <file>    Write JSON results to file\n";
+    std::cout << "  --help             Show this help message\n";
+    std::cout << "\n";
+    std::cout << "Available benchmarks:\n";
+    std::cout << "  single_threaded    Single-threaded coroutine post throughput\n";
+    std::cout << "  multithreaded      Multi-threaded scaling test\n";
+    std::cout << "  interleaved        Interleaved post/poll pattern\n";
+    std::cout << "  concurrent         Concurrent post and run\n";
+    std::cout << "  all                Run all benchmarks (default)\n";
+}
+
+int main(int argc, char* argv[])
+{
+    const char* output_file = nullptr;
+    const char* bench_filter = nullptr;
+
+    for (int i = 1; i < argc; ++i)
+    {
+        if (std::strcmp(argv[i], "--bench") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                bench_filter = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --bench requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--output") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                output_file = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --output requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0)
+        {
+            print_usage(argv[0]);
+            return 0;
+        }
+        else
+        {
+            std::cerr << "Unknown option: " << argv[i] << "\n";
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    run_benchmarks(output_file, bench_filter);
     return 0;
 }

--- a/bench/asio/socket_latency_bench.cpp
+++ b/bench/asio/socket_latency_bench.cpp
@@ -17,6 +17,7 @@
 #include <boost/asio/read.hpp>
 #include <boost/asio/write.hpp>
 
+#include <cstring>
 #include <iostream>
 #include <vector>
 
@@ -93,8 +94,11 @@ asio::awaitable<void> pingpong_task(
     catch (std::exception const&) {}
 }
 
-// Benchmark: Ping-pong latency measurement
-void bench_pingpong_latency(std::size_t message_size, int iterations)
+// Measures Asio's round-trip latency for request-response patterns. Uses coroutines
+// for fair comparison with Corosio. Reports mean and tail latencies (p99, p99.9).
+// Compare against Corosio to evaluate which framework achieves lower latency for
+// RPC-style protocols.
+bench::benchmark_result bench_pingpong_latency(std::size_t message_size, int iterations)
 {
     std::cout << "  Message size: " << message_size << " bytes, ";
     std::cout << "Iterations: " << iterations << "\n";
@@ -114,10 +118,18 @@ void bench_pingpong_latency(std::size_t message_size, int iterations)
 
     client.close();
     server.close();
+
+    return bench::benchmark_result("pingpong_" + std::to_string(message_size))
+        .add("message_size", static_cast<double>(message_size))
+        .add("iterations", iterations)
+        .add_latency_stats("rtt", latency_stats);
 }
 
-// Benchmark: Multiple concurrent socket pairs
-void bench_concurrent_latency(int num_pairs, std::size_t message_size, int iterations)
+// Measures Asio's latency degradation under concurrent connection load. Multiple
+// socket pairs perform ping-pong simultaneously. Compare against Corosio to
+// evaluate which framework maintains lower latency as connection count increases.
+// Critical for understanding scalability limits.
+bench::benchmark_result bench_concurrent_latency(int num_pairs, std::size_t message_size, int iterations)
 {
     std::cout << "  Concurrent pairs: " << num_pairs << ", ";
     std::cout << "Message size: " << message_size << " bytes, ";
@@ -178,29 +190,113 @@ void bench_concurrent_latency(int num_pairs, std::size_t message_size, int itera
         c.close();
     for (auto& s : servers)
         s.close();
+
+    return bench::benchmark_result("concurrent_" + std::to_string(num_pairs) + "_pairs")
+        .add("num_pairs", num_pairs)
+        .add("message_size", static_cast<double>(message_size))
+        .add("iterations", iterations)
+        .add("avg_mean_latency_us", total_mean / num_pairs)
+        .add("avg_p99_latency_us", total_p99 / num_pairs);
 }
 
-int main()
+// Run benchmarks
+void run_benchmarks(const char* output_file, const char* bench_filter)
 {
     std::cout << "Boost.Asio Socket Latency Benchmarks\n";
     std::cout << "====================================\n";
 
-    bench::print_header("Ping-Pong Round-Trip Latency (Asio)");
+    bench::result_collector collector("asio");
+
+    bool run_all = !bench_filter || std::strcmp(bench_filter, "all") == 0;
 
     // Variable message sizes
     std::vector<std::size_t> message_sizes = {1, 64, 1024};
     int iterations = 1000;
 
-    for (auto size : message_sizes)
-        bench_pingpong_latency(size, iterations);
+    if (run_all || std::strcmp(bench_filter, "pingpong") == 0)
+    {
+        bench::print_header("Ping-Pong Round-Trip Latency (Asio)");
+        for (auto size : message_sizes)
+            collector.add(bench_pingpong_latency(size, iterations));
+    }
 
-    bench::print_header("Concurrent Socket Pairs Latency (Asio)");
-
-    // Multiple concurrent connections
-    bench_concurrent_latency(1, 64, 1000);
-    bench_concurrent_latency(4, 64, 500);
-    bench_concurrent_latency(16, 64, 250);
+    if (run_all || std::strcmp(bench_filter, "concurrent") == 0)
+    {
+        bench::print_header("Concurrent Socket Pairs Latency (Asio)");
+        collector.add(bench_concurrent_latency(1, 64, 1000));
+        collector.add(bench_concurrent_latency(4, 64, 500));
+        collector.add(bench_concurrent_latency(16, 64, 250));
+    }
 
     std::cout << "\nBenchmarks complete.\n";
+
+    if (output_file)
+    {
+        if (collector.write_json(output_file))
+            std::cout << "Results written to: " << output_file << "\n";
+        else
+            std::cerr << "Error: Failed to write results to: " << output_file << "\n";
+    }
+}
+
+void print_usage(const char* program_name)
+{
+    std::cout << "Usage: " << program_name << " [OPTIONS]\n\n";
+    std::cout << "Options:\n";
+    std::cout << "  --bench <name>     Run only the specified benchmark\n";
+    std::cout << "  --output <file>    Write JSON results to file\n";
+    std::cout << "  --help             Show this help message\n";
+    std::cout << "\n";
+    std::cout << "Available benchmarks:\n";
+    std::cout << "  pingpong           Ping-pong round-trip latency (various message sizes)\n";
+    std::cout << "  concurrent         Concurrent socket pairs latency\n";
+    std::cout << "  all                Run all benchmarks (default)\n";
+}
+
+int main(int argc, char* argv[])
+{
+    const char* output_file = nullptr;
+    const char* bench_filter = nullptr;
+
+    for (int i = 1; i < argc; ++i)
+    {
+        if (std::strcmp(argv[i], "--bench") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                bench_filter = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --bench requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--output") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                output_file = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --output requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0)
+        {
+            print_usage(argv[0]);
+            return 0;
+        }
+        else
+        {
+            std::cerr << "Unknown option: " << argv[i] << "\n";
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    run_benchmarks(output_file, bench_filter);
     return 0;
 }

--- a/bench/asio/socket_throughput_bench.cpp
+++ b/bench/asio/socket_throughput_bench.cpp
@@ -18,6 +18,7 @@
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/connect.hpp>
 
+#include <cstring>
 #include <iostream>
 #include <vector>
 
@@ -46,8 +47,11 @@ std::pair<tcp::socket, tcp::socket> make_socket_pair(asio::io_context& ioc)
     return {std::move(client), std::move(server)};
 }
 
-// Benchmark: Socket throughput with varying buffer sizes
-void bench_throughput(std::size_t chunk_size, std::size_t total_bytes)
+// Measures Asio's unidirectional socket throughput over loopback. Uses coroutines
+// for fair comparison with Corosio. Tests async I/O efficiency across different
+// buffer sizes. Compare against Corosio to evaluate which framework achieves
+// higher throughput for streaming workloads.
+bench::benchmark_result bench_throughput(std::size_t chunk_size, std::size_t total_bytes)
 {
     std::cout << "  Buffer size: " << chunk_size << " bytes, ";
     std::cout << "Transfer: " << (total_bytes / (1024 * 1024)) << " MB\n";
@@ -68,7 +72,7 @@ void bench_throughput(std::size_t chunk_size, std::size_t total_bytes)
         {
             while (total_written < total_bytes)
             {
-                std::size_t to_write = std::min(chunk_size, total_bytes - total_written);
+                std::size_t to_write = (std::min)(chunk_size, total_bytes - total_written);
                 auto n = co_await writer.async_write_some(
                     asio::buffer(write_buf.data(), to_write),
                     asio::use_awaitable);
@@ -114,10 +118,20 @@ void bench_throughput(std::size_t chunk_size, std::size_t total_bytes)
 
     writer.close();
     reader.close();
+
+    return bench::benchmark_result("throughput_" + std::to_string(chunk_size))
+        .add("chunk_size", static_cast<double>(chunk_size))
+        .add("total_bytes", static_cast<double>(total_bytes))
+        .add("bytes_written", static_cast<double>(total_written))
+        .add("bytes_read", static_cast<double>(total_read))
+        .add("elapsed_s", elapsed)
+        .add("throughput_bytes_per_sec", throughput);
 }
 
-// Benchmark: Bidirectional throughput
-void bench_bidirectional_throughput(std::size_t chunk_size, std::size_t total_bytes)
+// Measures Asio's full-duplex throughput with simultaneous send/receive. Four
+// concurrent coroutines stress the scheduler's I/O multiplexing. Compare against
+// Corosio for protocols requiring bidirectional data flow like WebSocket or gRPC.
+bench::benchmark_result bench_bidirectional_throughput(std::size_t chunk_size, std::size_t total_bytes)
 {
     std::cout << "  Buffer size: " << chunk_size << " bytes, ";
     std::cout << "Transfer: " << (total_bytes / (1024 * 1024)) << " MB each direction\n";
@@ -138,7 +152,7 @@ void bench_bidirectional_throughput(std::size_t chunk_size, std::size_t total_by
         {
             while (written1 < total_bytes)
             {
-                std::size_t to_write = std::min(chunk_size, total_bytes - written1);
+                std::size_t to_write = (std::min)(chunk_size, total_bytes - written1);
                 auto n = co_await sock1.async_write_some(
                     asio::buffer(buf1.data(), to_write),
                     asio::use_awaitable);
@@ -174,7 +188,7 @@ void bench_bidirectional_throughput(std::size_t chunk_size, std::size_t total_by
         {
             while (written2 < total_bytes)
             {
-                std::size_t to_write = std::min(chunk_size, total_bytes - written2);
+                std::size_t to_write = (std::min)(chunk_size, total_bytes - written2);
                 auto n = co_await sock2.async_write_some(
                     asio::buffer(buf2.data(), to_write),
                     asio::use_awaitable);
@@ -225,28 +239,114 @@ void bench_bidirectional_throughput(std::size_t chunk_size, std::size_t total_by
 
     sock1.close();
     sock2.close();
+
+    return bench::benchmark_result("bidirectional_" + std::to_string(chunk_size))
+        .add("chunk_size", static_cast<double>(chunk_size))
+        .add("total_bytes_per_direction", static_cast<double>(total_bytes))
+        .add("bytes_direction1", static_cast<double>(read1))
+        .add("bytes_direction2", static_cast<double>(read2))
+        .add("total_transferred", static_cast<double>(total_transferred))
+        .add("elapsed_s", elapsed)
+        .add("throughput_bytes_per_sec", throughput);
 }
 
-int main()
+// Run benchmarks
+void run_benchmarks(const char* output_file, const char* bench_filter)
 {
     std::cout << "Boost.Asio Socket Throughput Benchmarks\n";
     std::cout << "=======================================\n";
 
-    bench::print_header("Unidirectional Throughput (Asio)");
+    bench::result_collector collector("asio");
+
+    bool run_all = !bench_filter || std::strcmp(bench_filter, "all") == 0;
 
     // Variable buffer sizes
     std::vector<std::size_t> buffer_sizes = {1024, 4096, 16384, 65536};
     std::size_t transfer_size = 64 * 1024 * 1024; // 64 MB
 
-    for (auto size : buffer_sizes)
-        bench_throughput(size, transfer_size);
+    if (run_all || std::strcmp(bench_filter, "unidirectional") == 0)
+    {
+        bench::print_header("Unidirectional Throughput (Asio)");
+        for (auto size : buffer_sizes)
+            collector.add(bench_throughput(size, transfer_size));
+    }
 
-    bench::print_header("Bidirectional Throughput (Asio)");
-
-    // Bidirectional with different buffer sizes
-    for (auto size : buffer_sizes)
-        bench_bidirectional_throughput(size, transfer_size / 2);
+    if (run_all || std::strcmp(bench_filter, "bidirectional") == 0)
+    {
+        bench::print_header("Bidirectional Throughput (Asio)");
+        for (auto size : buffer_sizes)
+            collector.add(bench_bidirectional_throughput(size, transfer_size / 2));
+    }
 
     std::cout << "\nBenchmarks complete.\n";
+
+    if (output_file)
+    {
+        if (collector.write_json(output_file))
+            std::cout << "Results written to: " << output_file << "\n";
+        else
+            std::cerr << "Error: Failed to write results to: " << output_file << "\n";
+    }
+}
+
+void print_usage(const char* program_name)
+{
+    std::cout << "Usage: " << program_name << " [OPTIONS]\n\n";
+    std::cout << "Options:\n";
+    std::cout << "  --bench <name>     Run only the specified benchmark\n";
+    std::cout << "  --output <file>    Write JSON results to file\n";
+    std::cout << "  --help             Show this help message\n";
+    std::cout << "\n";
+    std::cout << "Available benchmarks:\n";
+    std::cout << "  unidirectional     Unidirectional throughput (various buffer sizes)\n";
+    std::cout << "  bidirectional      Bidirectional throughput (various buffer sizes)\n";
+    std::cout << "  all                Run all benchmarks (default)\n";
+}
+
+int main(int argc, char* argv[])
+{
+    const char* output_file = nullptr;
+    const char* bench_filter = nullptr;
+
+    for (int i = 1; i < argc; ++i)
+    {
+        if (std::strcmp(argv[i], "--bench") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                bench_filter = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --bench requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--output") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                output_file = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --output requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0)
+        {
+            print_usage(argv[0]);
+            return 0;
+        }
+        else
+        {
+            std::cerr << "Unknown option: " << argv[i] << "\n";
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    run_benchmarks(output_file, bench_filter);
     return 0;
 }

--- a/bench/common/backend_selection.hpp
+++ b/bench/common/backend_selection.hpp
@@ -1,0 +1,98 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BENCH_COMMON_BACKEND_SELECTION_HPP
+#define BENCH_COMMON_BACKEND_SELECTION_HPP
+
+#include <boost/corosio/io_context.hpp>
+#include <boost/corosio/detail/platform.hpp>
+
+#include <cstring>
+#include <iostream>
+
+namespace bench {
+
+/** Return the default backend name for the current platform. */
+inline const char* default_backend_name()
+{
+#if BOOST_COROSIO_HAS_IOCP
+    return "iocp";
+#elif BOOST_COROSIO_HAS_EPOLL
+    return "epoll";
+#elif BOOST_COROSIO_HAS_KQUEUE
+    return "kqueue";
+#elif BOOST_COROSIO_HAS_SELECT
+    return "select";
+#else
+    return "unknown";
+#endif
+}
+
+/** Print available backends for the current platform. */
+inline void print_available_backends()
+{
+    std::cout << "Available backends on this platform:\n";
+#if BOOST_COROSIO_HAS_IOCP
+    std::cout << "  iocp     - Windows I/O Completion Ports (default)\n";
+#endif
+#if BOOST_COROSIO_HAS_EPOLL
+    std::cout << "  epoll    - Linux epoll (default)\n";
+#endif
+#if BOOST_COROSIO_HAS_KQUEUE
+    std::cout << "  kqueue   - BSD/macOS kqueue (default)\n";
+#endif
+#if BOOST_COROSIO_HAS_SELECT
+    std::cout << "  select   - POSIX select (portable)\n";
+#endif
+    std::cout << "\nDefault backend: " << default_backend_name() << "\n";
+}
+
+/** Dispatch to a templated function based on backend name.
+
+    @param backend The backend name (epoll, select, iocp, etc.)
+    @param func A callable that takes a type tag as template parameter
+    @return 0 on success, 1 if backend is not available
+*/
+template<typename Func>
+int dispatch_backend(const char* backend, Func&& func)
+{
+    namespace corosio = boost::corosio;
+
+#if BOOST_COROSIO_HAS_EPOLL
+    if (std::strcmp(backend, "epoll") == 0)
+    {
+        func.template operator()<corosio::epoll_context>("epoll");
+        return 0;
+    }
+#endif
+
+#if BOOST_COROSIO_HAS_SELECT
+    if (std::strcmp(backend, "select") == 0)
+    {
+        func.template operator()<corosio::select_context>("select");
+        return 0;
+    }
+#endif
+
+#if BOOST_COROSIO_HAS_IOCP
+    if (std::strcmp(backend, "iocp") == 0)
+    {
+        func.template operator()<corosio::iocp_context>("iocp");
+        return 0;
+    }
+#endif
+
+    std::cerr << "Error: Backend '" << backend << "' is not available on this platform.\n\n";
+    print_available_backends();
+    return 1;
+}
+
+} // namespace bench
+
+#endif // BENCH_COMMON_BACKEND_SELECTION_HPP

--- a/bench/common/benchmark.hpp
+++ b/bench/common/benchmark.hpp
@@ -13,6 +13,8 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <ctime>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <numeric>
@@ -234,6 +236,148 @@ inline void print_latency_stats(statistics const& stats, char const* label)
     std::cout << "    min:   " << format_latency((stats.min)()) << "\n";
     std::cout << "    max:   " << format_latency((stats.max)()) << "\n";
 }
+
+/** A single metric with a name and numeric value. */
+struct metric
+{
+    std::string name;
+    double value;
+
+    metric(std::string n, double v)
+        : name(std::move(n))
+        , value(v)
+    {
+    }
+};
+
+/** Result from a single benchmark run. */
+struct benchmark_result
+{
+    std::string name;
+    std::vector<metric> metrics;
+
+    explicit benchmark_result(std::string n)
+        : name(std::move(n))
+    {
+    }
+
+    benchmark_result& add(std::string metric_name, double value)
+    {
+        metrics.emplace_back(std::move(metric_name), value);
+        return *this;
+    }
+
+    /** Add all statistics from a statistics object with a prefix. */
+    benchmark_result& add_latency_stats(std::string prefix, statistics const& stats)
+    {
+        add(prefix + "_mean_us", stats.mean());
+        add(prefix + "_p50_us", stats.p50());
+        add(prefix + "_p90_us", stats.p90());
+        add(prefix + "_p99_us", stats.p99());
+        add(prefix + "_p999_us", stats.p999());
+        add(prefix + "_min_us", (stats.min)());
+        add(prefix + "_max_us", (stats.max)());
+        return *this;
+    }
+};
+
+/** Collect benchmark results and serialize to JSON. */
+class result_collector
+{
+    std::string backend_;
+    std::string timestamp_;
+    std::vector<benchmark_result> results_;
+
+    static std::string escape_json(std::string const& s)
+    {
+        std::ostringstream oss;
+        for (char c : s)
+        {
+            switch (c)
+            {
+            case '"':  oss << "\\\""; break;
+            case '\\': oss << "\\\\"; break;
+            case '\b': oss << "\\b";  break;
+            case '\f': oss << "\\f";  break;
+            case '\n': oss << "\\n";  break;
+            case '\r': oss << "\\r";  break;
+            case '\t': oss << "\\t";  break;
+            default:   oss << c;      break;
+            }
+        }
+        return oss.str();
+    }
+
+    static std::string current_timestamp()
+    {
+        auto now = std::chrono::system_clock::now();
+        auto time = std::chrono::system_clock::to_time_t(now);
+        std::tm tm_buf;
+#ifdef _WIN32
+        localtime_s(&tm_buf, &time);
+#else
+        localtime_r(&time, &tm_buf);
+#endif
+        std::ostringstream oss;
+        oss << std::put_time(&tm_buf, "%Y-%m-%dT%H:%M:%S");
+        return oss.str();
+    }
+
+public:
+    explicit result_collector(std::string backend = "")
+        : backend_(std::move(backend))
+        , timestamp_(current_timestamp())
+    {
+    }
+
+    void set_backend(std::string backend) { backend_ = std::move(backend); }
+
+    void add(benchmark_result result) { results_.push_back(std::move(result)); }
+
+    /** Serialize all results to JSON. */
+    std::string to_json() const
+    {
+        std::ostringstream oss;
+        oss << std::setprecision(10);
+
+        oss << "{\n";
+        oss << "  \"metadata\": {\n";
+        oss << "    \"backend\": \"" << escape_json(backend_) << "\",\n";
+        oss << "    \"timestamp\": \"" << escape_json(timestamp_) << "\"\n";
+        oss << "  },\n";
+        oss << "  \"benchmarks\": [\n";
+
+        for (std::size_t i = 0; i < results_.size(); ++i)
+        {
+            auto const& r = results_[i];
+            oss << "    {\n";
+            oss << "      \"name\": \"" << escape_json(r.name) << "\"";
+
+            for (auto const& m : r.metrics)
+                oss << ",\n      \"" << escape_json(m.name) << "\": " << m.value;
+
+            oss << "\n    }";
+            if (i + 1 < results_.size())
+                oss << ",";
+            oss << "\n";
+        }
+
+        oss << "  ]\n";
+        oss << "}\n";
+
+        return oss.str();
+    }
+
+    /** Write JSON to a file. Returns true on success. */
+    bool write_json(std::string const& path) const
+    {
+        std::ofstream out(path);
+        if (!out)
+            return false;
+        out << to_json();
+        return out.good();
+    }
+};
 
 } // namespace bench
 

--- a/bench/common/http_protocol.hpp
+++ b/bench/common/http_protocol.hpp
@@ -1,0 +1,175 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_BENCH_HTTP_PROTOCOL_HPP
+#define BOOST_COROSIO_BENCH_HTTP_PROTOCOL_HPP
+
+#include <cstddef>
+#include <cstring>
+#include <string_view>
+
+namespace bench::http {
+
+/** Pre-formatted HTTP request. */
+constexpr char const small_request[] =
+    "GET /api/data HTTP/1.1\r\n"
+    "Host: localhost\r\n"
+    "Content-Length: 0\r\n"
+    "\r\n";
+
+constexpr std::size_t small_request_size = sizeof(small_request) - 1;
+
+/** Pre-formatted HTTP response. */
+constexpr char const small_response[] =
+    "HTTP/1.1 200 OK\r\n"
+    "Content-Length: 13\r\n"
+    "\r\n"
+    "Hello, World!";
+
+constexpr std::size_t small_response_size = sizeof(small_response) - 1;
+
+/** Simple HTTP request parser using a state machine.
+
+    Parses HTTP/1.1 requests by looking for the \r\n\r\n sequence
+    that terminates the headers. Content-Length handling is simplified
+    since the benchmark uses zero-length bodies.
+*/
+class request_parser
+{
+    std::size_t header_end_ = 0;
+    bool complete_ = false;
+
+public:
+    /** Reset the parser for a new request. */
+    void reset()
+    {
+        header_end_ = 0;
+        complete_ = false;
+    }
+
+    /** Return true if a complete request has been parsed. */
+    bool complete() const { return complete_; }
+
+    /** Return the number of bytes consumed by the complete request.
+
+        Only valid when complete() returns true.
+    */
+    std::size_t bytes_consumed() const { return header_end_; }
+
+    /** Parse incoming data and return number of bytes consumed.
+
+        @param data Pointer to the buffer containing request data.
+        @param size Number of bytes available in the buffer.
+        @return Number of bytes consumed (0 if incomplete).
+    */
+    std::size_t parse(char const* data, std::size_t size)
+    {
+        if (complete_)
+            return 0;
+
+        // Search for \r\n\r\n sequence
+        for (std::size_t i = 0; i + 3 < size; ++i)
+        {
+            if (data[i] == '\r' && data[i + 1] == '\n' &&
+                data[i + 2] == '\r' && data[i + 3] == '\n')
+            {
+                header_end_ = i + 4;
+                complete_ = true;
+                return header_end_;
+            }
+        }
+        return 0;
+    }
+};
+
+/** Simple HTTP response parser.
+
+    Parses HTTP/1.1 responses by finding the header end and extracting
+    Content-Length to determine the total message size.
+*/
+class response_parser
+{
+    std::size_t header_end_ = 0;
+    std::size_t content_length_ = 0;
+    std::size_t total_size_ = 0;
+    bool complete_ = false;
+
+public:
+    /** Reset the parser for a new response. */
+    void reset()
+    {
+        header_end_ = 0;
+        content_length_ = 0;
+        total_size_ = 0;
+        complete_ = false;
+    }
+
+    /** Return true if a complete response has been parsed. */
+    bool complete() const { return complete_; }
+
+    /** Return the total size of the complete response.
+
+        Only valid when complete() returns true.
+    */
+    std::size_t total_size() const { return total_size_; }
+
+    /** Parse incoming data and check for completion.
+
+        @param data Pointer to the buffer containing response data.
+        @param size Number of bytes available in the buffer.
+        @return True if the response is complete.
+    */
+    bool parse(char const* data, std::size_t size)
+    {
+        if (complete_)
+            return true;
+
+        // Find header end if not yet found
+        if (header_end_ == 0)
+        {
+            for (std::size_t i = 0; i + 3 < size; ++i)
+            {
+                if (data[i] == '\r' && data[i + 1] == '\n' &&
+                    data[i + 2] == '\r' && data[i + 3] == '\n')
+                {
+                    header_end_ = i + 4;
+
+                    // Extract Content-Length
+                    std::string_view headers(data, header_end_);
+                    auto pos = headers.find("Content-Length: ");
+                    if (pos != std::string_view::npos)
+                    {
+                        pos += 16;
+                        content_length_ = 0;
+                        while (pos < headers.size() && headers[pos] >= '0' && headers[pos] <= '9')
+                        {
+                            content_length_ = content_length_ * 10 + (headers[pos] - '0');
+                            ++pos;
+                        }
+                    }
+                    total_size_ = header_end_ + content_length_;
+                    break;
+                }
+            }
+        }
+
+        // Check if we have the complete response
+        if (header_end_ > 0 && size >= total_size_)
+        {
+            complete_ = true;
+            return true;
+        }
+
+        return false;
+    }
+};
+
+} // namespace bench::http
+
+#endif

--- a/bench/corosio/CMakeLists.txt
+++ b/bench/corosio/CMakeLists.txt
@@ -39,3 +39,13 @@ target_link_libraries(corosio_bench_socket_latency
         Threads::Threads)
 set_property(TARGET corosio_bench_socket_latency
     PROPERTY FOLDER "benchmarks/corosio")
+
+# http server benchmark
+add_executable(corosio_bench_http_server
+    http_server_bench.cpp)
+target_link_libraries(corosio_bench_http_server
+    PRIVATE
+        Boost::corosio
+        Threads::Threads)
+set_property(TARGET corosio_bench_http_server
+    PROPERTY FOLDER "benchmarks/corosio")

--- a/bench/corosio/http_server_bench.cpp
+++ b/bench/corosio/http_server_bench.cpp
@@ -8,7 +8,6 @@
 //
 
 #include <boost/corosio/io_context.hpp>
-#include <boost/corosio/epoll_context.hpp>
 #include <boost/corosio/socket.hpp>
 #include <boost/corosio/test/socket_pair.hpp>
 #include <boost/capy/buffers.hpp>
@@ -26,6 +25,7 @@
 #include <thread>
 #include <vector>
 
+#include "../common/backend_selection.hpp"
 #include "../common/benchmark.hpp"
 #include "../common/http_protocol.hpp"
 
@@ -118,11 +118,12 @@ capy::task<> client_task(
 }
 
 // Single connection benchmark
+template<typename Context>
 bench::benchmark_result bench_single_connection(int num_requests)
 {
     std::cout << "  Requests: " << num_requests << "\n";
 
-    corosio::io_context ioc;
+    Context ioc;
     auto [client, server] = corosio::test::make_socket_pair(ioc);
 
     client.set_no_delay(true);
@@ -161,6 +162,7 @@ bench::benchmark_result bench_single_connection(int num_requests)
 }
 
 // Concurrent connections benchmark
+template<typename Context>
 bench::benchmark_result bench_concurrent_connections(int num_connections, int requests_per_conn)
 {
     int total_requests = num_connections * requests_per_conn;
@@ -168,7 +170,7 @@ bench::benchmark_result bench_concurrent_connections(int num_connections, int re
               << ", Requests per connection: " << requests_per_conn
               << ", Total: " << total_requests << "\n";
 
-    corosio::io_context ioc;
+    Context ioc;
 
     std::vector<corosio::socket> clients;
     std::vector<corosio::socket> servers;
@@ -235,6 +237,7 @@ bench::benchmark_result bench_concurrent_connections(int num_connections, int re
 }
 
 // Multi-threaded benchmark: multiple threads calling run()
+template<typename Context>
 bench::benchmark_result bench_multithread(int num_threads, int num_connections, int requests_per_conn)
 {
     int total_requests = num_connections * requests_per_conn;
@@ -243,8 +246,7 @@ bench::benchmark_result bench_multithread(int num_threads, int num_connections, 
               << ", Requests per connection: " << requests_per_conn
               << ", Total: " << total_requests << "\n";
 
-    // Use default io_context for socket creation (make_socket_pair calls run() internally)
-    corosio::io_context ioc;
+    Context ioc;
 
     std::vector<corosio::socket> clients;
     std::vector<corosio::socket> servers;
@@ -323,19 +325,22 @@ bench::benchmark_result bench_multithread(int num_threads, int num_connections, 
         .add("avg_p99_latency_us", total_p99 / num_connections);
 }
 
-void run_benchmarks(char const* output_file, char const* bench_filter)
+// Run benchmarks for a specific context type
+template<typename Context>
+void run_benchmarks(char const* backend_name, char const* output_file, char const* bench_filter)
 {
     std::cout << "Boost.Corosio HTTP Server Benchmarks\n";
     std::cout << "====================================\n";
+    std::cout << "Backend: " << backend_name << "\n\n";
 
-    bench::result_collector collector("corosio");
+    bench::result_collector collector(backend_name);
 
     bool run_all = !bench_filter || std::strcmp(bench_filter, "all") == 0;
 
     if (run_all || std::strcmp(bench_filter, "single_conn") == 0)
     {
         bench::print_header("Single Connection (Sequential Requests)");
-        collector.add(bench_single_connection(10000));
+        collector.add(bench_single_connection<Context>(10000));
     }
 
     if (run_all || std::strcmp(bench_filter, "concurrent") == 0)
@@ -343,10 +348,10 @@ void run_benchmarks(char const* output_file, char const* bench_filter)
         if (run_all)
             std::this_thread::sleep_for(std::chrono::seconds(5));
         bench::print_header("Concurrent Connections");
-        collector.add(bench_concurrent_connections(1, 10000));
-        collector.add(bench_concurrent_connections(4, 2500));
-        collector.add(bench_concurrent_connections(16, 625));
-        collector.add(bench_concurrent_connections(32, 312));
+        collector.add(bench_concurrent_connections<Context>(1, 10000));
+        collector.add(bench_concurrent_connections<Context>(4, 2500));
+        collector.add(bench_concurrent_connections<Context>(16, 625));
+        collector.add(bench_concurrent_connections<Context>(32, 312));
     }
 
     if (run_all || std::strcmp(bench_filter, "multithread") == 0)
@@ -354,10 +359,10 @@ void run_benchmarks(char const* output_file, char const* bench_filter)
         if (run_all)
             std::this_thread::sleep_for(std::chrono::seconds(5));
         bench::print_header("Multi-threaded (32 connections, varying threads)");
-        collector.add(bench_multithread(1, 32, 312));
-        collector.add(bench_multithread(2, 32, 312));
-        collector.add(bench_multithread(4, 32, 312));
-        collector.add(bench_multithread(8, 32, 312));
+        collector.add(bench_multithread<Context>(1, 32, 312));
+        collector.add(bench_multithread<Context>(2, 32, 312));
+        collector.add(bench_multithread<Context>(4, 32, 312));
+        collector.add(bench_multithread<Context>(8, 32, 312));
     }
 
     std::cout << "\nBenchmarks complete.\n";
@@ -375,8 +380,10 @@ void print_usage(char const* program_name)
 {
     std::cout << "Usage: " << program_name << " [OPTIONS]\n\n";
     std::cout << "Options:\n";
+    std::cout << "  --backend <name>   Select I/O backend (default: platform default)\n";
     std::cout << "  --bench <name>     Run only the specified benchmark\n";
     std::cout << "  --output <file>    Write JSON results to file\n";
+    std::cout << "  --list             List available backends\n";
     std::cout << "  --help             Show this help message\n";
     std::cout << "\n";
     std::cout << "Available benchmarks:\n";
@@ -384,16 +391,31 @@ void print_usage(char const* program_name)
     std::cout << "  concurrent         Multiple concurrent connections\n";
     std::cout << "  multithread        Multi-threaded with varying thread counts\n";
     std::cout << "  all                Run all benchmarks (default)\n";
+    std::cout << "\n";
+    bench::print_available_backends();
 }
 
 int main(int argc, char* argv[])
 {
+    char const* backend = nullptr;
     char const* output_file = nullptr;
     char const* bench_filter = nullptr;
 
     for (int i = 1; i < argc; ++i)
     {
-        if (std::strcmp(argv[i], "--bench") == 0)
+        if (std::strcmp(argv[i], "--backend") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                backend = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --backend requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--bench") == 0)
         {
             if (i + 1 < argc)
             {
@@ -417,6 +439,11 @@ int main(int argc, char* argv[])
                 return 1;
             }
         }
+        else if (std::strcmp(argv[i], "--list") == 0)
+        {
+            bench::print_available_backends();
+            return 0;
+        }
         else if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0)
         {
             print_usage(argv[0]);
@@ -430,6 +457,14 @@ int main(int argc, char* argv[])
         }
     }
 
-    run_benchmarks(output_file, bench_filter);
-    return 0;
+    // If no backend specified, use platform default
+    if (!backend)
+        backend = bench::default_backend_name();
+
+    // Dispatch to the selected backend using a generic lambda
+    return bench::dispatch_backend(backend,
+        [=]<typename Context>(const char* name)
+        {
+            run_benchmarks<Context>(name, output_file, bench_filter);
+        });
 }

--- a/bench/corosio/http_server_bench.cpp
+++ b/bench/corosio/http_server_bench.cpp
@@ -1,0 +1,435 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#include <boost/corosio/io_context.hpp>
+#include <boost/corosio/epoll_context.hpp>
+#include <boost/corosio/socket.hpp>
+#include <boost/corosio/test/socket_pair.hpp>
+#include <boost/capy/buffers.hpp>
+#include <boost/capy/buffers/string_dynamic_buffer.hpp>
+#include <boost/capy/ex/run_async.hpp>
+#include <boost/capy/read.hpp>
+#include <boost/capy/read_until.hpp>
+#include <boost/capy/task.hpp>
+#include <boost/capy/write.hpp>
+
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "../common/benchmark.hpp"
+#include "../common/http_protocol.hpp"
+
+namespace corosio = boost::corosio;
+namespace capy = boost::capy;
+
+// Server coroutine: reads requests and sends responses
+capy::task<> server_task(
+    corosio::socket& sock,
+    int num_requests,
+    int& completed_requests)
+{
+    std::string buf;
+
+    while (completed_requests < num_requests)
+    {
+        // Read until end of HTTP headers
+        auto [ec, n] = co_await capy::read_until(
+            sock, capy::dynamic_buffer(buf), "\r\n\r\n");
+        if (ec)
+            co_return;
+
+        // Send response
+        auto [wec, wn] = co_await capy::write(
+            sock, capy::const_buffer(bench::http::small_response, bench::http::small_response_size));
+        if (wec)
+            co_return;
+
+        ++completed_requests;
+        buf.erase(0, n);
+    }
+}
+
+// Client coroutine: sends requests and reads responses
+capy::task<> client_task(
+    corosio::socket& sock,
+    int num_requests,
+    bench::statistics& latency_stats)
+{
+    std::string buf;
+
+    for (int i = 0; i < num_requests; ++i)
+    {
+        bench::stopwatch sw;
+
+        // Send request
+        auto [wec, wn] = co_await capy::write(
+            sock, capy::const_buffer(bench::http::small_request, bench::http::small_request_size));
+        if (wec)
+            co_return;
+
+        // Read response headers
+        auto [ec, header_end] = co_await capy::read_until(
+            sock, capy::dynamic_buffer(buf), "\r\n\r\n");
+        if (ec)
+            co_return;
+
+        // Parse Content-Length from headers and read body if needed
+        std::string_view headers(buf.data(), header_end);
+        std::size_t content_length = 0;
+        auto pos = headers.find("Content-Length: ");
+        if (pos != std::string_view::npos)
+        {
+            pos += 16;
+            while (pos < headers.size() && headers[pos] >= '0' && headers[pos] <= '9')
+            {
+                content_length = content_length * 10 + (headers[pos] - '0');
+                ++pos;
+            }
+        }
+
+        // Read body if not already in buffer
+        std::size_t total_size = header_end + content_length;
+        if (buf.size() < total_size)
+        {
+            std::size_t need = total_size - buf.size();
+            std::size_t old_size = buf.size();
+            buf.resize(total_size);
+            auto [rec, rn] = co_await capy::read(
+                sock, capy::mutable_buffer(buf.data() + old_size, need));
+            if (rec)
+                co_return;
+        }
+
+        double latency_us = sw.elapsed_us();
+        latency_stats.add(latency_us);
+
+        buf.erase(0, total_size);
+    }
+}
+
+// Single connection benchmark
+bench::benchmark_result bench_single_connection(int num_requests)
+{
+    std::cout << "  Requests: " << num_requests << "\n";
+
+    corosio::io_context ioc;
+    auto [client, server] = corosio::test::make_socket_pair(ioc);
+
+    client.set_no_delay(true);
+    server.set_no_delay(true);
+
+    int completed_requests = 0;
+    bench::statistics latency_stats;
+
+    bench::stopwatch total_sw;
+
+    capy::run_async(ioc.get_executor())(
+        server_task(server, num_requests, completed_requests));
+    capy::run_async(ioc.get_executor())(
+        client_task(client, num_requests, latency_stats));
+
+    ioc.run();
+
+    double elapsed = total_sw.elapsed_seconds();
+    double requests_per_sec = static_cast<double>(num_requests) / elapsed;
+
+    std::cout << "    Completed: " << num_requests << " requests\n";
+    std::cout << "    Elapsed: " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "    Throughput: " << bench::format_rate(requests_per_sec) << "\n";
+    bench::print_latency_stats(latency_stats, "Request latency");
+    std::cout << "\n";
+
+    client.close();
+    server.close();
+
+    return bench::benchmark_result("single_conn")
+        .add("num_requests", num_requests)
+        .add("num_connections", 1)
+        .add("requests_per_sec", requests_per_sec)
+        .add_latency_stats("request_latency", latency_stats);
+}
+
+// Concurrent connections benchmark
+bench::benchmark_result bench_concurrent_connections(int num_connections, int requests_per_conn)
+{
+    int total_requests = num_connections * requests_per_conn;
+    std::cout << "  Connections: " << num_connections
+              << ", Requests per connection: " << requests_per_conn
+              << ", Total: " << total_requests << "\n";
+
+    corosio::io_context ioc;
+
+    std::vector<corosio::socket> clients;
+    std::vector<corosio::socket> servers;
+    std::vector<int> completed(num_connections, 0);
+    std::vector<bench::statistics> stats(num_connections);
+
+    clients.reserve(num_connections);
+    servers.reserve(num_connections);
+
+    for (int i = 0; i < num_connections; ++i)
+    {
+        auto [c, s] = corosio::test::make_socket_pair(ioc);
+        c.set_no_delay(true);
+        s.set_no_delay(true);
+        clients.push_back(std::move(c));
+        servers.push_back(std::move(s));
+    }
+
+    bench::stopwatch total_sw;
+
+    for (int i = 0; i < num_connections; ++i)
+    {
+        capy::run_async(ioc.get_executor())(
+            server_task(servers[i], requests_per_conn, completed[i]));
+        capy::run_async(ioc.get_executor())(
+            client_task(clients[i], requests_per_conn, stats[i]));
+    }
+
+    ioc.run();
+
+    double elapsed = total_sw.elapsed_seconds();
+    double requests_per_sec = static_cast<double>(total_requests) / elapsed;
+
+    // Aggregate latency stats
+    double total_mean = 0;
+    double total_p99 = 0;
+    for (auto& s : stats)
+    {
+        total_mean += s.mean();
+        total_p99 += s.p99();
+    }
+
+    std::cout << "    Completed: " << total_requests << " requests\n";
+    std::cout << "    Elapsed: " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "    Throughput: " << bench::format_rate(requests_per_sec) << "\n";
+    std::cout << "    Avg mean latency: "
+              << bench::format_latency(total_mean / num_connections) << "\n";
+    std::cout << "    Avg p99 latency: "
+              << bench::format_latency(total_p99 / num_connections) << "\n\n";
+
+    for (auto& c : clients)
+        c.close();
+    for (auto& s : servers)
+        s.close();
+
+    return bench::benchmark_result("concurrent_" + std::to_string(num_connections))
+        .add("num_connections", num_connections)
+        .add("requests_per_conn", requests_per_conn)
+        .add("total_requests", total_requests)
+        .add("requests_per_sec", requests_per_sec)
+        .add("avg_mean_latency_us", total_mean / num_connections)
+        .add("avg_p99_latency_us", total_p99 / num_connections);
+}
+
+// Multi-threaded benchmark: multiple threads calling run()
+bench::benchmark_result bench_multithread(int num_threads, int num_connections, int requests_per_conn)
+{
+    int total_requests = num_connections * requests_per_conn;
+    std::cout << "  Threads: " << num_threads
+              << ", Connections: " << num_connections
+              << ", Requests per connection: " << requests_per_conn
+              << ", Total: " << total_requests << "\n";
+
+    // Use default io_context for socket creation (make_socket_pair calls run() internally)
+    corosio::io_context ioc;
+
+    std::vector<corosio::socket> clients;
+    std::vector<corosio::socket> servers;
+    std::vector<int> completed(num_connections, 0);
+    std::vector<bench::statistics> stats(num_connections);
+
+    clients.reserve(num_connections);
+    servers.reserve(num_connections);
+
+    for (int i = 0; i < num_connections; ++i)
+    {
+        auto [c, s] = corosio::test::make_socket_pair(ioc);
+        c.set_no_delay(true);
+        s.set_no_delay(true);
+        clients.push_back(std::move(c));
+        servers.push_back(std::move(s));
+    }
+
+    // Spawn all coroutines before starting threads
+    for (int i = 0; i < num_connections; ++i)
+    {
+        capy::run_async(ioc.get_executor())(
+            server_task(servers[i], requests_per_conn, completed[i]));
+        capy::run_async(ioc.get_executor())(
+            client_task(clients[i], requests_per_conn, stats[i]));
+    }
+
+    bench::stopwatch total_sw;
+
+    // Launch worker threads
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads - 1);
+    for (int i = 1; i < num_threads; ++i)
+        threads.emplace_back([&ioc] { ioc.run(); });
+
+    // Main thread also runs
+    ioc.run();
+
+    // Wait for all threads
+    for (auto& t : threads)
+        t.join();
+
+    double elapsed = total_sw.elapsed_seconds();
+    double requests_per_sec = static_cast<double>(total_requests) / elapsed;
+
+    // Aggregate latency stats
+    double total_mean = 0;
+    double total_p99 = 0;
+    for (auto& s : stats)
+    {
+        total_mean += s.mean();
+        total_p99 += s.p99();
+    }
+
+    std::cout << "    Completed: " << total_requests << " requests\n";
+    std::cout << "    Elapsed: " << std::fixed << std::setprecision(3)
+              << elapsed << " s\n";
+    std::cout << "    Throughput: " << bench::format_rate(requests_per_sec) << "\n";
+    std::cout << "    Avg mean latency: "
+              << bench::format_latency(total_mean / num_connections) << "\n";
+    std::cout << "    Avg p99 latency: "
+              << bench::format_latency(total_p99 / num_connections) << "\n\n";
+
+    for (auto& c : clients)
+        c.close();
+    for (auto& s : servers)
+        s.close();
+
+    return bench::benchmark_result("multithread_" + std::to_string(num_threads) + "t")
+        .add("num_threads", num_threads)
+        .add("num_connections", num_connections)
+        .add("requests_per_conn", requests_per_conn)
+        .add("total_requests", total_requests)
+        .add("requests_per_sec", requests_per_sec)
+        .add("avg_mean_latency_us", total_mean / num_connections)
+        .add("avg_p99_latency_us", total_p99 / num_connections);
+}
+
+void run_benchmarks(char const* output_file, char const* bench_filter)
+{
+    std::cout << "Boost.Corosio HTTP Server Benchmarks\n";
+    std::cout << "====================================\n";
+
+    bench::result_collector collector("corosio");
+
+    bool run_all = !bench_filter || std::strcmp(bench_filter, "all") == 0;
+
+    if (run_all || std::strcmp(bench_filter, "single_conn") == 0)
+    {
+        bench::print_header("Single Connection (Sequential Requests)");
+        collector.add(bench_single_connection(10000));
+    }
+
+    if (run_all || std::strcmp(bench_filter, "concurrent") == 0)
+    {
+        if (run_all)
+            std::this_thread::sleep_for(std::chrono::seconds(5));
+        bench::print_header("Concurrent Connections");
+        collector.add(bench_concurrent_connections(1, 10000));
+        collector.add(bench_concurrent_connections(4, 2500));
+        collector.add(bench_concurrent_connections(16, 625));
+        collector.add(bench_concurrent_connections(32, 312));
+    }
+
+    if (run_all || std::strcmp(bench_filter, "multithread") == 0)
+    {
+        if (run_all)
+            std::this_thread::sleep_for(std::chrono::seconds(5));
+        bench::print_header("Multi-threaded (32 connections, varying threads)");
+        collector.add(bench_multithread(1, 32, 312));
+        collector.add(bench_multithread(2, 32, 312));
+        collector.add(bench_multithread(4, 32, 312));
+        collector.add(bench_multithread(8, 32, 312));
+    }
+
+    std::cout << "\nBenchmarks complete.\n";
+
+    if (output_file)
+    {
+        if (collector.write_json(output_file))
+            std::cout << "Results written to: " << output_file << "\n";
+        else
+            std::cerr << "Error: Failed to write results to: " << output_file << "\n";
+    }
+}
+
+void print_usage(char const* program_name)
+{
+    std::cout << "Usage: " << program_name << " [OPTIONS]\n\n";
+    std::cout << "Options:\n";
+    std::cout << "  --bench <name>     Run only the specified benchmark\n";
+    std::cout << "  --output <file>    Write JSON results to file\n";
+    std::cout << "  --help             Show this help message\n";
+    std::cout << "\n";
+    std::cout << "Available benchmarks:\n";
+    std::cout << "  single_conn        Single connection, sequential requests\n";
+    std::cout << "  concurrent         Multiple concurrent connections\n";
+    std::cout << "  multithread        Multi-threaded with varying thread counts\n";
+    std::cout << "  all                Run all benchmarks (default)\n";
+}
+
+int main(int argc, char* argv[])
+{
+    char const* output_file = nullptr;
+    char const* bench_filter = nullptr;
+
+    for (int i = 1; i < argc; ++i)
+    {
+        if (std::strcmp(argv[i], "--bench") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                bench_filter = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --bench requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--output") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                output_file = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --output requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0)
+        {
+            print_usage(argv[0]);
+            return 0;
+        }
+        else
+        {
+            std::cerr << "Unknown option: " << argv[i] << "\n";
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    run_benchmarks(output_file, bench_filter);
+    return 0;
+}

--- a/bench/corosio/io_context_bench.cpp
+++ b/bench/corosio/io_context_bench.cpp
@@ -71,9 +71,12 @@ capy::task<> atomic_increment_task(std::atomic<int>& counter)
     co_return;
 }
 
-// Benchmark: Single-threaded handler posting rate
+// Measures the raw throughput of posting and executing coroutines from a single
+// thread. This establishes a baseline for the scheduler's best-case performance
+// without any synchronization overhead. Useful for comparing coroutine dispatch
+// efficiency against other async frameworks and identifying per-handler overhead.
 template <typename Context>
-void bench_single_threaded_post(int num_handlers)
+bench::benchmark_result bench_single_threaded_post(int num_handlers)
 {
     bench::print_header("Single-threaded Handler Post");
 
@@ -101,16 +104,29 @@ void bench_single_threaded_post(int num_handlers)
         std::cerr << "  ERROR: counter mismatch! Expected " << num_handlers
                   << ", got " << counter << "\n";
     }
+
+    return bench::benchmark_result("single_threaded_post")
+        .add("handlers", num_handlers)
+        .add("elapsed_s", elapsed)
+        .add("ops_per_sec", ops_per_sec);
 }
 
-// Benchmark: Multi-threaded scaling
+// Measures how throughput scales when multiple threads call run() on the same
+// io_context. Pre-posts all work, then times execution across 1, 2, 4, 8 threads.
+// Reveals lock contention in the scheduler's work queue. Ideal scaling would show
+// linear speedup; sub-linear or negative scaling indicates contention issues that
+// may need strand-based partitioning in real applications.
 template <typename Context>
-void bench_multithreaded_scaling(int num_handlers, int max_threads)
+bench::benchmark_result bench_multithreaded_scaling(int num_handlers, int max_threads)
 {
     bench::print_header("Multi-threaded Scaling");
 
     std::cout << "  Handlers per test: " << num_handlers << "\n\n";
 
+    bench::benchmark_result result("multithreaded_scaling");
+    result.add("handlers", num_handlers);
+
+    double baseline_ops = 0;
     for (int num_threads = 1; num_threads <= max_threads; num_threads *= 2)
     {
         Context ioc;
@@ -137,17 +153,15 @@ void bench_multithreaded_scaling(int num_handlers, int max_threads)
         std::cout << "  " << num_threads << " thread(s): "
                   << bench::format_rate(ops_per_sec);
 
-        if (num_threads > 1)
-        {
-            // Calculate speedup vs single-threaded baseline
-            static double baseline_ops = 0;
-            if (num_threads == 1)
-                baseline_ops = ops_per_sec;
-            else if (baseline_ops > 0)
-                std::cout << " (speedup: " << std::fixed << std::setprecision(2)
-                          << (ops_per_sec / baseline_ops) << "x)";
-        }
+        if (num_threads == 1)
+            baseline_ops = ops_per_sec;
+        else if (baseline_ops > 0)
+            std::cout << " (speedup: " << std::fixed << std::setprecision(2)
+                      << (ops_per_sec / baseline_ops) << "x)";
         std::cout << "\n";
+
+        // Record per-thread results
+        result.add("threads_" + std::to_string(num_threads) + "_ops_per_sec", ops_per_sec);
 
         if (counter.load() != num_handlers)
         {
@@ -155,11 +169,17 @@ void bench_multithreaded_scaling(int num_handlers, int max_threads)
                       << ", got " << counter.load() << "\n";
         }
     }
+
+    return result;
 }
 
-// Benchmark: Post and run interleaved
+// Measures performance when posting and polling are interleaved, simulating a
+// game loop or GUI event pump that processes available work each frame. Posts a
+// batch of handlers, calls poll() to execute ready work, then repeats. Tests the
+// efficiency of poll() with small work batches and frequent context restarts,
+// which is common in latency-sensitive applications that can't block on run().
 template <typename Context>
-void bench_interleaved_post_run(int iterations, int handlers_per_iteration)
+bench::benchmark_result bench_interleaved_post_run(int iterations, int handlers_per_iteration)
 {
     bench::print_header("Interleaved Post/Run");
 
@@ -197,11 +217,23 @@ void bench_interleaved_post_run(int iterations, int handlers_per_iteration)
         std::cerr << "  ERROR: counter mismatch! Expected " << total_handlers
                   << ", got " << counter << "\n";
     }
+
+    return bench::benchmark_result("interleaved_post_run")
+        .add("iterations", iterations)
+        .add("handlers_per_iteration", handlers_per_iteration)
+        .add("total_handlers", total_handlers)
+        .add("elapsed_s", elapsed)
+        .add("ops_per_sec", ops_per_sec);
 }
 
-// Benchmark: Multi-threaded concurrent posting and running
+// Measures performance under realistic concurrent load where multiple threads
+// simultaneously post work AND execute it. This is the most stressful test for
+// the scheduler's synchronization, as threads contend for both the submission
+// and completion paths. Simulates server workloads where worker threads both
+// generate new tasks and process existing ones, revealing producer-consumer
+// bottlenecks.
 template <typename Context>
-void bench_concurrent_post_run(int num_threads, int handlers_per_thread)
+bench::benchmark_result bench_concurrent_post_run(int num_threads, int handlers_per_thread)
 {
     bench::print_header("Concurrent Post and Run");
 
@@ -242,15 +274,26 @@ void bench_concurrent_post_run(int num_threads, int handlers_per_thread)
         std::cerr << "  ERROR: counter mismatch! Expected " << total_handlers
                   << ", got " << counter.load() << "\n";
     }
+
+    return bench::benchmark_result("concurrent_post_run")
+        .add("threads", num_threads)
+        .add("handlers_per_thread", handlers_per_thread)
+        .add("total_handlers", total_handlers)
+        .add("elapsed_s", elapsed)
+        .add("ops_per_sec", ops_per_sec);
 }
 
-// Run all benchmarks for a specific context type
+// Run benchmarks for a specific context type
 template <typename Context>
-void run_all_benchmarks(const char* backend_name)
+void run_benchmarks(const char* backend_name, const char* output_file, const char* bench_filter)
 {
     std::cout << "Boost.Corosio io_context Benchmarks\n";
     std::cout << "====================================\n";
     std::cout << "Backend: " << backend_name << "\n\n";
+
+    bench::result_collector collector(backend_name);
+
+    bool run_all = !bench_filter || std::strcmp(bench_filter, "all") == 0;
 
     // Warm up
     {
@@ -262,13 +305,28 @@ void run_all_benchmarks(const char* backend_name)
         ioc.run();
     }
 
-    // Run benchmarks
-    bench_single_threaded_post<Context>(1000000);
-    bench_multithreaded_scaling<Context>(1000000, 8);
-    bench_interleaved_post_run<Context>(10000, 100);
-    bench_concurrent_post_run<Context>(4, 250000);
+    // Run selected benchmarks
+    if (run_all || std::strcmp(bench_filter, "single_threaded") == 0)
+        collector.add(bench_single_threaded_post<Context>(1000000));
+
+    if (run_all || std::strcmp(bench_filter, "multithreaded") == 0)
+        collector.add(bench_multithreaded_scaling<Context>(1000000, 8));
+
+    if (run_all || std::strcmp(bench_filter, "interleaved") == 0)
+        collector.add(bench_interleaved_post_run<Context>(10000, 100));
+
+    if (run_all || std::strcmp(bench_filter, "concurrent") == 0)
+        collector.add(bench_concurrent_post_run<Context>(4, 250000));
 
     std::cout << "\nBenchmarks complete.\n";
+
+    if (output_file)
+    {
+        if (collector.write_json(output_file))
+            std::cout << "Results written to: " << output_file << "\n";
+        else
+            std::cerr << "Error: Failed to write results to: " << output_file << "\n";
+    }
 }
 
 void print_usage(const char* program_name)
@@ -276,8 +334,17 @@ void print_usage(const char* program_name)
     std::cout << "Usage: " << program_name << " [OPTIONS]\n\n";
     std::cout << "Options:\n";
     std::cout << "  --backend <name>   Select I/O backend (default: platform default)\n";
+    std::cout << "  --bench <name>     Run only the specified benchmark\n";
+    std::cout << "  --output <file>    Write JSON results to file\n";
     std::cout << "  --list             List available backends\n";
     std::cout << "  --help             Show this help message\n";
+    std::cout << "\n";
+    std::cout << "Available benchmarks:\n";
+    std::cout << "  single_threaded    Single-threaded handler post throughput\n";
+    std::cout << "  multithreaded      Multi-threaded scaling test\n";
+    std::cout << "  interleaved        Interleaved post/poll pattern\n";
+    std::cout << "  concurrent         Concurrent post and run\n";
+    std::cout << "  all                Run all benchmarks (default)\n";
     std::cout << "\n";
     print_available_backends();
 }
@@ -285,6 +352,8 @@ void print_usage(const char* program_name)
 int main(int argc, char* argv[])
 {
     const char* backend = nullptr;
+    const char* output_file = nullptr;
+    const char* bench_filter = nullptr;
 
     // Parse command-line arguments
     for (int i = 1; i < argc; ++i)
@@ -298,6 +367,30 @@ int main(int argc, char* argv[])
             else
             {
                 std::cerr << "Error: --backend requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--bench") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                bench_filter = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --bench requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--output") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                output_file = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --output requires an argument\n";
                 return 1;
             }
         }
@@ -329,7 +422,7 @@ int main(int argc, char* argv[])
 #if BOOST_COROSIO_HAS_EPOLL
     if (std::strcmp(backend, "epoll") == 0)
     {
-        run_all_benchmarks<corosio::epoll_context>("epoll");
+        run_benchmarks<corosio::epoll_context>("epoll", output_file, bench_filter);
         return 0;
     }
 #endif
@@ -337,7 +430,7 @@ int main(int argc, char* argv[])
 #if BOOST_COROSIO_HAS_SELECT
     if (std::strcmp(backend, "select") == 0)
     {
-        run_all_benchmarks<corosio::select_context>("select");
+        run_benchmarks<corosio::select_context>("select", output_file, bench_filter);
         return 0;
     }
 #endif
@@ -345,7 +438,7 @@ int main(int argc, char* argv[])
 #if BOOST_COROSIO_HAS_IOCP
     if (std::strcmp(backend, "iocp") == 0)
     {
-        run_all_benchmarks<corosio::iocp_context>("iocp");
+        run_benchmarks<corosio::iocp_context>("iocp", output_file, bench_filter);
         return 0;
     }
 #endif

--- a/bench/corosio/io_context_bench.cpp
+++ b/bench/corosio/io_context_bench.cpp
@@ -18,44 +18,11 @@
 #include <thread>
 #include <vector>
 
+#include "../common/backend_selection.hpp"
 #include "../common/benchmark.hpp"
 
 namespace corosio = boost::corosio;
 namespace capy = boost::capy;
-
-// Backend names for display
-inline const char* default_backend_name()
-{
-#if BOOST_COROSIO_HAS_IOCP
-    return "iocp";
-#elif BOOST_COROSIO_HAS_EPOLL
-    return "epoll";
-#elif BOOST_COROSIO_HAS_KQUEUE
-    return "kqueue";
-#elif BOOST_COROSIO_HAS_SELECT
-    return "select";
-#else
-    return "unknown";
-#endif
-}
-
-inline void print_available_backends()
-{
-    std::cout << "Available backends on this platform:\n";
-#if BOOST_COROSIO_HAS_IOCP
-    std::cout << "  iocp     - Windows I/O Completion Ports (default)\n";
-#endif
-#if BOOST_COROSIO_HAS_EPOLL
-    std::cout << "  epoll    - Linux epoll (default)\n";
-#endif
-#if BOOST_COROSIO_HAS_KQUEUE
-    std::cout << "  kqueue   - BSD/macOS kqueue (default)\n";
-#endif
-#if BOOST_COROSIO_HAS_SELECT
-    std::cout << "  select   - POSIX select (portable)\n";
-#endif
-    std::cout << "\nDefault backend: " << default_backend_name() << "\n";
-}
 
 // Coroutine that increments a counter
 capy::task<> increment_task(int& counter)
@@ -346,7 +313,7 @@ void print_usage(const char* program_name)
     std::cout << "  concurrent         Concurrent post and run\n";
     std::cout << "  all                Run all benchmarks (default)\n";
     std::cout << "\n";
-    print_available_backends();
+    bench::print_available_backends();
 }
 
 int main(int argc, char* argv[])
@@ -396,7 +363,7 @@ int main(int argc, char* argv[])
         }
         else if (std::strcmp(argv[i], "--list") == 0)
         {
-            print_available_backends();
+            bench::print_available_backends();
             return 0;
         }
         else if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0)
@@ -414,37 +381,12 @@ int main(int argc, char* argv[])
 
     // If no backend specified, use platform default
     if (!backend)
-    {
-        backend = default_backend_name();
-    }
+        backend = bench::default_backend_name();
 
-    // Run benchmarks for the selected backend
-#if BOOST_COROSIO_HAS_EPOLL
-    if (std::strcmp(backend, "epoll") == 0)
-    {
-        run_benchmarks<corosio::epoll_context>("epoll", output_file, bench_filter);
-        return 0;
-    }
-#endif
-
-#if BOOST_COROSIO_HAS_SELECT
-    if (std::strcmp(backend, "select") == 0)
-    {
-        run_benchmarks<corosio::select_context>("select", output_file, bench_filter);
-        return 0;
-    }
-#endif
-
-#if BOOST_COROSIO_HAS_IOCP
-    if (std::strcmp(backend, "iocp") == 0)
-    {
-        run_benchmarks<corosio::iocp_context>("iocp", output_file, bench_filter);
-        return 0;
-    }
-#endif
-
-    // If we get here, the backend is not available
-    std::cerr << "Error: Backend '" << backend << "' is not available on this platform.\n\n";
-    print_available_backends();
-    return 1;
+    // Dispatch to the selected backend using a generic lambda
+    return bench::dispatch_backend(backend,
+        [=]<typename Context>(const char* name)
+        {
+            run_benchmarks<Context>(name, output_file, bench_filter);
+        });
 }

--- a/bench/corosio/socket_latency_bench.cpp
+++ b/bench/corosio/socket_latency_bench.cpp
@@ -16,6 +16,7 @@
 #include <boost/capy/task.hpp>
 #include <boost/capy/write.hpp>
 
+#include <cstring>
 #include <iostream>
 #include <vector>
 
@@ -80,8 +81,12 @@ capy::task<> pingpong_task(
     }
 }
 
-// Benchmark: Ping-pong latency measurement
-void bench_pingpong_latency(std::size_t message_size, int iterations)
+// Measures round-trip latency for a request-response pattern over loopback sockets.
+// Client sends a message, server echoes it back, measuring the complete cycle time.
+// This is the fundamental latency metric for RPC-style protocols. Reports mean,
+// median (p50), and tail latencies (p99, p99.9) which are critical for SLA compliance.
+// Different message sizes reveal fixed overhead vs. size-dependent costs.
+bench::benchmark_result bench_pingpong_latency(std::size_t message_size, int iterations)
 {
     std::cout << "  Message size: " << message_size << " bytes, ";
     std::cout << "Iterations: " << iterations << "\n";
@@ -104,10 +109,20 @@ void bench_pingpong_latency(std::size_t message_size, int iterations)
 
     client.close();
     server.close();
+
+    return bench::benchmark_result("pingpong_" + std::to_string(message_size))
+        .add("message_size", static_cast<double>(message_size))
+        .add("iterations", iterations)
+        .add_latency_stats("rtt", latency_stats);
 }
 
-// Benchmark: Multiple concurrent socket pairs
-void bench_concurrent_latency(int num_pairs, std::size_t message_size, int iterations)
+// Measures latency degradation under concurrent connection load. Multiple socket
+// pairs perform ping-pong simultaneously, revealing how latency increases as the
+// scheduler multiplexes more connections. Critical for capacity planning: shows
+// how many concurrent connections can be sustained before latency becomes
+// unacceptable. A well-designed scheduler should show gradual degradation rather
+// than sudden latency spikes.
+bench::benchmark_result bench_concurrent_latency(int num_pairs, std::size_t message_size, int iterations)
 {
     std::cout << "  Concurrent pairs: " << num_pairs << ", ";
     std::cout << "Message size: " << message_size << " bytes, ";
@@ -170,29 +185,113 @@ void bench_concurrent_latency(int num_pairs, std::size_t message_size, int itera
         c.close();
     for (auto& s : servers)
         s.close();
+
+    return bench::benchmark_result("concurrent_" + std::to_string(num_pairs) + "_pairs")
+        .add("num_pairs", num_pairs)
+        .add("message_size", static_cast<double>(message_size))
+        .add("iterations", iterations)
+        .add("avg_mean_latency_us", total_mean / num_pairs)
+        .add("avg_p99_latency_us", total_p99 / num_pairs);
 }
 
-int main()
+// Run benchmarks
+void run_benchmarks(const char* output_file, const char* bench_filter)
 {
     std::cout << "Boost.Corosio Socket Latency Benchmarks\n";
     std::cout << "=======================================\n";
 
-    bench::print_header("Ping-Pong Round-Trip Latency");
+    bench::result_collector collector("corosio");
+
+    bool run_all = !bench_filter || std::strcmp(bench_filter, "all") == 0;
 
     // Variable message sizes
     std::vector<std::size_t> message_sizes = {1, 64, 1024};
     int iterations = 1000;
 
-    for (auto size : message_sizes)
-        bench_pingpong_latency(size, iterations);
+    if (run_all || std::strcmp(bench_filter, "pingpong") == 0)
+    {
+        bench::print_header("Ping-Pong Round-Trip Latency");
+        for (auto size : message_sizes)
+            collector.add(bench_pingpong_latency(size, iterations));
+    }
 
-    bench::print_header("Concurrent Socket Pairs Latency");
-
-    // Multiple concurrent connections
-    bench_concurrent_latency(1, 64, 1000);
-    bench_concurrent_latency(4, 64, 500);
-    bench_concurrent_latency(16, 64, 250);
+    if (run_all || std::strcmp(bench_filter, "concurrent") == 0)
+    {
+        bench::print_header("Concurrent Socket Pairs Latency");
+        collector.add(bench_concurrent_latency(1, 64, 1000));
+        collector.add(bench_concurrent_latency(4, 64, 500));
+        collector.add(bench_concurrent_latency(16, 64, 250));
+    }
 
     std::cout << "\nBenchmarks complete.\n";
+
+    if (output_file)
+    {
+        if (collector.write_json(output_file))
+            std::cout << "Results written to: " << output_file << "\n";
+        else
+            std::cerr << "Error: Failed to write results to: " << output_file << "\n";
+    }
+}
+
+void print_usage(const char* program_name)
+{
+    std::cout << "Usage: " << program_name << " [OPTIONS]\n\n";
+    std::cout << "Options:\n";
+    std::cout << "  --bench <name>     Run only the specified benchmark\n";
+    std::cout << "  --output <file>    Write JSON results to file\n";
+    std::cout << "  --help             Show this help message\n";
+    std::cout << "\n";
+    std::cout << "Available benchmarks:\n";
+    std::cout << "  pingpong           Ping-pong round-trip latency (various message sizes)\n";
+    std::cout << "  concurrent         Concurrent socket pairs latency\n";
+    std::cout << "  all                Run all benchmarks (default)\n";
+}
+
+int main(int argc, char* argv[])
+{
+    const char* output_file = nullptr;
+    const char* bench_filter = nullptr;
+
+    for (int i = 1; i < argc; ++i)
+    {
+        if (std::strcmp(argv[i], "--bench") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                bench_filter = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --bench requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--output") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                output_file = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --output requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0)
+        {
+            print_usage(argv[0]);
+            return 0;
+        }
+        else
+        {
+            std::cerr << "Unknown option: " << argv[i] << "\n";
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    run_benchmarks(output_file, bench_filter);
     return 0;
 }

--- a/bench/corosio/socket_latency_bench.cpp
+++ b/bench/corosio/socket_latency_bench.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <vector>
 
+#include "../common/backend_selection.hpp"
 #include "../common/benchmark.hpp"
 
 namespace corosio = boost::corosio;
@@ -86,12 +87,13 @@ capy::task<> pingpong_task(
 // This is the fundamental latency metric for RPC-style protocols. Reports mean,
 // median (p50), and tail latencies (p99, p99.9) which are critical for SLA compliance.
 // Different message sizes reveal fixed overhead vs. size-dependent costs.
+template<typename Context>
 bench::benchmark_result bench_pingpong_latency(std::size_t message_size, int iterations)
 {
     std::cout << "  Message size: " << message_size << " bytes, ";
     std::cout << "Iterations: " << iterations << "\n";
 
-    corosio::io_context ioc;
+    Context ioc;
     auto [client, server] = corosio::test::make_socket_pair(ioc);
 
     // Disable Nagle's algorithm for low latency
@@ -122,13 +124,14 @@ bench::benchmark_result bench_pingpong_latency(std::size_t message_size, int ite
 // how many concurrent connections can be sustained before latency becomes
 // unacceptable. A well-designed scheduler should show gradual degradation rather
 // than sudden latency spikes.
+template<typename Context>
 bench::benchmark_result bench_concurrent_latency(int num_pairs, std::size_t message_size, int iterations)
 {
     std::cout << "  Concurrent pairs: " << num_pairs << ", ";
     std::cout << "Message size: " << message_size << " bytes, ";
     std::cout << "Iterations: " << iterations << "\n";
 
-    corosio::io_context ioc;
+    Context ioc;
 
     // Store sockets and stats separately for safe reference passing
     std::vector<corosio::socket> clients;
@@ -194,13 +197,15 @@ bench::benchmark_result bench_concurrent_latency(int num_pairs, std::size_t mess
         .add("avg_p99_latency_us", total_p99 / num_pairs);
 }
 
-// Run benchmarks
-void run_benchmarks(const char* output_file, const char* bench_filter)
+// Run benchmarks for a specific context type
+template<typename Context>
+void run_benchmarks(const char* backend_name, const char* output_file, const char* bench_filter)
 {
     std::cout << "Boost.Corosio Socket Latency Benchmarks\n";
     std::cout << "=======================================\n";
+    std::cout << "Backend: " << backend_name << "\n\n";
 
-    bench::result_collector collector("corosio");
+    bench::result_collector collector(backend_name);
 
     bool run_all = !bench_filter || std::strcmp(bench_filter, "all") == 0;
 
@@ -212,15 +217,15 @@ void run_benchmarks(const char* output_file, const char* bench_filter)
     {
         bench::print_header("Ping-Pong Round-Trip Latency");
         for (auto size : message_sizes)
-            collector.add(bench_pingpong_latency(size, iterations));
+            collector.add(bench_pingpong_latency<Context>(size, iterations));
     }
 
     if (run_all || std::strcmp(bench_filter, "concurrent") == 0)
     {
         bench::print_header("Concurrent Socket Pairs Latency");
-        collector.add(bench_concurrent_latency(1, 64, 1000));
-        collector.add(bench_concurrent_latency(4, 64, 500));
-        collector.add(bench_concurrent_latency(16, 64, 250));
+        collector.add(bench_concurrent_latency<Context>(1, 64, 1000));
+        collector.add(bench_concurrent_latency<Context>(4, 64, 500));
+        collector.add(bench_concurrent_latency<Context>(16, 64, 250));
     }
 
     std::cout << "\nBenchmarks complete.\n";
@@ -238,24 +243,41 @@ void print_usage(const char* program_name)
 {
     std::cout << "Usage: " << program_name << " [OPTIONS]\n\n";
     std::cout << "Options:\n";
+    std::cout << "  --backend <name>   Select I/O backend (default: platform default)\n";
     std::cout << "  --bench <name>     Run only the specified benchmark\n";
     std::cout << "  --output <file>    Write JSON results to file\n";
+    std::cout << "  --list             List available backends\n";
     std::cout << "  --help             Show this help message\n";
     std::cout << "\n";
     std::cout << "Available benchmarks:\n";
     std::cout << "  pingpong           Ping-pong round-trip latency (various message sizes)\n";
     std::cout << "  concurrent         Concurrent socket pairs latency\n";
     std::cout << "  all                Run all benchmarks (default)\n";
+    std::cout << "\n";
+    bench::print_available_backends();
 }
 
 int main(int argc, char* argv[])
 {
+    const char* backend = nullptr;
     const char* output_file = nullptr;
     const char* bench_filter = nullptr;
 
     for (int i = 1; i < argc; ++i)
     {
-        if (std::strcmp(argv[i], "--bench") == 0)
+        if (std::strcmp(argv[i], "--backend") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                backend = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --backend requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--bench") == 0)
         {
             if (i + 1 < argc)
             {
@@ -279,6 +301,11 @@ int main(int argc, char* argv[])
                 return 1;
             }
         }
+        else if (std::strcmp(argv[i], "--list") == 0)
+        {
+            bench::print_available_backends();
+            return 0;
+        }
         else if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0)
         {
             print_usage(argv[0]);
@@ -292,6 +319,14 @@ int main(int argc, char* argv[])
         }
     }
 
-    run_benchmarks(output_file, bench_filter);
-    return 0;
+    // If no backend specified, use platform default
+    if (!backend)
+        backend = bench::default_backend_name();
+
+    // Dispatch to the selected backend using a generic lambda
+    return bench::dispatch_backend(backend,
+        [=]<typename Context>(const char* name)
+        {
+            run_benchmarks<Context>(name, output_file, bench_filter);
+        });
 }

--- a/bench/corosio/socket_throughput_bench.cpp
+++ b/bench/corosio/socket_throughput_bench.cpp
@@ -28,6 +28,7 @@
 #include <sys/socket.h>
 #endif
 
+#include "../common/backend_selection.hpp"
 #include "../common/benchmark.hpp"
 
 namespace corosio = boost::corosio;
@@ -50,12 +51,13 @@ inline void set_nodelay(corosio::socket& s)
 // operations. Runs with different buffer sizes to reveal the optimal chunk size
 // for this platform. Small buffers stress syscall overhead; large buffers approach
 // memory bandwidth limits. Useful for tuning buffer sizes in streaming protocols.
+template<typename Context>
 bench::benchmark_result bench_throughput(std::size_t chunk_size, std::size_t total_bytes)
 {
     std::cout << "  Buffer size: " << chunk_size << " bytes, ";
     std::cout << "Transfer: " << (total_bytes / (1024 * 1024)) << " MB\n";
 
-    corosio::io_context ioc;
+    Context ioc;
     auto [writer, reader] = corosio::test::make_socket_pair(ioc);
 
     // Disable Nagle's algorithm for fair comparison with Asio
@@ -140,12 +142,13 @@ bench::benchmark_result bench_throughput(std::size_t chunk_size, std::size_t tot
 // the scheduler's ability to multiplex I/O efficiently. This pattern is common
 // in protocols like WebSocket or gRPC where data flows in both directions.
 // Combined throughput should ideally approach 2x unidirectional throughput.
+template<typename Context>
 bench::benchmark_result bench_bidirectional_throughput(std::size_t chunk_size, std::size_t total_bytes)
 {
     std::cout << "  Buffer size: " << chunk_size << " bytes, ";
     std::cout << "Transfer: " << (total_bytes / (1024 * 1024)) << " MB each direction\n";
 
-    corosio::io_context ioc;
+    Context ioc;
     auto [sock1, sock2] = corosio::test::make_socket_pair(ioc);
 
     // Disable Nagle's algorithm for fair comparison with Asio
@@ -245,13 +248,15 @@ bench::benchmark_result bench_bidirectional_throughput(std::size_t chunk_size, s
         .add("throughput_bytes_per_sec", throughput);
 }
 
-// Run benchmarks
-void run_benchmarks(const char* output_file, const char* bench_filter)
+// Run benchmarks for a specific context type
+template<typename Context>
+void run_benchmarks(const char* backend_name, const char* output_file, const char* bench_filter)
 {
     std::cout << "Boost.Corosio Socket Throughput Benchmarks\n";
     std::cout << "==========================================\n";
+    std::cout << "Backend: " << backend_name << "\n\n";
 
-    bench::result_collector collector("corosio");
+    bench::result_collector collector(backend_name);
 
     bool run_all = !bench_filter || std::strcmp(bench_filter, "all") == 0;
 
@@ -263,14 +268,14 @@ void run_benchmarks(const char* output_file, const char* bench_filter)
     {
         bench::print_header("Unidirectional Throughput");
         for (auto size : buffer_sizes)
-            collector.add(bench_throughput(size, transfer_size));
+            collector.add(bench_throughput<Context>(size, transfer_size));
     }
 
     if (run_all || std::strcmp(bench_filter, "bidirectional") == 0)
     {
         bench::print_header("Bidirectional Throughput");
         for (auto size : buffer_sizes)
-            collector.add(bench_bidirectional_throughput(size, transfer_size / 2));
+            collector.add(bench_bidirectional_throughput<Context>(size, transfer_size / 2));
     }
 
     std::cout << "\nBenchmarks complete.\n";
@@ -288,24 +293,41 @@ void print_usage(const char* program_name)
 {
     std::cout << "Usage: " << program_name << " [OPTIONS]\n\n";
     std::cout << "Options:\n";
+    std::cout << "  --backend <name>   Select I/O backend (default: platform default)\n";
     std::cout << "  --bench <name>     Run only the specified benchmark\n";
     std::cout << "  --output <file>    Write JSON results to file\n";
+    std::cout << "  --list             List available backends\n";
     std::cout << "  --help             Show this help message\n";
     std::cout << "\n";
     std::cout << "Available benchmarks:\n";
     std::cout << "  unidirectional     Unidirectional throughput (various buffer sizes)\n";
     std::cout << "  bidirectional      Bidirectional throughput (various buffer sizes)\n";
     std::cout << "  all                Run all benchmarks (default)\n";
+    std::cout << "\n";
+    bench::print_available_backends();
 }
 
 int main(int argc, char* argv[])
 {
+    const char* backend = nullptr;
     const char* output_file = nullptr;
     const char* bench_filter = nullptr;
 
     for (int i = 1; i < argc; ++i)
     {
-        if (std::strcmp(argv[i], "--bench") == 0)
+        if (std::strcmp(argv[i], "--backend") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                backend = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --backend requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--bench") == 0)
         {
             if (i + 1 < argc)
             {
@@ -329,6 +351,11 @@ int main(int argc, char* argv[])
                 return 1;
             }
         }
+        else if (std::strcmp(argv[i], "--list") == 0)
+        {
+            bench::print_available_backends();
+            return 0;
+        }
         else if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0)
         {
             print_usage(argv[0]);
@@ -342,6 +369,14 @@ int main(int argc, char* argv[])
         }
     }
 
-    run_benchmarks(output_file, bench_filter);
-    return 0;
+    // If no backend specified, use platform default
+    if (!backend)
+        backend = bench::default_backend_name();
+
+    // Dispatch to the selected backend using a generic lambda
+    return bench::dispatch_backend(backend,
+        [=]<typename Context>(const char* name)
+        {
+            run_benchmarks<Context>(name, output_file, bench_filter);
+        });
 }

--- a/bench/corosio/socket_throughput_bench.cpp
+++ b/bench/corosio/socket_throughput_bench.cpp
@@ -45,8 +45,12 @@ inline void set_nodelay(corosio::socket& s)
 #endif
 }
 
-// Benchmark: Socket throughput with varying buffer sizes
-void bench_throughput(std::size_t chunk_size, std::size_t total_bytes)
+// Measures maximum unidirectional data transfer rate over a loopback socket pair.
+// One coroutine writes while another reads, testing the efficiency of async I/O
+// operations. Runs with different buffer sizes to reveal the optimal chunk size
+// for this platform. Small buffers stress syscall overhead; large buffers approach
+// memory bandwidth limits. Useful for tuning buffer sizes in streaming protocols.
+bench::benchmark_result bench_throughput(std::size_t chunk_size, std::size_t total_bytes)
 {
     std::cout << "  Buffer size: " << chunk_size << " bytes, ";
     std::cout << "Transfer: " << (total_bytes / (1024 * 1024)) << " MB\n";
@@ -121,10 +125,22 @@ void bench_throughput(std::size_t chunk_size, std::size_t total_bytes)
 
     writer.close();
     reader.close();
+
+    return bench::benchmark_result("throughput_" + std::to_string(chunk_size))
+        .add("chunk_size", static_cast<double>(chunk_size))
+        .add("total_bytes", static_cast<double>(total_bytes))
+        .add("bytes_written", static_cast<double>(total_written))
+        .add("bytes_read", static_cast<double>(total_read))
+        .add("elapsed_s", elapsed)
+        .add("throughput_bytes_per_sec", throughput);
 }
 
-// Benchmark: Bidirectional throughput
-void bench_bidirectional_throughput(std::size_t chunk_size, std::size_t total_bytes)
+// Measures full-duplex throughput with both endpoints sending and receiving
+// simultaneously. Four concurrent coroutines (two writers, two readers) stress
+// the scheduler's ability to multiplex I/O efficiently. This pattern is common
+// in protocols like WebSocket or gRPC where data flows in both directions.
+// Combined throughput should ideally approach 2x unidirectional throughput.
+bench::benchmark_result bench_bidirectional_throughput(std::size_t chunk_size, std::size_t total_bytes)
 {
     std::cout << "  Buffer size: " << chunk_size << " bytes, ";
     std::cout << "Transfer: " << (total_bytes / (1024 * 1024)) << " MB each direction\n";
@@ -218,28 +234,114 @@ void bench_bidirectional_throughput(std::size_t chunk_size, std::size_t total_by
 
     sock1.close();
     sock2.close();
+
+    return bench::benchmark_result("bidirectional_" + std::to_string(chunk_size))
+        .add("chunk_size", static_cast<double>(chunk_size))
+        .add("total_bytes_per_direction", static_cast<double>(total_bytes))
+        .add("bytes_direction1", static_cast<double>(read1))
+        .add("bytes_direction2", static_cast<double>(read2))
+        .add("total_transferred", static_cast<double>(total_transferred))
+        .add("elapsed_s", elapsed)
+        .add("throughput_bytes_per_sec", throughput);
 }
 
-int main()
+// Run benchmarks
+void run_benchmarks(const char* output_file, const char* bench_filter)
 {
     std::cout << "Boost.Corosio Socket Throughput Benchmarks\n";
     std::cout << "==========================================\n";
 
-    bench::print_header("Unidirectional Throughput");
+    bench::result_collector collector("corosio");
+
+    bool run_all = !bench_filter || std::strcmp(bench_filter, "all") == 0;
 
     // Variable buffer sizes
     std::vector<std::size_t> buffer_sizes = {1024, 4096, 16384, 65536};
     std::size_t transfer_size = 64 * 1024 * 1024; // 64 MB
 
-    for (auto size : buffer_sizes)
-        bench_throughput(size, transfer_size);
+    if (run_all || std::strcmp(bench_filter, "unidirectional") == 0)
+    {
+        bench::print_header("Unidirectional Throughput");
+        for (auto size : buffer_sizes)
+            collector.add(bench_throughput(size, transfer_size));
+    }
 
-    bench::print_header("Bidirectional Throughput");
-
-    // Bidirectional with different buffer sizes
-    for (auto size : buffer_sizes)
-        bench_bidirectional_throughput(size, transfer_size / 2);
+    if (run_all || std::strcmp(bench_filter, "bidirectional") == 0)
+    {
+        bench::print_header("Bidirectional Throughput");
+        for (auto size : buffer_sizes)
+            collector.add(bench_bidirectional_throughput(size, transfer_size / 2));
+    }
 
     std::cout << "\nBenchmarks complete.\n";
+
+    if (output_file)
+    {
+        if (collector.write_json(output_file))
+            std::cout << "Results written to: " << output_file << "\n";
+        else
+            std::cerr << "Error: Failed to write results to: " << output_file << "\n";
+    }
+}
+
+void print_usage(const char* program_name)
+{
+    std::cout << "Usage: " << program_name << " [OPTIONS]\n\n";
+    std::cout << "Options:\n";
+    std::cout << "  --bench <name>     Run only the specified benchmark\n";
+    std::cout << "  --output <file>    Write JSON results to file\n";
+    std::cout << "  --help             Show this help message\n";
+    std::cout << "\n";
+    std::cout << "Available benchmarks:\n";
+    std::cout << "  unidirectional     Unidirectional throughput (various buffer sizes)\n";
+    std::cout << "  bidirectional      Bidirectional throughput (various buffer sizes)\n";
+    std::cout << "  all                Run all benchmarks (default)\n";
+}
+
+int main(int argc, char* argv[])
+{
+    const char* output_file = nullptr;
+    const char* bench_filter = nullptr;
+
+    for (int i = 1; i < argc; ++i)
+    {
+        if (std::strcmp(argv[i], "--bench") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                bench_filter = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --bench requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--output") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                output_file = argv[++i];
+            }
+            else
+            {
+                std::cerr << "Error: --output requires an argument\n";
+                return 1;
+            }
+        }
+        else if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0)
+        {
+            print_usage(argv[0]);
+            return 0;
+        }
+        else
+        {
+            std::cerr << "Unknown option: " << argv[i] << "\n";
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    run_benchmarks(output_file, bench_filter);
     return 0;
 }

--- a/doc/modules/ROOT/pages/guide/acceptor.adoc
+++ b/doc/modules/ROOT/pages/guide/acceptor.adoc
@@ -289,7 +289,7 @@ capy::task<void> run_server(corosio::io_context& ioc)
     capy::run_async(ioc.get_executor())(accept_loop(ioc, acc));
 
     // Wait for shutdown signal
-    auto [ec, signum] = co_await signals.async_wait();
+    auto [ec, signum] = co_await signals.wait();
     if (!ec)
     {
         std::cout << "Received signal " << signum << ", shutting down\n";

--- a/doc/modules/ROOT/pages/guide/signals.adoc
+++ b/doc/modules/ROOT/pages/guide/signals.adoc
@@ -28,7 +28,7 @@ namespace corosio = boost::corosio;
 ----
 corosio::signal_set signals(ioc, SIGINT, SIGTERM);
 
-auto [ec, signum] = co_await signals.async_wait();
+auto [ec, signum] = co_await signals.wait();
 if (!ec)
     std::cout << "Received signal " << signum << "\n";
 ----
@@ -199,11 +199,11 @@ signals.clear(ec);
 
 == Waiting for Signals
 
-The `async_wait()` operation waits for any signal in the set:
+The `wait()` operation waits for any signal in the set:
 
 [source,cpp]
 ----
-auto [ec, signum] = co_await signals.async_wait();
+auto [ec, signum] = co_await signals.wait();
 
 if (!ec)
 {
@@ -234,7 +234,7 @@ The wait completes with `capy::error::canceled`:
 
 [source,cpp]
 ----
-auto [ec, signum] = co_await signals.async_wait();
+auto [ec, signum] = co_await signals.wait();
 if (ec == capy::error::canceled)
     std::cout << "Wait was cancelled\n";
 ----
@@ -258,7 +258,7 @@ capy::task<void> shutdown_handler(
 {
     corosio::signal_set signals(ioc, SIGINT, SIGTERM);
 
-    auto [ec, signum] = co_await signals.async_wait();
+    auto [ec, signum] = co_await signals.wait();
     if (!ec)
     {
         std::cout << "Shutdown signal received\n";
@@ -280,7 +280,7 @@ capy::task<void> signal_loop(corosio::io_context& ioc)
 
     for (;;)
     {
-        auto [ec, signum] = co_await signals.async_wait();
+        auto [ec, signum] = co_await signals.wait();
         if (ec)
             break;
 
@@ -302,7 +302,7 @@ capy::task<void> config_reloader(
 
     for (;;)
     {
-        auto [ec, signum] = co_await signals.async_wait();
+        auto [ec, signum] = co_await signals.wait();
         if (ec)
             break;
 
@@ -328,7 +328,7 @@ capy::task<void> child_reaper(corosio::io_context& ioc)
 
     for (;;)
     {
-        auto [ec, signum] = co_await signals.async_wait();
+        auto [ec, signum] = co_await signals.wait();
         if (ec)
             break;
 
@@ -365,7 +365,7 @@ IMPORTANT: Source and destination must share the same execution context.
 | NOT safe for concurrent operations
 |===
 
-Don't call `async_wait()`, `add()`, `remove()`, `clear()`, or `cancel()`
+Don't call `wait()`, `add()`, `remove()`, `clear()`, or `cancel()`
 concurrently on the same signal_set.
 
 == Example: Server with Graceful Shutdown
@@ -382,7 +382,7 @@ capy::task<void> run_server(corosio::io_context& ioc)
             -> capy::task<void>
         {
             corosio::signal_set signals(ioc, SIGINT, SIGTERM);
-            co_await signals.async_wait();
+            co_await signals.wait();
             running = false;
             ioc.stop();
         }(ioc, running));

--- a/include/boost/corosio/signal_set.hpp
+++ b/include/boost/corosio/signal_set.hpp
@@ -74,9 +74,15 @@ namespace boost::corosio {
     @par Example
     @code
     signal_set signals(ctx, SIGINT, SIGTERM);
-    auto [ec, signum] = co_await signals.async_wait();
-    if (!ec)
+    auto [ec, signum] = co_await signals.wait();
+    if (ec == capy::cond::canceled)
+    {
+        // Operation was cancelled via stop_token or cancel()
+    }
+    else if (!ec)
+    {
         std::cout << "Received signal " << signum << std::endl;
+    }
     @endcode
 */
 class BOOST_COROSIO_DECL signal_set : public io_object
@@ -323,7 +329,8 @@ public:
 
         This function forces the completion of any pending asynchronous
         wait operations against the signal set. The handler for each
-        cancelled operation will be invoked with capy::error::canceled.
+        cancelled operation will be invoked with an error code that
+        compares equal to `capy::cond::canceled`.
 
         Cancellation does not alter the set of registered signals.
     */
@@ -333,15 +340,33 @@ public:
 
         The operation supports cancellation via `std::stop_token` through
         the affine awaitable protocol. If the associated stop token is
-        triggered, the operation completes immediately with
-        `capy::error::canceled`.
+        triggered, the operation completes immediately with an error
+        that compares equal to `capy::cond::canceled`.
+
+        @par Example
+        @code
+        signal_set signals(ctx, SIGINT);
+        auto [ec, signum] = co_await signals.wait();
+        if (ec == capy::cond::canceled)
+        {
+            // Cancelled via stop_token or cancel()
+            co_return;
+        }
+        if (ec)
+        {
+            // Handle other errors
+            co_return;
+        }
+        // Process signal
+        std::cout << "Received signal " << signum << std::endl;
+        @endcode
 
         @return An awaitable that completes with `io_result<int>`.
             Returns the signal number when a signal is delivered,
-            or an error code on failure including:
-            - capy::error::canceled: Cancelled via stop_token or cancel().
+            or an error code on failure. Compare against error conditions
+            (e.g., `ec == capy::cond::canceled`) rather than error codes.
     */
-    auto async_wait()
+    auto wait()
     {
         return wait_awaitable(*this);
     }

--- a/include/boost/corosio/test/socket_pair.hpp
+++ b/include/boost/corosio/test/socket_pair.hpp
@@ -11,7 +11,7 @@
 #define BOOST_COROSIO_TEST_SOCKET_PAIR_HPP
 
 #include <boost/corosio/detail/config.hpp>
-#include <boost/corosio/io_context.hpp>
+#include <boost/corosio/basic_io_context.hpp>
 #include <boost/corosio/socket.hpp>
 
 #include <utility>
@@ -23,13 +23,13 @@ namespace boost::corosio::test {
     Creates two sockets connected via loopback TCP sockets.
     Data written to one socket can be read from the other.
 
-    @param ioc The io_context for the sockets.
+    @param ctx The I/O context for the sockets.
 
     @return A pair of connected sockets.
 */
 BOOST_COROSIO_DECL
 std::pair<socket, socket>
-make_socket_pair(io_context& ioc);
+make_socket_pair(basic_io_context& ctx);
 
 } // namespace boost::corosio::test
 

--- a/include/boost/corosio/timer.hpp
+++ b/include/boost/corosio/timer.hpp
@@ -143,8 +143,8 @@ public:
 
     /** Cancel any pending asynchronous operations.
 
-        All outstanding operations complete with @ref capy::error::canceled.
-        Check `ec == capy::cond::canceled` for portable comparison.
+        All outstanding operations complete with an error code that
+        compares equal to `capy::cond::canceled`.
     */
     void cancel();
 
@@ -188,14 +188,31 @@ public:
 
         The operation supports cancellation via `std::stop_token` through
         the affine awaitable protocol. If the associated stop token is
-        triggered, the operation completes immediately with
-        `capy::error::canceled`.
+        triggered, the operation completes immediately with an error
+        that compares equal to `capy::cond::canceled`.
+
+        @par Example
+        @code
+        timer t(ctx);
+        t.expires_after(std::chrono::seconds(5));
+        auto [ec] = co_await t.wait();
+        if (ec == capy::cond::canceled)
+        {
+            // Cancelled via stop_token or cancel()
+            co_return;
+        }
+        if (ec)
+        {
+            // Handle other errors
+            co_return;
+        }
+        // Timer expired
+        @endcode
 
         @return An awaitable that completes with `io_result<>`.
             Returns success (default error_code) when the timer expires,
-            or an error code on failure including:
-            - capy::error::canceled: Cancelled via stop_token or cancel().
-                Check `ec == cond::canceled` for portable comparison.
+            or an error code on failure. Compare against error conditions
+            (e.g., `ec == capy::cond::canceled`) rather than error codes.
 
         @par Preconditions
         The timer must have an expiry time set via expires_at() or

--- a/src/corosio/src/detail/epoll/acceptors.cpp
+++ b/src/corosio/src/detail/epoll/acceptors.cpp
@@ -71,6 +71,13 @@ operator()()
                 auto& impl = static_cast<epoll_socket_impl&>(socket_svc->create_impl());
                 impl.set_socket(accepted_fd);
 
+                // Register accepted socket for persistent epoll monitoring
+                impl.desc_data_.fd = accepted_fd;
+                impl.desc_data_.read_op = nullptr;
+                impl.desc_data_.write_op = nullptr;
+                impl.desc_data_.connect_op = nullptr;
+                socket_svc->scheduler().register_descriptor(accepted_fd, &impl.desc_data_);
+
                 sockaddr_in local_addr{};
                 socklen_t local_len = sizeof(local_addr);
                 sockaddr_in remote_addr{};
@@ -144,6 +151,16 @@ epoll_acceptor_impl(epoll_acceptor_service& svc) noexcept
 
 void
 epoll_acceptor_impl::
+update_epoll_events() noexcept
+{
+    std::uint32_t events = 0;
+    if (desc_data_.read_op)  // accept uses EPOLLIN
+        events |= EPOLLIN;
+    svc_.scheduler().update_descriptor_events(fd_, &desc_data_, events);
+}
+
+void
+epoll_acceptor_impl::
 release()
 {
     close_socket();
@@ -185,35 +202,16 @@ accept(
     if (errno == EAGAIN || errno == EWOULDBLOCK)
     {
         svc_.work_started();
-        // Set registering BEFORE register_fd to close the race window where
-        // reactor sees an event before we set registered.
-        op.registered.store(registration_state::registering, std::memory_order_release);
-        svc_.scheduler().register_fd(fd_, &op, EPOLLIN | EPOLLET);
+        op.impl_ptr = shared_from_this();
+        desc_data_.read_op = &op;  // accept uses read_op slot (EPOLLIN)
+        update_epoll_events();
 
-        // Transition to registered. If this fails, reactor or cancel already
-        // claimed the op (state is now unregistered), so we're done. However,
-        // we must still unregister the fd because cancel's unregister_fd may
-        // have run before our register_fd, leaving the fd orphaned in epoll.
-        auto expected = registration_state::registering;
-        if (!op.registered.compare_exchange_strong(
-                expected, registration_state::registered, std::memory_order_acq_rel))
-        {
-            svc_.scheduler().unregister_fd(fd_);
-            return;
-        }
-
-        // If cancelled was set before we registered, handle it now.
         if (op.cancelled.load(std::memory_order_acquire))
         {
-            auto prev = op.registered.exchange(
-                registration_state::unregistered, std::memory_order_acq_rel);
-            if (prev != registration_state::unregistered)
-            {
-                svc_.scheduler().unregister_fd(fd_);
-                op.impl_ptr = shared_from_this();
-                svc_.post(&op);
-                svc_.work_finished();
-            }
+            desc_data_.read_op = nullptr;
+            update_epoll_events();
+            svc_.post(&op);
+            svc_.work_finished();
         }
         return;
     }
@@ -234,13 +232,12 @@ cancel() noexcept
         return;
     }
 
-    auto prev = acc_.registered.exchange(
-        registration_state::unregistered, std::memory_order_acq_rel);
     acc_.request_cancel();
-
-    if (prev != registration_state::unregistered)
+    if (desc_data_.read_op == &acc_)
     {
-        svc_.scheduler().unregister_fd(fd_);
+        desc_data_.read_op = nullptr;
+        if (desc_data_.is_registered)
+            update_epoll_events();
         acc_.impl_ptr = self;
         svc_.post(&acc_);
         svc_.work_finished();
@@ -251,22 +248,16 @@ void
 epoll_acceptor_impl::
 cancel_single_op(epoll_op& op) noexcept
 {
-    // Called from stop_token callback to cancel a specific pending operation.
-    auto prev = op.registered.exchange(
-        registration_state::unregistered, std::memory_order_acq_rel);
     op.request_cancel();
 
-    if (prev != registration_state::unregistered)
+    if (desc_data_.read_op == &op)
     {
-        svc_.scheduler().unregister_fd(fd_);
-
-        // Keep impl alive until op completes
+        desc_data_.read_op = nullptr;
+        if (desc_data_.is_registered)
+            update_epoll_events();
         try {
             op.impl_ptr = shared_from_this();
-        } catch (const std::bad_weak_ptr&) {
-            // Impl is being destroyed, op will be orphaned but that's ok
-        }
-
+        } catch (const std::bad_weak_ptr&) {}
         svc_.post(&op);
         svc_.work_finished();
     }
@@ -280,11 +271,16 @@ close_socket() noexcept
 
     if (fd_ >= 0)
     {
-        // Unconditionally remove from epoll to handle edge cases
-        svc_.scheduler().unregister_fd(fd_);
+        if (desc_data_.registered_events != 0)
+            svc_.scheduler().deregister_descriptor(fd_);
         ::close(fd_);
         fd_ = -1;
     }
+
+    desc_data_.fd = -1;
+    desc_data_.is_registered = false;
+    desc_data_.read_op = nullptr;
+    desc_data_.registered_events = 0;
 
     // Clear cached endpoint
     local_endpoint_ = endpoint{};
@@ -375,6 +371,11 @@ open_acceptor(
     }
 
     epoll_impl->fd_ = fd;
+
+    // Register fd for persistent epoll monitoring (lazy registration)
+    epoll_impl->desc_data_.fd = fd;
+    epoll_impl->desc_data_.read_op = nullptr;
+    scheduler().register_descriptor(fd, &epoll_impl->desc_data_);
 
     // Cache the local endpoint (queries OS for ephemeral port if port was 0)
     sockaddr_in local_addr{};

--- a/src/corosio/src/detail/epoll/acceptors.cpp
+++ b/src/corosio/src/detail/epoll/acceptors.cpp
@@ -24,10 +24,6 @@
 
 namespace boost::corosio::detail {
 
-//------------------------------------------------------------------------------
-// epoll_accept_op::cancel
-//------------------------------------------------------------------------------
-
 void
 epoll_accept_op::
 cancel() noexcept
@@ -37,10 +33,6 @@ cancel() noexcept
     else
         request_cancel();
 }
-
-//------------------------------------------------------------------------------
-// epoll_accept_op::operator() - creates peer socket and caches endpoints
-//------------------------------------------------------------------------------
 
 void
 epoll_accept_op::
@@ -138,10 +130,6 @@ operator()()
     auto prevent_premature_destruction = std::move(impl_ptr);
     saved_ex.dispatch( saved_h ).resume();
 }
-
-//------------------------------------------------------------------------------
-// epoll_acceptor_impl
-//------------------------------------------------------------------------------
 
 epoll_acceptor_impl::
 epoll_acceptor_impl(epoll_acceptor_service& svc) noexcept
@@ -306,10 +294,6 @@ close_socket() noexcept
     // Clear cached endpoint
     local_endpoint_ = endpoint{};
 }
-
-//------------------------------------------------------------------------------
-// epoll_acceptor_service
-//------------------------------------------------------------------------------
 
 epoll_acceptor_service::
 epoll_acceptor_service(capy::execution_context& ctx)

--- a/src/corosio/src/detail/epoll/acceptors.cpp
+++ b/src/corosio/src/detail/epoll/acceptors.cpp
@@ -71,11 +71,11 @@ operator()()
                 auto& impl = static_cast<epoll_socket_impl&>(socket_svc->create_impl());
                 impl.set_socket(accepted_fd);
 
-                // Register accepted socket for persistent epoll monitoring
+                // Register accepted socket with epoll (edge-triggered mode)
                 impl.desc_data_.fd = accepted_fd;
-                impl.desc_data_.read_op = nullptr;
-                impl.desc_data_.write_op = nullptr;
-                impl.desc_data_.connect_op = nullptr;
+                impl.desc_data_.read_op.store(nullptr, std::memory_order_relaxed);
+                impl.desc_data_.write_op.store(nullptr, std::memory_order_relaxed);
+                impl.desc_data_.connect_op.store(nullptr, std::memory_order_relaxed);
                 socket_svc->scheduler().register_descriptor(accepted_fd, &impl.desc_data_);
 
                 sockaddr_in local_addr{};
@@ -153,10 +153,7 @@ void
 epoll_acceptor_impl::
 update_epoll_events() noexcept
 {
-    std::uint32_t events = 0;
-    if (desc_data_.read_op)  // accept uses EPOLLIN
-        events |= EPOLLIN;
-    svc_.scheduler().update_descriptor_events(fd_, &desc_data_, events);
+    svc_.scheduler().update_descriptor_events(fd_, &desc_data_, 0);
 }
 
 void
@@ -192,6 +189,7 @@ accept(
 
     if (accepted >= 0)
     {
+        desc_data_.read_ready.store(false, std::memory_order_relaxed);
         op.accepted_fd = accepted;
         op.complete(0, 0);
         op.impl_ptr = shared_from_this();
@@ -203,15 +201,38 @@ accept(
     {
         svc_.work_started();
         op.impl_ptr = shared_from_this();
-        desc_data_.read_op = &op;  // accept uses read_op slot (EPOLLIN)
-        update_epoll_events();
+
+        desc_data_.read_op.store(&op, std::memory_order_release);
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+
+        if (desc_data_.read_ready.exchange(false, std::memory_order_acquire))
+        {
+            auto* claimed = desc_data_.read_op.exchange(nullptr, std::memory_order_acq_rel);
+            if (claimed)
+            {
+                claimed->perform_io();
+                if (claimed->errn == EAGAIN || claimed->errn == EWOULDBLOCK)
+                {
+                    claimed->errn = 0;
+                    desc_data_.read_op.store(claimed, std::memory_order_release);
+                }
+                else
+                {
+                    svc_.post(claimed);
+                    svc_.work_finished();
+                }
+                return;
+            }
+        }
 
         if (op.cancelled.load(std::memory_order_acquire))
         {
-            desc_data_.read_op = nullptr;
-            update_epoll_events();
-            svc_.post(&op);
-            svc_.work_finished();
+            auto* claimed = desc_data_.read_op.exchange(nullptr, std::memory_order_acq_rel);
+            if (claimed)
+            {
+                svc_.post(claimed);
+                svc_.work_finished();
+            }
         }
         return;
     }
@@ -233,11 +254,10 @@ cancel() noexcept
     }
 
     acc_.request_cancel();
-    if (desc_data_.read_op == &acc_)
+    // Use atomic exchange - only one of cancellation or reactor will succeed
+    auto* claimed = desc_data_.read_op.exchange(nullptr, std::memory_order_acq_rel);
+    if (claimed == &acc_)
     {
-        desc_data_.read_op = nullptr;
-        if (desc_data_.is_registered)
-            update_epoll_events();
         acc_.impl_ptr = self;
         svc_.post(&acc_);
         svc_.work_finished();
@@ -250,11 +270,10 @@ cancel_single_op(epoll_op& op) noexcept
 {
     op.request_cancel();
 
-    if (desc_data_.read_op == &op)
+    // Use atomic exchange - only one of cancellation or reactor will succeed
+    auto* claimed = desc_data_.read_op.exchange(nullptr, std::memory_order_acq_rel);
+    if (claimed == &op)
     {
-        desc_data_.read_op = nullptr;
-        if (desc_data_.is_registered)
-            update_epoll_events();
         try {
             op.impl_ptr = shared_from_this();
         } catch (const std::bad_weak_ptr&) {}
@@ -279,7 +298,9 @@ close_socket() noexcept
 
     desc_data_.fd = -1;
     desc_data_.is_registered = false;
-    desc_data_.read_op = nullptr;
+    desc_data_.read_op.store(nullptr, std::memory_order_relaxed);
+    desc_data_.read_ready.store(false, std::memory_order_relaxed);
+    desc_data_.write_ready.store(false, std::memory_order_relaxed);
     desc_data_.registered_events = 0;
 
     // Clear cached endpoint
@@ -372,9 +393,9 @@ open_acceptor(
 
     epoll_impl->fd_ = fd;
 
-    // Register fd for persistent epoll monitoring (lazy registration)
+    // Register fd with epoll (edge-triggered mode)
     epoll_impl->desc_data_.fd = fd;
-    epoll_impl->desc_data_.read_op = nullptr;
+    epoll_impl->desc_data_.read_op.store(nullptr, std::memory_order_relaxed);
     scheduler().register_descriptor(fd, &epoll_impl->desc_data_);
 
     // Cache the local endpoint (queries OS for ephemeral port if port was 0)

--- a/src/corosio/src/detail/epoll/acceptors.hpp
+++ b/src/corosio/src/detail/epoll/acceptors.hpp
@@ -34,8 +34,7 @@ class epoll_acceptor_service;
 class epoll_acceptor_impl;
 class epoll_socket_service;
 
-//------------------------------------------------------------------------------
-
+/// Acceptor implementation for epoll backend.
 class epoll_acceptor_impl
     : public acceptor::acceptor_impl
     , public std::enable_shared_from_this<epoll_acceptor_impl>
@@ -74,8 +73,6 @@ private:
     int fd_ = -1;
     endpoint local_endpoint_;
 };
-
-//------------------------------------------------------------------------------
 
 /** State for epoll acceptor service. */
 class epoll_acceptor_state

--- a/src/corosio/src/detail/epoll/acceptors.hpp
+++ b/src/corosio/src/detail/epoll/acceptors.hpp
@@ -61,11 +61,13 @@ public:
     void cancel() noexcept override;
     void cancel_single_op(epoll_op& op) noexcept;
     void close_socket() noexcept;
+    void update_epoll_events() noexcept;
     void set_local_endpoint(endpoint ep) noexcept { local_endpoint_ = ep; }
 
     epoll_acceptor_service& service() noexcept { return svc_; }
 
     epoll_accept_op acc_;
+    descriptor_data desc_data_;
 
 private:
     epoll_acceptor_service& svc_;

--- a/src/corosio/src/detail/epoll/op.hpp
+++ b/src/corosio/src/detail/epoll/op.hpp
@@ -251,7 +251,6 @@ struct epoll_op : scheduler_op
     virtual void perform_io() noexcept {}
 };
 
-//------------------------------------------------------------------------------
 
 struct epoll_connect_op : epoll_op
 {
@@ -278,7 +277,6 @@ struct epoll_connect_op : epoll_op
     void cancel() noexcept override;
 };
 
-//------------------------------------------------------------------------------
 
 struct epoll_read_op : epoll_op
 {
@@ -311,7 +309,6 @@ struct epoll_read_op : epoll_op
     void cancel() noexcept override;
 };
 
-//------------------------------------------------------------------------------
 
 struct epoll_write_op : epoll_op
 {
@@ -341,7 +338,6 @@ struct epoll_write_op : epoll_op
     void cancel() noexcept override;
 };
 
-//------------------------------------------------------------------------------
 
 struct epoll_accept_op : epoll_op
 {

--- a/src/corosio/src/detail/epoll/op.hpp
+++ b/src/corosio/src/detail/epoll/op.hpp
@@ -49,63 +49,64 @@
     fixed slots for each operation type (conn_, rd_, wr_), so only one
     operation of each type can be pending per socket at a time.
 
-    Completion vs Cancellation Race
-    -------------------------------
-    The `registered` atomic uses a tri-state (unregistered, registering,
-    registered) to handle two races: (1) between register_fd() and the
-    reactor seeing an event, and (2) between reactor completion and cancel().
-
-    The registering state closes the window where an event could arrive
-    after register_fd() but before the boolean was set. The reactor and
-    cancel() both treat registering the same as registered when claiming.
-
-    Whoever atomically exchanges to unregistered "claims" the operation
-    and is responsible for completing it. The loser sees unregistered and
-    does nothing. The initiating thread uses compare_exchange to transition
-    from registering to registered; if this fails, the reactor or cancel
-    already claimed the op. This avoids double-completion bugs without
-    requiring a mutex in the hot path.
+    Persistent Registration
+    -----------------------
+    File descriptors are registered with epoll once (via descriptor_data) and
+    stay registered until closed. The descriptor_data tracks which operations
+    are pending (read_op, write_op, connect_op). When an event arrives, the
+    reactor dispatches to the appropriate pending operation.
 
     Impl Lifetime Management
     ------------------------
     When cancel() posts an op to the scheduler's ready queue, the socket impl
     might be destroyed before the scheduler processes the op. The `impl_ptr`
     member holds a shared_ptr to the impl, keeping it alive until the op
-    completes. This is set by cancel() in sockets.hpp and cleared in operator()
-    after the coroutine is resumed. Without this, closing a socket with pending
-    operations causes use-after-free.
+    completes. This is set by cancel() and cleared in operator() after the
+    coroutine is resumed.
 
     EOF Detection
     -------------
     For reads, 0 bytes with no error means EOF. But an empty user buffer also
-    returns 0 bytes. The `empty_buffer_read` flag distinguishes these cases
-    so we don't spuriously report EOF when the user just passed an empty buffer.
+    returns 0 bytes. The `empty_buffer_read` flag distinguishes these cases.
 
     SIGPIPE Prevention
     ------------------
     Writes use sendmsg() with MSG_NOSIGNAL instead of writev() to prevent
-    SIGPIPE when the peer has closed. This is the same approach Boost.Asio
-    uses on Linux.
+    SIGPIPE when the peer has closed.
 */
 
 namespace boost::corosio::detail {
 
-// Forward declarations for cancellation support
+// Forward declarations
 class epoll_socket_impl;
 class epoll_acceptor_impl;
+struct epoll_op;
 
-/** Registration state for async operations.
+/** Per-descriptor state for persistent epoll registration.
 
-    Tri-state enum to handle the race between register_fd() and
-    run_reactor() seeing an event. Setting REGISTERING before
-    calling register_fd() ensures events delivered during the
-    registration window are not dropped.
+    Tracks pending operations for a file descriptor. The fd is registered
+    once with epoll and stays registered until closed. Events are dispatched
+    to the appropriate pending operation (EPOLLIN -> read_op, etc.).
 */
-enum class registration_state : std::uint8_t
+struct descriptor_data
 {
-    unregistered,  ///< Not registered with reactor
-    registering,   ///< register_fd() called, not yet confirmed
-    registered     ///< Fully registered, ready for events
+    /// Currently registered events (EPOLLIN, EPOLLOUT, etc.)
+    std::uint32_t registered_events = 0;
+
+    /// Pending read operation (nullptr if none)
+    epoll_op* read_op = nullptr;
+
+    /// Pending write operation (nullptr if none)
+    epoll_op* write_op = nullptr;
+
+    /// Pending connect operation (nullptr if none)
+    epoll_op* connect_op = nullptr;
+
+    /// The file descriptor
+    int fd = -1;
+
+    /// Whether this descriptor is managed by persistent registration
+    bool is_registered = false;
 };
 
 struct epoll_op : scheduler_op
@@ -126,7 +127,6 @@ struct epoll_op : scheduler_op
     std::size_t bytes_transferred = 0;
 
     std::atomic<bool> cancelled{false};
-    std::atomic<registration_state> registered{registration_state::unregistered};
     std::optional<std::stop_callback<canceller>> stop_cb;
 
     // Prevents use-after-free when socket is closed with pending ops.
@@ -149,7 +149,6 @@ struct epoll_op : scheduler_op
         errn = 0;
         bytes_transferred = 0;
         cancelled.store(false, std::memory_order_relaxed);
-        registered.store(registration_state::unregistered, std::memory_order_relaxed);
         impl_ptr.reset();
         socket_impl_ = nullptr;
         acceptor_impl_ = nullptr;

--- a/src/corosio/src/detail/epoll/op.hpp
+++ b/src/corosio/src/detail/epoll/op.hpp
@@ -87,6 +87,11 @@ struct epoll_op;
     Tracks pending operations for a file descriptor. The fd is registered
     once with epoll and stays registered until closed. Events are dispatched
     to the appropriate pending operation (EPOLLIN -> read_op, etc.).
+
+    With edge-triggered epoll (EPOLLET), atomic operations are required to
+    synchronize between operation registration and reactor event delivery.
+    The read_ready/write_ready flags cache edge events that arrived before
+    an operation was registered.
 */
 struct descriptor_data
 {
@@ -94,13 +99,19 @@ struct descriptor_data
     std::uint32_t registered_events = 0;
 
     /// Pending read operation (nullptr if none)
-    epoll_op* read_op = nullptr;
+    std::atomic<epoll_op*> read_op{nullptr};
 
     /// Pending write operation (nullptr if none)
-    epoll_op* write_op = nullptr;
+    std::atomic<epoll_op*> write_op{nullptr};
 
     /// Pending connect operation (nullptr if none)
-    epoll_op* connect_op = nullptr;
+    std::atomic<epoll_op*> connect_op{nullptr};
+
+    /// Cached read readiness (edge event arrived before op registered)
+    std::atomic<bool> read_ready{false};
+
+    /// Cached write readiness (edge event arrived before op registered)
+    std::atomic<bool> write_ready{false};
 
     /// The file descriptor
     int fd = -1;

--- a/src/corosio/src/detail/epoll/scheduler.cpp
+++ b/src/corosio/src/detail/epoll/scheduler.cpp
@@ -141,7 +141,7 @@ epoll_scheduler(
     }
 
     epoll_event ev{};
-    ev.events = EPOLLIN;
+    ev.events = EPOLLIN | EPOLLET;
     ev.data.ptr = nullptr;
     if (::epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, event_fd_, &ev) < 0)
     {
@@ -402,27 +402,26 @@ void
 epoll_scheduler::
 register_descriptor(int fd, descriptor_data* desc) const
 {
-    // Don't register yet - we'll register lazily when first operation waits
-    desc->registered_events = 0;
+    epoll_event ev{};
+    ev.events = EPOLLIN | EPOLLOUT | EPOLLET | EPOLLERR | EPOLLHUP;
+    ev.data.ptr = desc;
+
+    if (::epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, fd, &ev) < 0)
+        detail::throw_system_error(make_err(errno), "epoll_ctl (register)");
+
+    desc->registered_events = ev.events;
     desc->is_registered = true;
     desc->fd = fd;
+    desc->read_ready.store(false, std::memory_order_relaxed);
+    desc->write_ready.store(false, std::memory_order_relaxed);
 }
 
 void
 epoll_scheduler::
-update_descriptor_events(int fd, descriptor_data* desc, std::uint32_t events) const
+update_descriptor_events(int, descriptor_data*, std::uint32_t) const
 {
-    // Always include error/hangup events and oneshot for auto-disarm
-    events |= EPOLLERR | EPOLLHUP | EPOLLONESHOT;
-
-    epoll_event ev{};
-    ev.events = events;
-    ev.data.ptr = desc;
-
-    int op = (desc->registered_events == 0) ? EPOLL_CTL_ADD : EPOLL_CTL_MOD;
-    if (::epoll_ctl(epoll_fd_, op, fd, &ev) < 0)
-        detail::throw_system_error(make_err(errno), "epoll_ctl (persistent)");
-    desc->registered_events = events;
+    // Provides memory fence for operation pointer visibility across threads
+    std::atomic_thread_fence(std::memory_order_seq_cst);
 }
 
 void
@@ -464,8 +463,14 @@ void
 epoll_scheduler::
 interrupt_reactor() const
 {
-    std::uint64_t val = 1;
-    [[maybe_unused]] auto r = ::write(event_fd_, &val, sizeof(val));
+    // Only write if not already armed to avoid redundant writes
+    bool expected = false;
+    if (eventfd_armed_.compare_exchange_strong(expected, true,
+            std::memory_order_release, std::memory_order_relaxed))
+    {
+        std::uint64_t val = 1;
+        [[maybe_unused]] auto r = ::write(event_fd_, &val, sizeof(val));
+    }
 }
 
 void
@@ -474,22 +479,17 @@ wake_one_thread_and_unlock(std::unique_lock<std::mutex>& lock) const
 {
     if (idle_thread_count_ > 0)
     {
-        // Idle worker exists - wake it via condvar
         wakeup_event_.notify_one();
         lock.unlock();
     }
     else if (reactor_running_ && !reactor_interrupted_)
     {
-        // No idle workers but reactor is running - interrupt it so it
-        // can re-check the queue after processing current epoll events
         reactor_interrupted_ = true;
         lock.unlock();
         interrupt_reactor();
     }
     else
     {
-        // No one to wake - either reactor will pick up work when it
-        // re-checks queue, or next thread to call run() will get it
         lock.unlock();
     }
 }
@@ -530,7 +530,6 @@ void
 epoll_scheduler::
 run_reactor(std::unique_lock<std::mutex>& lock)
 {
-    // Calculate timeout considering timers, use 0 if interrupted
     long effective_timeout_us = reactor_interrupted_ ? 0 : calculate_timeout(-1);
 
     int timeout_ms;
@@ -545,17 +544,13 @@ run_reactor(std::unique_lock<std::mutex>& lock)
 
     epoll_event events[128];
     int nfds = ::epoll_wait(epoll_fd_, events, 128, timeout_ms);
-    int saved_errno = errno;  // Save before process_expired() may overwrite
+    int saved_errno = errno;
 
-    // Process timers outside the lock - timer completions may call post()
-    // which needs to acquire the lock
     timer_svc_->process_expired();
 
     if (nfds < 0 && saved_errno != EINTR)
         detail::throw_system_error(make_err(saved_errno), "epoll_wait");
 
-    // Process I/O completions - these become handlers in the queue
-    // Must re-acquire lock before modifying completed_ops_
     lock.lock();
 
     int completions_queued = 0;
@@ -563,9 +558,9 @@ run_reactor(std::unique_lock<std::mutex>& lock)
     {
         if (events[i].data.ptr == nullptr)
         {
-            // eventfd interrupt - just drain it
             std::uint64_t val;
             [[maybe_unused]] auto r = ::read(event_fd_, &val, sizeof(val));
+            eventfd_armed_.store(false, std::memory_order_relaxed);
             continue;
         }
 
@@ -582,76 +577,129 @@ run_reactor(std::unique_lock<std::mutex>& lock)
                 err = EIO;
         }
 
-        // Handle read events (including accept)
-        if ((ev & EPOLLIN) && desc->read_op)
+        if (ev & EPOLLIN)
         {
-            auto* op = desc->read_op;
-            desc->read_op = nullptr;
-            if (err)
-                op->complete(err, 0);
+            auto* op = desc->read_op.exchange(nullptr, std::memory_order_acq_rel);
+            if (op)
+            {
+                if (err)
+                {
+                    op->complete(err, 0);
+                    completed_ops_.push(op);
+                    ++completions_queued;
+                }
+                else
+                {
+                    op->perform_io();
+                    if (op->errn == EAGAIN || op->errn == EWOULDBLOCK)
+                    {
+                        op->errn = 0;
+                        desc->read_op.store(op, std::memory_order_release);
+                    }
+                    else
+                    {
+                        completed_ops_.push(op);
+                        ++completions_queued;
+                    }
+                }
+            }
             else
-                op->perform_io();
-            completed_ops_.push(op);
-            ++completions_queued;
+            {
+                desc->read_ready.store(true, std::memory_order_release);
+            }
         }
 
-        // Handle write events
-        if ((ev & EPOLLOUT) && desc->write_op)
+        if (ev & EPOLLOUT)
         {
-            auto* op = desc->write_op;
-            desc->write_op = nullptr;
-            if (err)
-                op->complete(err, 0);
-            else
-                op->perform_io();
-            completed_ops_.push(op);
-            ++completions_queued;
+            bool any_completed = false;
+
+            // Connect uses write readiness - try it first
+            auto* conn_op = desc->connect_op.exchange(nullptr, std::memory_order_acq_rel);
+            if (conn_op)
+            {
+                if (err)
+                {
+                    conn_op->complete(err, 0);
+                    completed_ops_.push(conn_op);
+                    ++completions_queued;
+                    any_completed = true;
+                }
+                else
+                {
+                    conn_op->perform_io();
+                    if (conn_op->errn == EAGAIN || conn_op->errn == EWOULDBLOCK)
+                    {
+                        conn_op->errn = 0;
+                        desc->connect_op.store(conn_op, std::memory_order_release);
+                    }
+                    else
+                    {
+                        completed_ops_.push(conn_op);
+                        ++completions_queued;
+                        any_completed = true;
+                    }
+                }
+            }
+
+            auto* write_op = desc->write_op.exchange(nullptr, std::memory_order_acq_rel);
+            if (write_op)
+            {
+                if (err)
+                {
+                    write_op->complete(err, 0);
+                    completed_ops_.push(write_op);
+                    ++completions_queued;
+                    any_completed = true;
+                }
+                else
+                {
+                    write_op->perform_io();
+                    if (write_op->errn == EAGAIN || write_op->errn == EWOULDBLOCK)
+                    {
+                        write_op->errn = 0;
+                        desc->write_op.store(write_op, std::memory_order_release);
+                    }
+                    else
+                    {
+                        completed_ops_.push(write_op);
+                        ++completions_queued;
+                        any_completed = true;
+                    }
+                }
+            }
+
+            if (!conn_op && !write_op)
+                desc->write_ready.store(true, std::memory_order_release);
         }
 
-        // Handle connect events
-        if ((ev & EPOLLOUT) && desc->connect_op)
-        {
-            auto* op = desc->connect_op;
-            desc->connect_op = nullptr;
-            if (err)
-                op->complete(err, 0);
-            else
-                op->perform_io();
-            completed_ops_.push(op);
-            ++completions_queued;
-        }
-
-        // Handle errors for pending ops even if no specific event
         if (err)
         {
-            if (desc->read_op)
+            auto* read_op = desc->read_op.exchange(nullptr, std::memory_order_acq_rel);
+            if (read_op)
             {
-                auto* op = desc->read_op;
-                desc->read_op = nullptr;
-                op->complete(err, 0);
-                completed_ops_.push(op);
+                read_op->complete(err, 0);
+                completed_ops_.push(read_op);
                 ++completions_queued;
             }
-            if (desc->write_op)
+
+            auto* write_op = desc->write_op.exchange(nullptr, std::memory_order_acq_rel);
+            if (write_op)
             {
-                auto* op = desc->write_op;
-                desc->write_op = nullptr;
-                op->complete(err, 0);
-                completed_ops_.push(op);
+                write_op->complete(err, 0);
+                completed_ops_.push(write_op);
                 ++completions_queued;
             }
-            if (desc->connect_op)
+
+            auto* conn_op = desc->connect_op.exchange(nullptr, std::memory_order_acq_rel);
+            if (conn_op)
             {
-                auto* op = desc->connect_op;
-                desc->connect_op = nullptr;
-                op->complete(err, 0);
-                completed_ops_.push(op);
+                conn_op->complete(err, 0);
+                completed_ops_.push(conn_op);
                 ++completions_queued;
             }
         }
     }
 
-    // Wake idle workers if we queued I/O completions
     if (completions_queued > 0)
     {
         if (completions_queued >= idle_thread_count_)
@@ -659,7 +707,6 @@ run_reactor(std::unique_lock<std::mutex>& lock)
         else
             for (int i = 0; i < completions_queued; ++i)
                 wakeup_event_.notify_one();
-
     }
 }
 
@@ -679,26 +726,30 @@ do_one(long timeout_us)
         if (stopped_.load(std::memory_order_acquire))
             return 0;
 
-        // Try to get a handler from the queue
+        // Prevents timer starvation when handlers are continuously posted
+        if (timer_svc_->nearest_expiry() <= std::chrono::steady_clock::now())
+        {
+            lock.unlock();
+            timer_svc_->process_expired();
+            lock.lock();
+        }
+
         scheduler_op* op = completed_ops_.pop();
 
         if (op != nullptr)
         {
-            // Got a handler - execute it
             lock.unlock();
             work_guard g{this};
             (*op)();
             return 1;
         }
 
-        // Queue is empty - check if we should become reactor or wait
         if (outstanding_work_.load(std::memory_order_acquire) == 0)
             return 0;
 
         if (timeout_us == 0)
-            return 0;  // Non-blocking poll
+            return 0;
 
-        // Check if timeout has expired (for positive timeout_us)
         long remaining_us = timeout_us;
         if (timeout_us > 0)
         {
@@ -711,19 +762,15 @@ do_one(long timeout_us)
 
         if (!reactor_running_)
         {
-            // No reactor running and queue empty - become the reactor
             reactor_running_ = true;
-            // If handlers arrived since our last check, don't block in epoll_wait
             reactor_interrupted_ = !completed_ops_.empty();
 
             run_reactor(lock);
 
             reactor_running_ = false;
-            // Loop back to check for handlers that reactor may have queued
             continue;
         }
 
-        // Reactor is running in another thread - wait for work on condvar
         ++idle_thread_count_;
         if (timeout_us < 0)
             wakeup_event_.wait(lock);

--- a/src/corosio/src/detail/epoll/scheduler.cpp
+++ b/src/corosio/src/detail/epoll/scheduler.cpp
@@ -400,29 +400,34 @@ poll_one()
 
 void
 epoll_scheduler::
-register_fd(int fd, epoll_op* op, std::uint32_t events) const
+register_descriptor(int fd, descriptor_data* desc) const
 {
-    epoll_event ev{};
-    ev.events = events;
-    ev.data.ptr = op;
-    if (::epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, fd, &ev) < 0)
-        detail::throw_system_error(make_err(errno), "epoll_ctl ADD");
+    // Don't register yet - we'll register lazily when first operation waits
+    desc->registered_events = 0;
+    desc->is_registered = true;
+    desc->fd = fd;
 }
 
 void
 epoll_scheduler::
-modify_fd(int fd, epoll_op* op, std::uint32_t events) const
+update_descriptor_events(int fd, descriptor_data* desc, std::uint32_t events) const
 {
+    // Always include error/hangup events and oneshot for auto-disarm
+    events |= EPOLLERR | EPOLLHUP | EPOLLONESHOT;
+
     epoll_event ev{};
     ev.events = events;
-    ev.data.ptr = op;
-    if (::epoll_ctl(epoll_fd_, EPOLL_CTL_MOD, fd, &ev) < 0)
-        detail::throw_system_error(make_err(errno), "epoll_ctl MOD");
+    ev.data.ptr = desc;
+
+    int op = (desc->registered_events == 0) ? EPOLL_CTL_ADD : EPOLL_CTL_MOD;
+    if (::epoll_ctl(epoll_fd_, op, fd, &ev) < 0)
+        detail::throw_system_error(make_err(errno), "epoll_ctl (persistent)");
+    desc->registered_events = events;
 }
 
 void
 epoll_scheduler::
-unregister_fd(int fd) const
+deregister_descriptor(int fd) const
 {
     ::epoll_ctl(epoll_fd_, EPOLL_CTL_DEL, fd, nullptr);
 }
@@ -538,8 +543,8 @@ run_reactor(std::unique_lock<std::mutex>& lock)
 
     lock.unlock();
 
-    epoll_event events[64];
-    int nfds = ::epoll_wait(epoll_fd_, events, 64, timeout_ms);
+    epoll_event events[128];
+    int nfds = ::epoll_wait(epoll_fd_, events, 128, timeout_ms);
     int saved_errno = errno;  // Save before process_expired() may overwrite
 
     // Process timers outside the lock - timer completions may call post()
@@ -564,35 +569,86 @@ run_reactor(std::unique_lock<std::mutex>& lock)
             continue;
         }
 
-        auto* op = static_cast<epoll_op*>(events[i].data.ptr);
+        auto* desc = static_cast<descriptor_data*>(events[i].data.ptr);
+        std::uint32_t ev = events[i].events;
+        int err = 0;
 
-        // Claim the op by exchanging to unregistered. Both registering and
-        // registered states mean the op is ours to complete. If already
-        // unregistered, cancel or another thread handled it.
-        auto prev = op->registered.exchange(
-            registration_state::unregistered, std::memory_order_acq_rel);
-        if (prev == registration_state::unregistered)
-            continue;
-
-        unregister_fd(op->fd);
-
-        if (events[i].events & (EPOLLERR | EPOLLHUP))
+        if (ev & (EPOLLERR | EPOLLHUP))
         {
-            int errn = 0;
-            socklen_t len = sizeof(errn);
-            if (::getsockopt(op->fd, SOL_SOCKET, SO_ERROR, &errn, &len) < 0)
-                errn = errno;
-            if (errn == 0)
-                errn = EIO;
-            op->complete(errn, 0);
-        }
-        else
-        {
-            op->perform_io();
+            socklen_t len = sizeof(err);
+            if (::getsockopt(desc->fd, SOL_SOCKET, SO_ERROR, &err, &len) < 0)
+                err = errno;
+            if (err == 0)
+                err = EIO;
         }
 
-        completed_ops_.push(op);
-        ++completions_queued;
+        // Handle read events (including accept)
+        if ((ev & EPOLLIN) && desc->read_op)
+        {
+            auto* op = desc->read_op;
+            desc->read_op = nullptr;
+            if (err)
+                op->complete(err, 0);
+            else
+                op->perform_io();
+            completed_ops_.push(op);
+            ++completions_queued;
+        }
+
+        // Handle write events
+        if ((ev & EPOLLOUT) && desc->write_op)
+        {
+            auto* op = desc->write_op;
+            desc->write_op = nullptr;
+            if (err)
+                op->complete(err, 0);
+            else
+                op->perform_io();
+            completed_ops_.push(op);
+            ++completions_queued;
+        }
+
+        // Handle connect events
+        if ((ev & EPOLLOUT) && desc->connect_op)
+        {
+            auto* op = desc->connect_op;
+            desc->connect_op = nullptr;
+            if (err)
+                op->complete(err, 0);
+            else
+                op->perform_io();
+            completed_ops_.push(op);
+            ++completions_queued;
+        }
+
+        // Handle errors for pending ops even if no specific event
+        if (err)
+        {
+            if (desc->read_op)
+            {
+                auto* op = desc->read_op;
+                desc->read_op = nullptr;
+                op->complete(err, 0);
+                completed_ops_.push(op);
+                ++completions_queued;
+            }
+            if (desc->write_op)
+            {
+                auto* op = desc->write_op;
+                desc->write_op = nullptr;
+                op->complete(err, 0);
+                completed_ops_.push(op);
+                ++completions_queued;
+            }
+            if (desc->connect_op)
+            {
+                auto* op = desc->connect_op;
+                desc->connect_op = nullptr;
+                op->complete(err, 0);
+                completed_ops_.push(op);
+                ++completions_queued;
+            }
+        }
     }
 
     // Wake idle workers if we queued I/O completions
@@ -603,6 +659,7 @@ run_reactor(std::unique_lock<std::mutex>& lock)
         else
             for (int i = 0; i < completions_queued; ++i)
                 wakeup_event_.notify_one();
+
     }
 }
 
@@ -656,7 +713,8 @@ do_one(long timeout_us)
         {
             // No reactor running and queue empty - become the reactor
             reactor_running_ = true;
-            reactor_interrupted_ = false;
+            // If handlers arrived since our last check, don't block in epoll_wait
+            reactor_interrupted_ = !completed_ops_.empty();
 
             run_reactor(lock);
 

--- a/src/corosio/src/detail/epoll/scheduler.hpp
+++ b/src/corosio/src/detail/epoll/scheduler.hpp
@@ -31,6 +31,7 @@
 namespace boost::corosio::detail {
 
 struct epoll_op;
+struct descriptor_data;
 
 /** Linux scheduler using epoll for I/O multiplexing.
 
@@ -98,27 +99,30 @@ public:
     */
     int epoll_fd() const noexcept { return epoll_fd_; }
 
-    /** Register a file descriptor with epoll.
+    /** Register a descriptor for persistent monitoring.
+
+        The fd is registered once and stays registered until explicitly
+        deregistered. Events are dispatched via descriptor_data which
+        tracks pending read/write/connect operations.
 
         @param fd The file descriptor to register.
-        @param op The operation associated with this fd.
-        @param events The epoll events to monitor (EPOLLIN, EPOLLOUT, etc.).
+        @param desc Pointer to descriptor data (stored in epoll_event.data.ptr).
     */
-    void register_fd(int fd, epoll_op* op, std::uint32_t events) const;
+    void register_descriptor(int fd, descriptor_data* desc) const;
 
-    /** Modify epoll registration for a file descriptor.
+    /** Update events for a persistently registered descriptor.
 
-        @param fd The file descriptor to modify.
-        @param op The operation associated with this fd.
-        @param events The new epoll events to monitor.
+        @param fd The file descriptor.
+        @param desc Pointer to descriptor data.
+        @param events The new events to monitor.
     */
-    void modify_fd(int fd, epoll_op* op, std::uint32_t events) const;
+    void update_descriptor_events(int fd, descriptor_data* desc, std::uint32_t events) const;
 
-    /** Unregister a file descriptor from epoll.
+    /** Deregister a persistently registered descriptor.
 
-        @param fd The file descriptor to unregister.
+        @param fd The file descriptor to deregister.
     */
-    void unregister_fd(int fd) const;
+    void deregister_descriptor(int fd) const;
 
     /** For use by I/O operations to track pending work. */
     void work_started() const noexcept override;

--- a/src/corosio/src/detail/epoll/scheduler.hpp
+++ b/src/corosio/src/detail/epoll/scheduler.hpp
@@ -151,6 +151,9 @@ private:
     mutable bool reactor_running_ = false;
     mutable bool reactor_interrupted_ = false;
     mutable int idle_thread_count_ = 0;
+
+    // Edge-triggered eventfd state
+    mutable std::atomic<bool> eventfd_armed_{false};
 };
 
 } // namespace boost::corosio::detail

--- a/src/corosio/src/detail/epoll/sockets.cpp
+++ b/src/corosio/src/detail/epoll/sockets.cpp
@@ -132,12 +132,8 @@ void
 epoll_socket_impl::
 update_epoll_events() noexcept
 {
-    std::uint32_t events = 0;
-    if (desc_data_.read_op)
-        events |= EPOLLIN;
-    if (desc_data_.write_op || desc_data_.connect_op)
-        events |= EPOLLOUT;
-    svc_.scheduler().update_descriptor_events(fd_, &desc_data_, events);
+    // With EPOLLET, update_descriptor_events just provides a memory fence
+    svc_.scheduler().update_descriptor_events(fd_, &desc_data_, 0);
 }
 
 void
@@ -189,15 +185,38 @@ connect(
     {
         svc_.work_started();
         op.impl_ptr = shared_from_this();
-        desc_data_.connect_op = &op;
-        update_epoll_events();
+
+        desc_data_.connect_op.store(&op, std::memory_order_release);
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+
+        if (desc_data_.write_ready.exchange(false, std::memory_order_acquire))
+        {
+            auto* claimed = desc_data_.connect_op.exchange(nullptr, std::memory_order_acq_rel);
+            if (claimed)
+            {
+                claimed->perform_io();
+                if (claimed->errn == EAGAIN || claimed->errn == EWOULDBLOCK)
+                {
+                    claimed->errn = 0;
+                    desc_data_.connect_op.store(claimed, std::memory_order_release);
+                }
+                else
+                {
+                    svc_.post(claimed);
+                    svc_.work_finished();
+                }
+                return;
+            }
+        }
 
         if (op.cancelled.load(std::memory_order_acquire))
         {
-            desc_data_.connect_op = nullptr;
-            update_epoll_events();
-            svc_.post(&op);
-            svc_.work_finished();
+            auto* claimed = desc_data_.connect_op.exchange(nullptr, std::memory_order_acq_rel);
+            if (claimed)
+            {
+                svc_.post(claimed);
+                svc_.work_finished();
+            }
         }
         return;
     }
@@ -248,6 +267,7 @@ read_some(
 
     if (n > 0)
     {
+        desc_data_.read_ready.store(false, std::memory_order_relaxed);
         op.complete(0, static_cast<std::size_t>(n));
         op.impl_ptr = shared_from_this();
         svc_.post(&op);
@@ -256,6 +276,7 @@ read_some(
 
     if (n == 0)
     {
+        desc_data_.read_ready.store(false, std::memory_order_relaxed);
         op.complete(0, 0);
         op.impl_ptr = shared_from_this();
         svc_.post(&op);
@@ -266,15 +287,38 @@ read_some(
     {
         svc_.work_started();
         op.impl_ptr = shared_from_this();
-        desc_data_.read_op = &op;
-        update_epoll_events();
+
+        desc_data_.read_op.store(&op, std::memory_order_release);
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+
+        if (desc_data_.read_ready.exchange(false, std::memory_order_acquire))
+        {
+            auto* claimed = desc_data_.read_op.exchange(nullptr, std::memory_order_acq_rel);
+            if (claimed)
+            {
+                claimed->perform_io();
+                if (claimed->errn == EAGAIN || claimed->errn == EWOULDBLOCK)
+                {
+                    claimed->errn = 0;
+                    desc_data_.read_op.store(claimed, std::memory_order_release);
+                }
+                else
+                {
+                    svc_.post(claimed);
+                    svc_.work_finished();
+                }
+                return;
+            }
+        }
 
         if (op.cancelled.load(std::memory_order_acquire))
         {
-            desc_data_.read_op = nullptr;
-            update_epoll_events();
-            svc_.post(&op);
-            svc_.work_finished();
+            auto* claimed = desc_data_.read_op.exchange(nullptr, std::memory_order_acq_rel);
+            if (claimed)
+            {
+                svc_.post(claimed);
+                svc_.work_finished();
+            }
         }
         return;
     }
@@ -328,6 +372,7 @@ write_some(
 
     if (n > 0)
     {
+        desc_data_.write_ready.store(false, std::memory_order_relaxed);
         op.complete(0, static_cast<std::size_t>(n));
         op.impl_ptr = shared_from_this();
         svc_.post(&op);
@@ -338,15 +383,38 @@ write_some(
     {
         svc_.work_started();
         op.impl_ptr = shared_from_this();
-        desc_data_.write_op = &op;
-        update_epoll_events();
+
+        desc_data_.write_op.store(&op, std::memory_order_release);
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+
+        if (desc_data_.write_ready.exchange(false, std::memory_order_acquire))
+        {
+            auto* claimed = desc_data_.write_op.exchange(nullptr, std::memory_order_acq_rel);
+            if (claimed)
+            {
+                claimed->perform_io();
+                if (claimed->errn == EAGAIN || claimed->errn == EWOULDBLOCK)
+                {
+                    claimed->errn = 0;
+                    desc_data_.write_op.store(claimed, std::memory_order_release);
+                }
+                else
+                {
+                    svc_.post(claimed);
+                    svc_.work_finished();
+                }
+                return;
+            }
+        }
 
         if (op.cancelled.load(std::memory_order_acquire))
         {
-            desc_data_.write_op = nullptr;
-            update_epoll_events();
-            svc_.post(&op);
-            svc_.work_finished();
+            auto* claimed = desc_data_.write_op.exchange(nullptr, std::memory_order_acq_rel);
+            if (claimed)
+            {
+                svc_.post(claimed);
+                svc_.work_finished();
+            }
         }
         return;
     }
@@ -516,25 +584,22 @@ cancel() noexcept
         return;
     }
 
-    bool any_cancelled = false;
-    auto cancel_op = [this, &self, &any_cancelled](epoll_op& op, epoll_op*& desc_op_ptr) {
+    // Use atomic exchange to claim operations - only one of cancellation
+    // or reactor will succeed
+    auto cancel_atomic_op = [this, &self](epoll_op& op, std::atomic<epoll_op*>& desc_op_ptr) {
         op.request_cancel();
-        if (desc_op_ptr == &op)
+        auto* claimed = desc_op_ptr.exchange(nullptr, std::memory_order_acq_rel);
+        if (claimed == &op)
         {
-            desc_op_ptr = nullptr;
-            any_cancelled = true;
             op.impl_ptr = self;
             svc_.post(&op);
             svc_.work_finished();
         }
     };
 
-    cancel_op(conn_, desc_data_.connect_op);
-    cancel_op(rd_, desc_data_.read_op);
-    cancel_op(wr_, desc_data_.write_op);
-
-    if (any_cancelled && desc_data_.is_registered)
-        update_epoll_events();
+    cancel_atomic_op(conn_, desc_data_.connect_op);
+    cancel_atomic_op(rd_, desc_data_.read_op);
+    cancel_atomic_op(wr_, desc_data_.write_op);
 }
 
 void
@@ -543,21 +608,23 @@ cancel_single_op(epoll_op& op) noexcept
 {
     op.request_cancel();
 
-    epoll_op** desc_op_ptr = nullptr;
+    std::atomic<epoll_op*>* desc_op_ptr = nullptr;
     if (&op == &conn_) desc_op_ptr = &desc_data_.connect_op;
     else if (&op == &rd_) desc_op_ptr = &desc_data_.read_op;
     else if (&op == &wr_) desc_op_ptr = &desc_data_.write_op;
 
-    if (desc_op_ptr && *desc_op_ptr == &op)
+    if (desc_op_ptr)
     {
-        *desc_op_ptr = nullptr;
-        if (desc_data_.is_registered)
-            update_epoll_events();
-        try {
-            op.impl_ptr = shared_from_this();
-        } catch (const std::bad_weak_ptr&) {}
-        svc_.post(&op);
-        svc_.work_finished();
+        // Use atomic exchange - only one of cancellation or reactor will succeed
+        auto* claimed = desc_op_ptr->exchange(nullptr, std::memory_order_acq_rel);
+        if (claimed == &op)
+        {
+            try {
+                op.impl_ptr = shared_from_this();
+            } catch (const std::bad_weak_ptr&) {}
+            svc_.post(&op);
+            svc_.work_finished();
+        }
     }
 }
 
@@ -569,7 +636,6 @@ close_socket() noexcept
 
     if (fd_ >= 0)
     {
-        // Only deregister if we actually added to epoll (lazy registration)
         if (desc_data_.registered_events != 0)
             svc_.scheduler().deregister_descriptor(fd_);
         ::close(fd_);
@@ -578,9 +644,11 @@ close_socket() noexcept
 
     desc_data_.fd = -1;
     desc_data_.is_registered = false;
-    desc_data_.read_op = nullptr;
-    desc_data_.write_op = nullptr;
-    desc_data_.connect_op = nullptr;
+    desc_data_.read_op.store(nullptr, std::memory_order_relaxed);
+    desc_data_.write_op.store(nullptr, std::memory_order_relaxed);
+    desc_data_.connect_op.store(nullptr, std::memory_order_relaxed);
+    desc_data_.read_ready.store(false, std::memory_order_relaxed);
+    desc_data_.write_ready.store(false, std::memory_order_relaxed);
     desc_data_.registered_events = 0;
 
     local_endpoint_ = endpoint{};
@@ -653,11 +721,11 @@ open_socket(socket::socket_impl& impl)
 
     epoll_impl->fd_ = fd;
 
-    // Register fd persistently with epoll (prototype for performance)
+    // Register fd with epoll (edge-triggered mode)
     epoll_impl->desc_data_.fd = fd;
-    epoll_impl->desc_data_.read_op = nullptr;
-    epoll_impl->desc_data_.write_op = nullptr;
-    epoll_impl->desc_data_.connect_op = nullptr;
+    epoll_impl->desc_data_.read_op.store(nullptr, std::memory_order_relaxed);
+    epoll_impl->desc_data_.write_op.store(nullptr, std::memory_order_relaxed);
+    epoll_impl->desc_data_.connect_op.store(nullptr, std::memory_order_relaxed);
     scheduler().register_descriptor(fd, &epoll_impl->desc_data_);
 
     return {};

--- a/src/corosio/src/detail/epoll/sockets.cpp
+++ b/src/corosio/src/detail/epoll/sockets.cpp
@@ -130,6 +130,18 @@ epoll_socket_impl(epoll_socket_service& svc) noexcept
 
 void
 epoll_socket_impl::
+update_epoll_events() noexcept
+{
+    std::uint32_t events = 0;
+    if (desc_data_.read_op)
+        events |= EPOLLIN;
+    if (desc_data_.write_op || desc_data_.connect_op)
+        events |= EPOLLOUT;
+    svc_.scheduler().update_descriptor_events(fd_, &desc_data_, events);
+}
+
+void
+epoll_socket_impl::
 release()
 {
     close_socket();
@@ -176,36 +188,16 @@ connect(
     if (errno == EINPROGRESS)
     {
         svc_.work_started();
-        // Set registering BEFORE register_fd to close the race window where
-        // reactor sees an event before we set registered. The reactor treats
-        // registering the same as registered when claiming the op.
-        op.registered.store(registration_state::registering, std::memory_order_release);
-        svc_.scheduler().register_fd(fd_, &op, EPOLLOUT | EPOLLET);
+        op.impl_ptr = shared_from_this();
+        desc_data_.connect_op = &op;
+        update_epoll_events();
 
-        // Transition to registered. If this fails, reactor or cancel already
-        // claimed the op (state is now unregistered), so we're done. However,
-        // we must still unregister the fd because cancel's unregister_fd may
-        // have run before our register_fd, leaving the fd orphaned in epoll.
-        auto expected = registration_state::registering;
-        if (!op.registered.compare_exchange_strong(
-                expected, registration_state::registered, std::memory_order_acq_rel))
-        {
-            svc_.scheduler().unregister_fd(fd_);
-            return;
-        }
-
-        // If cancelled was set before we registered, handle it now.
         if (op.cancelled.load(std::memory_order_acquire))
         {
-            auto prev = op.registered.exchange(
-                registration_state::unregistered, std::memory_order_acq_rel);
-            if (prev != registration_state::unregistered)
-            {
-                svc_.scheduler().unregister_fd(fd_);
-                op.impl_ptr = shared_from_this();
-                svc_.post(&op);
-                svc_.work_finished();
-            }
+            desc_data_.connect_op = nullptr;
+            update_epoll_events();
+            svc_.post(&op);
+            svc_.work_finished();
         }
         return;
     }
@@ -273,35 +265,16 @@ read_some(
     if (errno == EAGAIN || errno == EWOULDBLOCK)
     {
         svc_.work_started();
-        // Set registering BEFORE register_fd to close the race window where
-        // reactor sees an event before we set registered.
-        op.registered.store(registration_state::registering, std::memory_order_release);
-        svc_.scheduler().register_fd(fd_, &op, EPOLLIN | EPOLLET);
+        op.impl_ptr = shared_from_this();
+        desc_data_.read_op = &op;
+        update_epoll_events();
 
-        // Transition to registered. If this fails, reactor or cancel already
-        // claimed the op (state is now unregistered), so we're done. However,
-        // we must still unregister the fd because cancel's unregister_fd may
-        // have run before our register_fd, leaving the fd orphaned in epoll.
-        auto expected = registration_state::registering;
-        if (!op.registered.compare_exchange_strong(
-                expected, registration_state::registered, std::memory_order_acq_rel))
-        {
-            svc_.scheduler().unregister_fd(fd_);
-            return;
-        }
-
-        // If cancelled was set before we registered, handle it now.
         if (op.cancelled.load(std::memory_order_acquire))
         {
-            auto prev = op.registered.exchange(
-                registration_state::unregistered, std::memory_order_acq_rel);
-            if (prev != registration_state::unregistered)
-            {
-                svc_.scheduler().unregister_fd(fd_);
-                op.impl_ptr = shared_from_this();
-                svc_.post(&op);
-                svc_.work_finished();
-            }
+            desc_data_.read_op = nullptr;
+            update_epoll_events();
+            svc_.post(&op);
+            svc_.work_finished();
         }
         return;
     }
@@ -364,35 +337,16 @@ write_some(
     if (errno == EAGAIN || errno == EWOULDBLOCK)
     {
         svc_.work_started();
-        // Set registering BEFORE register_fd to close the race window where
-        // reactor sees an event before we set registered.
-        op.registered.store(registration_state::registering, std::memory_order_release);
-        svc_.scheduler().register_fd(fd_, &op, EPOLLOUT | EPOLLET);
+        op.impl_ptr = shared_from_this();
+        desc_data_.write_op = &op;
+        update_epoll_events();
 
-        // Transition to registered. If this fails, reactor or cancel already
-        // claimed the op (state is now unregistered), so we're done. However,
-        // we must still unregister the fd because cancel's unregister_fd may
-        // have run before our register_fd, leaving the fd orphaned in epoll.
-        auto expected = registration_state::registering;
-        if (!op.registered.compare_exchange_strong(
-                expected, registration_state::registered, std::memory_order_acq_rel))
-        {
-            svc_.scheduler().unregister_fd(fd_);
-            return;
-        }
-
-        // If cancelled was set before we registered, handle it now.
         if (op.cancelled.load(std::memory_order_acquire))
         {
-            auto prev = op.registered.exchange(
-                registration_state::unregistered, std::memory_order_acq_rel);
-            if (prev != registration_state::unregistered)
-            {
-                svc_.scheduler().unregister_fd(fd_);
-                op.impl_ptr = shared_from_this();
-                svc_.post(&op);
-                svc_.work_finished();
-            }
+            desc_data_.write_op = nullptr;
+            update_epoll_events();
+            svc_.post(&op);
+            svc_.work_finished();
         }
         return;
     }
@@ -562,45 +516,46 @@ cancel() noexcept
         return;
     }
 
-    auto cancel_op = [this, &self](epoll_op& op) {
-        auto prev = op.registered.exchange(
-            registration_state::unregistered, std::memory_order_acq_rel);
+    bool any_cancelled = false;
+    auto cancel_op = [this, &self, &any_cancelled](epoll_op& op, epoll_op*& desc_op_ptr) {
         op.request_cancel();
-        if (prev != registration_state::unregistered)
+        if (desc_op_ptr == &op)
         {
-            svc_.scheduler().unregister_fd(fd_);
+            desc_op_ptr = nullptr;
+            any_cancelled = true;
             op.impl_ptr = self;
             svc_.post(&op);
             svc_.work_finished();
         }
     };
 
-    cancel_op(conn_);
-    cancel_op(rd_);
-    cancel_op(wr_);
+    cancel_op(conn_, desc_data_.connect_op);
+    cancel_op(rd_, desc_data_.read_op);
+    cancel_op(wr_, desc_data_.write_op);
+
+    if (any_cancelled && desc_data_.is_registered)
+        update_epoll_events();
 }
 
 void
 epoll_socket_impl::
 cancel_single_op(epoll_op& op) noexcept
 {
-    // Called from stop_token callback to cancel a specific pending operation.
-    // This performs actual I/O cancellation, not just setting a flag.
-    auto prev = op.registered.exchange(
-        registration_state::unregistered, std::memory_order_acq_rel);
     op.request_cancel();
 
-    if (prev != registration_state::unregistered)
-    {
-        svc_.scheduler().unregister_fd(fd_);
+    epoll_op** desc_op_ptr = nullptr;
+    if (&op == &conn_) desc_op_ptr = &desc_data_.connect_op;
+    else if (&op == &rd_) desc_op_ptr = &desc_data_.read_op;
+    else if (&op == &wr_) desc_op_ptr = &desc_data_.write_op;
 
-        // Keep impl alive until op completes
+    if (desc_op_ptr && *desc_op_ptr == &op)
+    {
+        *desc_op_ptr = nullptr;
+        if (desc_data_.is_registered)
+            update_epoll_events();
         try {
             op.impl_ptr = shared_from_this();
-        } catch (const std::bad_weak_ptr&) {
-            // Impl is being destroyed, op will be orphaned but that's ok
-        }
-
+        } catch (const std::bad_weak_ptr&) {}
         svc_.post(&op);
         svc_.work_finished();
     }
@@ -614,16 +569,20 @@ close_socket() noexcept
 
     if (fd_ >= 0)
     {
-        // Unconditionally remove from epoll to handle edge cases where
-        // the fd might be registered but cancel() didn't clean it up
-        // due to race conditions. Note: kernel auto-removes on close,
-        // but this is defensive and makes behavior consistent with select.
-        svc_.scheduler().unregister_fd(fd_);
+        // Only deregister if we actually added to epoll (lazy registration)
+        if (desc_data_.registered_events != 0)
+            svc_.scheduler().deregister_descriptor(fd_);
         ::close(fd_);
         fd_ = -1;
     }
 
-    // Clear cached endpoints
+    desc_data_.fd = -1;
+    desc_data_.is_registered = false;
+    desc_data_.read_op = nullptr;
+    desc_data_.write_op = nullptr;
+    desc_data_.connect_op = nullptr;
+    desc_data_.registered_events = 0;
+
     local_endpoint_ = endpoint{};
     remote_endpoint_ = endpoint{};
 }
@@ -693,6 +652,14 @@ open_socket(socket::socket_impl& impl)
         return make_err(errno);
 
     epoll_impl->fd_ = fd;
+
+    // Register fd persistently with epoll (prototype for performance)
+    epoll_impl->desc_data_.fd = fd;
+    epoll_impl->desc_data_.read_op = nullptr;
+    epoll_impl->desc_data_.write_op = nullptr;
+    epoll_impl->desc_data_.connect_op = nullptr;
+    scheduler().register_descriptor(fd, &epoll_impl->desc_data_);
+
     return {};
 }
 

--- a/src/corosio/src/detail/epoll/sockets.cpp
+++ b/src/corosio/src/detail/epoll/sockets.cpp
@@ -186,10 +186,9 @@ connect(
         svc_.work_started();
         op.impl_ptr = shared_from_this();
 
-        desc_data_.connect_op.store(&op, std::memory_order_release);
-        std::atomic_thread_fence(std::memory_order_seq_cst);
+        desc_data_.connect_op.store(&op, std::memory_order_seq_cst);
 
-        if (desc_data_.write_ready.exchange(false, std::memory_order_acquire))
+        if (desc_data_.write_ready.exchange(false, std::memory_order_seq_cst))
         {
             auto* claimed = desc_data_.connect_op.exchange(nullptr, std::memory_order_acq_rel);
             if (claimed)
@@ -288,10 +287,9 @@ read_some(
         svc_.work_started();
         op.impl_ptr = shared_from_this();
 
-        desc_data_.read_op.store(&op, std::memory_order_release);
-        std::atomic_thread_fence(std::memory_order_seq_cst);
+        desc_data_.read_op.store(&op, std::memory_order_seq_cst);
 
-        if (desc_data_.read_ready.exchange(false, std::memory_order_acquire))
+        if (desc_data_.read_ready.exchange(false, std::memory_order_seq_cst))
         {
             auto* claimed = desc_data_.read_op.exchange(nullptr, std::memory_order_acq_rel);
             if (claimed)
@@ -384,10 +382,9 @@ write_some(
         svc_.work_started();
         op.impl_ptr = shared_from_this();
 
-        desc_data_.write_op.store(&op, std::memory_order_release);
-        std::atomic_thread_fence(std::memory_order_seq_cst);
+        desc_data_.write_op.store(&op, std::memory_order_seq_cst);
 
-        if (desc_data_.write_ready.exchange(false, std::memory_order_acquire))
+        if (desc_data_.write_ready.exchange(false, std::memory_order_seq_cst))
         {
             auto* claimed = desc_data_.write_op.exchange(nullptr, std::memory_order_acq_rel);
             if (claimed)

--- a/src/corosio/src/detail/epoll/sockets.cpp
+++ b/src/corosio/src/detail/epoll/sockets.cpp
@@ -28,20 +28,12 @@
 
 namespace boost::corosio::detail {
 
-//------------------------------------------------------------------------------
-// epoll_op::canceller - implements stop_token cancellation
-//------------------------------------------------------------------------------
-
 void
 epoll_op::canceller::
 operator()() const noexcept
 {
     op->cancel();
 }
-
-//------------------------------------------------------------------------------
-// cancel() overrides for socket operations
-//------------------------------------------------------------------------------
 
 void
 epoll_connect_op::
@@ -72,10 +64,6 @@ cancel() noexcept
     else
         request_cancel();
 }
-
-//------------------------------------------------------------------------------
-// epoll_connect_op::operator() - caches endpoints on successful connect
-//------------------------------------------------------------------------------
 
 void
 epoll_connect_op::
@@ -117,10 +105,6 @@ operator()()
     auto prevent_premature_destruction = std::move(impl_ptr);
     resume_coro(saved_ex, saved_h);
 }
-
-//------------------------------------------------------------------------------
-// epoll_socket_impl
-//------------------------------------------------------------------------------
 
 epoll_socket_impl::
 epoll_socket_impl(epoll_socket_service& svc) noexcept
@@ -439,10 +423,6 @@ shutdown(socket::shutdown_type what) noexcept
     return {};
 }
 
-//------------------------------------------------------------------------------
-// Socket Options
-//------------------------------------------------------------------------------
-
 std::error_code
 epoll_socket_impl::
 set_no_delay(bool value) noexcept
@@ -651,10 +631,6 @@ close_socket() noexcept
     local_endpoint_ = endpoint{};
     remote_endpoint_ = endpoint{};
 }
-
-//------------------------------------------------------------------------------
-// epoll_socket_service
-//------------------------------------------------------------------------------
 
 epoll_socket_service::
 epoll_socket_service(capy::execution_context& ctx)

--- a/src/corosio/src/detail/epoll/sockets.hpp
+++ b/src/corosio/src/detail/epoll/sockets.hpp
@@ -82,8 +82,7 @@ namespace boost::corosio::detail {
 class epoll_socket_service;
 class epoll_socket_impl;
 
-//------------------------------------------------------------------------------
-
+/// Socket implementation for epoll backend.
 class epoll_socket_impl
     : public socket::socket_impl
     , public std::enable_shared_from_this<epoll_socket_impl>
@@ -166,8 +165,6 @@ private:
     endpoint local_endpoint_;
     endpoint remote_endpoint_;
 };
-
-//------------------------------------------------------------------------------
 
 /** State for epoll socket service. */
 class epoll_socket_state

--- a/src/corosio/src/detail/epoll/sockets.hpp
+++ b/src/corosio/src/detail/epoll/sockets.hpp
@@ -145,6 +145,7 @@ public:
     void cancel() noexcept override;
     void cancel_single_op(epoll_op& op) noexcept;
     void close_socket() noexcept;
+    void update_epoll_events() noexcept;
     void set_socket(int fd) noexcept { fd_ = fd; }
     void set_endpoints(endpoint local, endpoint remote) noexcept
     {
@@ -155,6 +156,9 @@ public:
     epoll_connect_op conn_;
     epoll_read_op rd_;
     epoll_write_op wr_;
+
+    /// Per-descriptor state for persistent epoll registration
+    descriptor_data desc_data_;
 
 private:
     epoll_socket_service& svc_;

--- a/src/corosio/src/detail/posix/signals.cpp
+++ b/src/corosio/src/detail/posix/signals.cpp
@@ -56,7 +56,7 @@
 
     3. posix_signal_impl (one per signal_set)
        - Owns a singly-linked list (sorted by signal number) of signal_registrations
-       - Contains the pending_op_ used for async_wait operations
+       - Contains the pending_op_ used for wait operations
 
     Signal Delivery Flow
     --------------------
@@ -69,7 +69,7 @@
          to the scheduler for immediate completion
        - Otherwise, increment reg->undelivered to queue the signal
 
-    3. When async_wait() is called via start_wait():
+    3. When wait() is called via start_wait():
        - First check for queued signals (undelivered > 0); if found, post
          immediate completion without blocking
        - Otherwise, set waiting_ = true and call on_work_started() to keep
@@ -138,7 +138,7 @@ class posix_signals_impl;
 enum { max_signal_number = 64 };
 
 //------------------------------------------------------------------------------
-// signal_op - pending async_wait operation
+// signal_op - pending wait operation
 //------------------------------------------------------------------------------
 
 struct signal_op : scheduler_op

--- a/src/corosio/src/detail/select/acceptors.cpp
+++ b/src/corosio/src/detail/select/acceptors.cpp
@@ -24,10 +24,6 @@
 
 namespace boost::corosio::detail {
 
-//------------------------------------------------------------------------------
-// select_accept_op::cancel
-//------------------------------------------------------------------------------
-
 void
 select_accept_op::
 cancel() noexcept
@@ -37,10 +33,6 @@ cancel() noexcept
     else
         request_cancel();
 }
-
-//------------------------------------------------------------------------------
-// select_accept_op::operator() - creates peer socket and caches endpoints
-//------------------------------------------------------------------------------
 
 void
 select_accept_op::
@@ -131,10 +123,6 @@ operator()()
     impl_ptr.reset();
     saved_ex.dispatch( saved_h ).resume();
 }
-
-//------------------------------------------------------------------------------
-// select_acceptor_impl
-//------------------------------------------------------------------------------
 
 select_acceptor_impl::
 select_acceptor_impl(select_acceptor_service& svc) noexcept
@@ -339,10 +327,6 @@ close_socket() noexcept
     // Clear cached endpoint
     local_endpoint_ = endpoint{};
 }
-
-//------------------------------------------------------------------------------
-// select_acceptor_service
-//------------------------------------------------------------------------------
 
 select_acceptor_service::
 select_acceptor_service(capy::execution_context& ctx)

--- a/src/corosio/src/detail/select/acceptors.cpp
+++ b/src/corosio/src/detail/select/acceptors.cpp
@@ -233,6 +233,8 @@ accept(
     if (errno == EAGAIN || errno == EWOULDBLOCK)
     {
         svc_.work_started();
+        op.impl_ptr = shared_from_this();
+
         // Set registering BEFORE register_fd to close the race window where
         // reactor sees an event before we set registered.
         op.registered.store(select_registration_state::registering, std::memory_order_release);

--- a/src/corosio/src/detail/select/acceptors.hpp
+++ b/src/corosio/src/detail/select/acceptors.hpp
@@ -34,8 +34,7 @@ class select_acceptor_service;
 class select_acceptor_impl;
 class select_socket_service;
 
-//------------------------------------------------------------------------------
-
+/// Acceptor implementation for select backend.
 class select_acceptor_impl
     : public acceptor::acceptor_impl
     , public std::enable_shared_from_this<select_acceptor_impl>
@@ -72,8 +71,6 @@ private:
     int fd_ = -1;
     endpoint local_endpoint_;
 };
-
-//------------------------------------------------------------------------------
 
 /** State for select acceptor service. */
 class select_acceptor_state

--- a/src/corosio/src/detail/select/op.hpp
+++ b/src/corosio/src/detail/select/op.hpp
@@ -233,7 +233,6 @@ struct select_op : scheduler_op
     virtual void perform_io() noexcept {}
 };
 
-//------------------------------------------------------------------------------
 
 struct select_connect_op : select_op
 {
@@ -260,7 +259,6 @@ struct select_connect_op : select_op
     void cancel() noexcept override;
 };
 
-//------------------------------------------------------------------------------
 
 struct select_read_op : select_op
 {
@@ -293,7 +291,6 @@ struct select_read_op : select_op
     void cancel() noexcept override;
 };
 
-//------------------------------------------------------------------------------
 
 struct select_write_op : select_op
 {
@@ -323,7 +320,6 @@ struct select_write_op : select_op
     void cancel() noexcept override;
 };
 
-//------------------------------------------------------------------------------
 
 struct select_accept_op : select_op
 {

--- a/src/corosio/src/detail/select/scheduler.cpp
+++ b/src/corosio/src/detail/select/scheduler.cpp
@@ -715,6 +715,14 @@ do_one(long timeout_us)
         if (stopped_.load(std::memory_order_acquire))
             return 0;
 
+        // Prevents timer starvation when handlers are continuously posted
+        if (timer_svc_->nearest_expiry() <= std::chrono::steady_clock::now())
+        {
+            lock.unlock();
+            timer_svc_->process_expired();
+            lock.lock();
+        }
+
         // Try to get a handler from the queue
         scheduler_op* op = completed_ops_.pop();
 

--- a/src/corosio/src/detail/select/sockets.cpp
+++ b/src/corosio/src/detail/select/sockets.cpp
@@ -26,20 +26,12 @@
 
 namespace boost::corosio::detail {
 
-//------------------------------------------------------------------------------
-// select_op::canceller - implements stop_token cancellation
-//------------------------------------------------------------------------------
-
 void
 select_op::canceller::
 operator()() const noexcept
 {
     op->cancel();
 }
-
-//------------------------------------------------------------------------------
-// cancel() overrides for socket operations
-//------------------------------------------------------------------------------
 
 void
 select_connect_op::
@@ -70,10 +62,6 @@ cancel() noexcept
     else
         request_cancel();
 }
-
-//------------------------------------------------------------------------------
-// select_connect_op::operator() - caches endpoints on successful connect
-//------------------------------------------------------------------------------
 
 void
 select_connect_op::
@@ -115,10 +103,6 @@ operator()()
     impl_ptr.reset();
     saved_ex.dispatch( saved_h ).resume();
 }
-
-//------------------------------------------------------------------------------
-// select_socket_impl
-//------------------------------------------------------------------------------
 
 select_socket_impl::
 select_socket_impl(select_socket_service& svc) noexcept
@@ -423,10 +407,6 @@ shutdown(socket::shutdown_type what) noexcept
     return {};
 }
 
-//------------------------------------------------------------------------------
-// Socket Options
-//------------------------------------------------------------------------------
-
 std::error_code
 select_socket_impl::
 set_no_delay(bool value) noexcept
@@ -636,10 +616,6 @@ close_socket() noexcept
     local_endpoint_ = endpoint{};
     remote_endpoint_ = endpoint{};
 }
-
-//------------------------------------------------------------------------------
-// select_socket_service
-//------------------------------------------------------------------------------
 
 select_socket_service::
 select_socket_service(capy::execution_context& ctx)

--- a/src/corosio/src/detail/select/sockets.cpp
+++ b/src/corosio/src/detail/select/sockets.cpp
@@ -173,6 +173,8 @@ connect(
     if (errno == EINPROGRESS)
     {
         svc_.work_started();
+        op.impl_ptr = shared_from_this();
+
         // Set registering BEFORE register_fd to close the race window where
         // reactor sees an event before we set registered. The reactor treats
         // registering the same as registered when claiming the op.
@@ -270,6 +272,8 @@ read_some(
     if (errno == EAGAIN || errno == EWOULDBLOCK)
     {
         svc_.work_started();
+        op.impl_ptr = shared_from_this();
+
         // Set registering BEFORE register_fd to close the race window where
         // reactor sees an event before we set registered.
         op.registered.store(select_registration_state::registering, std::memory_order_release);
@@ -361,6 +365,8 @@ write_some(
     if (errno == EAGAIN || errno == EWOULDBLOCK)
     {
         svc_.work_started();
+        op.impl_ptr = shared_from_this();
+
         // Set registering BEFORE register_fd to close the race window where
         // reactor sees an event before we set registered.
         op.registered.store(select_registration_state::registering, std::memory_order_release);

--- a/src/corosio/src/detail/select/sockets.hpp
+++ b/src/corosio/src/detail/select/sockets.hpp
@@ -71,8 +71,7 @@ namespace boost::corosio::detail {
 class select_socket_service;
 class select_socket_impl;
 
-//------------------------------------------------------------------------------
-
+/// Socket implementation for select backend.
 class select_socket_impl
     : public socket::socket_impl
     , public std::enable_shared_from_this<select_socket_impl>
@@ -151,8 +150,6 @@ private:
     endpoint local_endpoint_;
     endpoint remote_endpoint_;
 };
-
-//------------------------------------------------------------------------------
 
 /** State for select socket service. */
 class select_socket_state

--- a/src/corosio/src/detail/win/signals.cpp
+++ b/src/corosio/src/detail/win/signals.cpp
@@ -46,7 +46,7 @@
 
     3. win_signal_impl (one per signal_set)
        - Owns a singly-linked list (sorted by signal number) of signal_registrations
-       - Contains the pending_op_ used for async_wait operations
+       - Contains the pending_op_ used for wait operations
 
     The signal_registration struct links these together:
        - next_in_set / (implicit via sorted order): links registrations within one signal_set

--- a/src/corosio/src/test/socket_pair.cpp
+++ b/src/corosio/src/test/socket_pair.cpp
@@ -10,7 +10,7 @@
 #include <boost/corosio/test/socket_pair.hpp>
 #include <boost/corosio/acceptor.hpp>
 #include <system_error>
-#include <boost/corosio/io_context.hpp>
+#include <boost/corosio/basic_io_context.hpp>
 #include <boost/corosio/detail/platform.hpp>
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/task.hpp>
@@ -59,9 +59,9 @@ get_test_port() noexcept
 } // namespace
 
 std::pair<socket, socket>
-make_socket_pair(io_context& ioc)
+make_socket_pair(basic_io_context& ctx)
 {
-    auto ex = ioc.get_executor();
+    auto ex = ctx.get_executor();
 
     std::error_code accept_ec;
     std::error_code connect_ec;
@@ -70,7 +70,7 @@ make_socket_pair(io_context& ioc)
 
     // Try multiple ports in case of conflicts (TIME_WAIT, parallel tests, etc.)
     std::uint16_t port = 0;
-    acceptor acc(ioc);
+    acceptor acc(ctx);
     bool listening = false;
     for (int attempt = 0; attempt < 20; ++attempt)
     {
@@ -85,7 +85,7 @@ make_socket_pair(io_context& ioc)
         {
             // Port in use, try another
             acc.close();
-            acc = acceptor(ioc);
+            acc = acceptor(ctx);
         }
     }
     if (!listening)
@@ -94,8 +94,8 @@ make_socket_pair(io_context& ioc)
         throw std::runtime_error("socket_pair: failed to find available port");
     }
 
-    socket s1(ioc);
-    socket s2(ioc);
+    socket s1(ctx);
+    socket s2(ctx);
     s2.open();
 
     capy::run_async(ex)(
@@ -117,8 +117,8 @@ make_socket_pair(io_context& ioc)
         }(s2, endpoint(ipv4_address::loopback(), port),
           connect_ec, connect_done));
 
-    ioc.run();
-    ioc.restart();
+    ctx.run();
+    ctx.restart();
 
     if (!accept_done || accept_ec)
     {

--- a/test/unit/signal_set.cpp
+++ b/test/unit/signal_set.cpp
@@ -205,7 +205,7 @@ struct signal_set_test_impl
 
         auto wait_task = [](signal_set& s_ref, std::error_code& ec_out, int& sig_out, bool& done_out) -> capy::task<>
         {
-            auto [ec, signum] = co_await s_ref.async_wait();
+            auto [ec, signum] = co_await s_ref.wait();
             ec_out = ec;
             sig_out = signum;
             done_out = true;
@@ -239,7 +239,7 @@ struct signal_set_test_impl
 
         auto wait_task = [](signal_set& s_ref, int& sig_out, bool& done_out) -> capy::task<>
         {
-            auto [ec, signum] = co_await s_ref.async_wait();
+            auto [ec, signum] = co_await s_ref.wait();
             sig_out = signum;
             done_out = true;
             (void)ec;
@@ -275,7 +275,7 @@ struct signal_set_test_impl
 
         auto wait_task = [](signal_set& s_ref, std::error_code& ec_out, bool& done_out) -> capy::task<>
         {
-            auto [ec, signum] = co_await s_ref.async_wait();
+            auto [ec, signum] = co_await s_ref.wait();
             ec_out = ec;
             done_out = true;
             (void)signum;
@@ -336,7 +336,7 @@ struct signal_set_test_impl
 
         auto wait_task = [](signal_set& s_ref, int& sig_out, bool& done_out) -> capy::task<>
         {
-            auto [ec, signum] = co_await s_ref.async_wait();
+            auto [ec, signum] = co_await s_ref.wait();
             sig_out = signum;
             done_out = true;
             (void)ec;
@@ -371,7 +371,7 @@ struct signal_set_test_impl
 
         auto wait_task = [](signal_set& s_ref, int& sig_out, bool& done_out) -> capy::task<>
         {
-            auto [ec, signum] = co_await s_ref.async_wait();
+            auto [ec, signum] = co_await s_ref.wait();
             sig_out = signum;
             done_out = true;
             (void)ec;
@@ -410,7 +410,7 @@ struct signal_set_test_impl
 
         auto wait_task = [](signal_set& s_ref, int& sig_out, bool& done_out) -> capy::task<>
         {
-            auto [ec, signum] = co_await s_ref.async_wait();
+            auto [ec, signum] = co_await s_ref.wait();
             sig_out = signum;
             done_out = true;
             (void)ec;
@@ -442,7 +442,7 @@ struct signal_set_test_impl
             (void)co_await t_ref.wait();
             std::raise(SIGINT);
 
-            auto [ec1, sig1] = co_await s_ref.async_wait();
+            auto [ec1, sig1] = co_await s_ref.wait();
             BOOST_TEST(!ec1);
             BOOST_TEST_EQ(sig1, SIGINT);
             ++count_out;
@@ -452,7 +452,7 @@ struct signal_set_test_impl
             (void)co_await t_ref.wait();
             std::raise(SIGINT);
 
-            auto [ec2, sig2] = co_await s_ref.async_wait();
+            auto [ec2, sig2] = co_await s_ref.wait();
             BOOST_TEST(!ec2);
             BOOST_TEST_EQ(sig2, SIGINT);
             ++count_out;
@@ -482,7 +482,7 @@ struct signal_set_test_impl
             (void)co_await t_ref.wait();
             std::raise(SIGINT);
 
-            auto result = co_await s_ref.async_wait();
+            auto result = co_await s_ref.wait();
             ok_out = !result.ec;
         };
         capy::run_async(ioc.get_executor())(task(s, t, result_ok));
@@ -503,7 +503,7 @@ struct signal_set_test_impl
 
         auto wait_task = [](signal_set& s_ref, bool& ok_out, std::error_code& ec_out) -> capy::task<>
         {
-            auto result = co_await s_ref.async_wait();
+            auto result = co_await s_ref.wait();
             ok_out = !result.ec;
             ec_out = result.ec;
         };
@@ -538,7 +538,7 @@ struct signal_set_test_impl
             (void)co_await t_ref.wait();
             std::raise(SIGINT);
 
-            auto [ec, signum] = co_await s_ref.async_wait();
+            auto [ec, signum] = co_await s_ref.wait();
             ec_out = ec;
             sig_out = signum;
         };
@@ -724,7 +724,7 @@ struct signal_set_test_impl
 
         auto wait_task = [](signal_set& s_ref, int& sig_out, bool& done_out) -> capy::task<>
         {
-            auto [ec, signum] = co_await s_ref.async_wait();
+            auto [ec, signum] = co_await s_ref.wait();
             sig_out = signum;
             done_out = true;
             (void)ec;

--- a/test/unit/socket_stress.cpp
+++ b/test/unit/socket_stress.cpp
@@ -18,15 +18,16 @@
 // 3. Rapid cancel/complete cycles
 // 4. shared_ptr lifetime - operation completion vs socket close race
 //
-// Currently IOCP-only: epoll stress tests hang on some Linux builds (GCC 13
-// coverage). The use-after-free fix is in place for epoll, but there appears
-// to be a separate deadlock issue that needs investigation.
+// Tests run on all backends (epoll, IOCP, select).
 
 #include <boost/corosio/detail/platform.hpp>
 
 #include <boost/corosio/socket.hpp>
 #include <boost/corosio/acceptor.hpp>
 #include <boost/corosio/io_context.hpp>
+#if BOOST_COROSIO_HAS_SELECT
+#include <boost/corosio/select_context.hpp>
+#endif
 #include <boost/corosio/timer.hpp>
 #include <boost/capy/cond.hpp>
 #include <boost/capy/ex/run_async.hpp>
@@ -81,9 +82,10 @@ get_stress_port() noexcept
 }
 
 // Create a connected socket pair for stress testing.
-// Must be called BEFORE io_context::run().
+// Must be called BEFORE context::run().
+template<class Context>
 std::pair<socket, socket>
-make_stress_pair(io_context& ctx)
+make_stress_pair(Context& ctx)
 {
     auto ex = ctx.get_executor();
 
@@ -161,7 +163,8 @@ make_stress_pair(io_context& ctx)
 // - During operator() execution
 //------------------------------------------------------------------------------
 
-struct stop_token_stress_test
+template<class Context>
+struct stop_token_stress_test_impl
 {
     void
     run()
@@ -169,11 +172,11 @@ struct stop_token_stress_test
         int duration = get_stress_duration();
         std::fprintf(stderr, "  stop_token_stress: running for %d seconds...\n", duration);
 
-        io_context ioc;
+        Context ioc;
         auto ex = ioc.get_executor();
 
         // Pre-create socket pair BEFORE ioc.run()
-        auto [s1, s2] = make_stress_pair(ioc);
+        auto [s1, s2] = make_stress_pair<Context>(ioc);
 
         std::atomic<std::size_t> iterations{0};
         std::atomic<std::size_t> cancellations{0};
@@ -279,7 +282,13 @@ struct stop_token_stress_test
     }
 };
 
+struct stop_token_stress_test : stop_token_stress_test_impl<io_context> {};
 TEST_SUITE(stop_token_stress_test, "boost.corosio.socket_stress.stop_token");
+
+#if BOOST_COROSIO_HAS_SELECT
+struct stop_token_stress_test_select : stop_token_stress_test_impl<select_context> {};
+TEST_SUITE(stop_token_stress_test_select, "boost.corosio.socket_stress.stop_token.select");
+#endif
 
 //------------------------------------------------------------------------------
 // Stress Test 2: Synchronous Completion Race (ready_ flag)
@@ -288,7 +297,8 @@ TEST_SUITE(stop_token_stress_test, "boost.corosio.socket_stress.stop_token");
 // race between the initiating thread and completion handler thread.
 //------------------------------------------------------------------------------
 
-struct sync_completion_stress_test
+template<class Context>
+struct sync_completion_stress_test_impl
 {
     void
     run()
@@ -296,11 +306,11 @@ struct sync_completion_stress_test
         int duration = get_stress_duration();
         std::fprintf(stderr, "  sync_completion_stress: running for %d seconds...\n", duration);
 
-        io_context ioc;
+        Context ioc;
         auto ex = ioc.get_executor();
 
         // Pre-create socket pair BEFORE ioc.run()
-        auto [s1, s2] = make_stress_pair(ioc);
+        auto [s1, s2] = make_stress_pair<Context>(ioc);
 
         std::atomic<std::size_t> iterations{0};
         std::atomic<bool> stop_flag{false};
@@ -362,7 +372,13 @@ struct sync_completion_stress_test
     }
 };
 
+struct sync_completion_stress_test : sync_completion_stress_test_impl<io_context> {};
 TEST_SUITE(sync_completion_stress_test, "boost.corosio.socket_stress.sync_completion");
+
+#if BOOST_COROSIO_HAS_SELECT
+struct sync_completion_stress_test_select : sync_completion_stress_test_impl<select_context> {};
+TEST_SUITE(sync_completion_stress_test_select, "boost.corosio.socket_stress.sync_completion.select");
+#endif
 
 //------------------------------------------------------------------------------
 // Stress Test 3: Rapid Cancel/Close Cycles
@@ -371,7 +387,8 @@ TEST_SUITE(sync_completion_stress_test, "boost.corosio.socket_stress.sync_comple
 // cleanup paths and ensure no use-after-free or double-free.
 //------------------------------------------------------------------------------
 
-struct cancel_close_stress_test
+template<class Context>
+struct cancel_close_stress_test_impl
 {
     void
     run()
@@ -379,11 +396,11 @@ struct cancel_close_stress_test
         int duration = get_stress_duration();
         std::fprintf(stderr, "  cancel_close_stress: running for %d seconds...\n", duration);
 
-        io_context ioc;
+        Context ioc;
         auto ex = ioc.get_executor();
 
         // Pre-create socket pair BEFORE ioc.run()
-        auto [s1, s2] = make_stress_pair(ioc);
+        auto [s1, s2] = make_stress_pair<Context>(ioc);
 
         std::atomic<std::size_t> iterations{0};
         std::atomic<std::size_t> cancels{0};
@@ -500,7 +517,13 @@ struct cancel_close_stress_test
     }
 };
 
+struct cancel_close_stress_test : cancel_close_stress_test_impl<io_context> {};
 TEST_SUITE(cancel_close_stress_test, "boost.corosio.socket_stress.cancel_close");
+
+#if BOOST_COROSIO_HAS_SELECT
+struct cancel_close_stress_test_select : cancel_close_stress_test_impl<select_context> {};
+TEST_SUITE(cancel_close_stress_test_select, "boost.corosio.socket_stress.cancel_close.select");
+#endif
 
 //------------------------------------------------------------------------------
 // Stress Test 4: Concurrent Operations
@@ -509,7 +532,8 @@ TEST_SUITE(cancel_close_stress_test, "boost.corosio.socket_stress.cancel_close")
 // thread safety and completion dispatch.
 //------------------------------------------------------------------------------
 
-struct concurrent_ops_stress_test
+template<class Context>
+struct concurrent_ops_stress_test_impl
 {
     void
     run()
@@ -517,7 +541,7 @@ struct concurrent_ops_stress_test
         int duration = get_stress_duration();
         std::fprintf(stderr, "  concurrent_ops_stress: running for %d seconds...\n", duration);
 
-        io_context ioc;
+        Context ioc;
         auto ex = ioc.get_executor();
 
         std::atomic<std::size_t> total_bytes{0};
@@ -529,7 +553,7 @@ struct concurrent_ops_stress_test
         std::vector<std::pair<socket, socket>> pairs;
         for (int i = 0; i < num_pairs; ++i)
         {
-            pairs.push_back(make_stress_pair(ioc));
+            pairs.push_back(make_stress_pair<Context>(ioc));
         }
 
         // Writer tasks - use function parameters to pass index reliably
@@ -602,7 +626,13 @@ struct concurrent_ops_stress_test
     }
 };
 
+struct concurrent_ops_stress_test : concurrent_ops_stress_test_impl<io_context> {};
 TEST_SUITE(concurrent_ops_stress_test, "boost.corosio.socket_stress.concurrent_ops");
+
+#if BOOST_COROSIO_HAS_SELECT
+struct concurrent_ops_stress_test_select : concurrent_ops_stress_test_impl<select_context> {};
+TEST_SUITE(concurrent_ops_stress_test_select, "boost.corosio.socket_stress.concurrent_ops.select");
+#endif
 
 //------------------------------------------------------------------------------
 // Stress Test 5: Accept/Connect Race
@@ -611,7 +641,8 @@ TEST_SUITE(concurrent_ops_stress_test, "boost.corosio.socket_stress.concurrent_o
 // code path and accept completion handling.
 //------------------------------------------------------------------------------
 
-struct accept_stress_test
+template<class Context>
+struct accept_stress_test_impl
 {
     void
     run()
@@ -619,7 +650,7 @@ struct accept_stress_test
         int duration = get_stress_duration();
         std::fprintf(stderr, "  accept_stress: running for %d seconds...\n", duration);
 
-        io_context ioc;
+        Context ioc;
         auto ex = ioc.get_executor();
 
         std::atomic<std::size_t> connections{0};
@@ -710,7 +741,13 @@ struct accept_stress_test
     }
 };
 
+struct accept_stress_test : accept_stress_test_impl<io_context> {};
 TEST_SUITE(accept_stress_test, "boost.corosio.socket_stress.accept");
+
+#if BOOST_COROSIO_HAS_SELECT
+struct accept_stress_test_select : accept_stress_test_impl<select_context> {};
+TEST_SUITE(accept_stress_test_select, "boost.corosio.socket_stress.accept.select");
+#endif
 
 } // namespace boost::corosio
 

--- a/test/unit/socket_stress.cpp
+++ b/test/unit/socket_stress.cpp
@@ -24,8 +24,6 @@
 
 #include <boost/corosio/detail/platform.hpp>
 
-#if BOOST_COROSIO_HAS_IOCP
-
 #include <boost/corosio/socket.hpp>
 #include <boost/corosio/acceptor.hpp>
 #include <boost/corosio/io_context.hpp>
@@ -716,4 +714,3 @@ TEST_SUITE(accept_stress_test, "boost.corosio.socket_stress.accept");
 
 } // namespace boost::corosio
 
-#endif // BOOST_COROSIO_HAS_IOCP


### PR DESCRIPTION
## Summary

This PR introduces edge-triggered epoll (EPOLLET) with persistent descriptor registration, significantly improving latency under concurrent load while maintaining throughput parity. It also includes bug fixes, documentation improvements, and new benchmarking infrastructure.

## Key Changes

### 1. Edge-Triggered Epoll Implementation

Switched from level-triggered to edge-triggered epoll with persistent registration:

- **Persistent registration**: File descriptors are registered once with epoll and stay registered until closed, eliminating repeated `epoll_ctl` calls
- **Edge-triggered mode**: Uses `EPOLLET` flag for more efficient event notification
- **Readiness caching**: Atomic `read_ready`/`write_ready` flags cache edge events that arrive before an operation is registered, preventing missed events
- **Memory ordering**: Uses `seq_cst` for critical synchronization between operation registration and reactor event delivery

### 2. Performance Results

**Latency improvements (lower is better):**

| Test | develop | This PR | Change |
|------|---------|---------|--------|
| 1 pair p99 | 8.58 µs | 4.96 µs | **-42%** |
| 4 pairs p99 | 24.32 µs | 19.18 µs | **-21%** |
| 16 pairs p99 | 131.06 µs | 71.46 µs | **-45%** |

**HTTP Server (concurrent connections):**

| Test | develop | This PR | Change |
|------|---------|---------|--------|
| 16 connections throughput | 203.99 Kops/s | 233.33 Kops/s | **+14%** |
| 4 threads, 32 connections | 246.14 Kops/s | 292.27 Kops/s | **+19%** |
| 16 connections p99 latency | 118.20 µs | 82.85 µs | **-30%** |

### 3. Bug Fixes

- **Use-after-free in select backend**: Fixed by setting `impl_ptr = shared_from_this()` immediately after `work_started()` in async operation paths
- **Timer starvation in select scheduler**: Added timer processing in `do_one()` loop to prevent timers from starving when handlers are continuously posted

### 4. Documentation Improvements

- Renamed `signal_set::async_wait()` to `wait()` for consistency with `timer::wait()`
- Changed documentation to reference `capy::cond::canceled` instead of `capy::error::canceled`
- Added usage examples showing correct error condition comparison pattern
- Removed line divider comments and redundant section headers per coding standards
- Added brief Javadoc to implementation classes

### 5. New Benchmarking Infrastructure

- **HTTP server benchmark**: New benchmark comparing corosio vs Asio HTTP server performance
- **Multi-backend support**: Benchmarks now support `--backend` flag to select epoll or select
- **JSON output**: Added `--json` flag for machine-readable benchmark results
- **Selective execution**: Added `--only` flag to run specific benchmark suites

### 6. Multi-Backend Test Support

Socket stress tests now run on both epoll and select backends:
- `boost.corosio.socket_stress.*` - epoll backend
- `boost.corosio.socket_stress.*.select` - select backend


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **API Changes**
  * Signal set asynchronous wait method renamed from `async_wait()` to `wait()`

* **Improvements**
  * Enhanced cancellation error handling with updated references to `capy::cond::canceled`
  * Improved timer processing to prevent starvation in event loops
  * Better lifecycle management and state consistency for socket operations

* **Documentation**
  * Updated examples demonstrating the new `wait()` API usage
  * Clarified cancellation behavior with detailed examples and error code comparisons

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->