### PR TITLE
use native wolfSSL API for encrypted private keys

### DIFF
--- a/src/wolfssl/src/wolfssl_stream.cpp
+++ b/src/wolfssl/src/wolfssl_stream.cpp
@@ -21,6 +21,7 @@
 #include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 #include <wolfssl/error-ssl.h>
+#include <wolfssl/wolfcrypt/asn_public.h>
 
 #include <algorithm>
 #include <array>
@@ -92,29 +93,6 @@ constexpr std::size_t default_buffer_size = 16384;
 //------------------------------------------------------------------------------
 
 namespace detail {
-
-// Password callback invoked by WolfSSL when loading encrypted private keys
-static int
-wolfssl_password_callback(char* buf, int size, int rwflag, void* userdata)
-{
-    auto* cd = static_cast<tls_context_data const*>(userdata);
-    if(!cd || !cd->password_callback)
-        return 0;
-
-    tls_password_purpose purpose = (rwflag == 0)
-        ? tls_password_purpose::for_reading
-        : tls_password_purpose::for_writing;
-
-    std::string password = cd->password_callback(
-        static_cast<std::size_t>(size), purpose);
-
-    int len = static_cast<int>(password.size());
-    if(len > size)
-        len = size;
-
-    std::memcpy(buf, password.data(), static_cast<std::size_t>(len));
-    return len;
-}
 
 // SNI callback invoked by WolfSSL during handshake (server-side)
 // Returns SNICbReturn enum: 0 = OK, fatal_return (2) = abort
@@ -188,20 +166,57 @@ public:
         // Apply private key if provided
         if(!cd.private_key.empty())
         {
-            // Set password callback before loading encrypted private key
             if(cd.password_callback)
             {
-                wolfSSL_CTX_set_default_passwd_cb(ctx, wolfssl_password_callback);
-                wolfSSL_CTX_set_default_passwd_cb_userdata(ctx,
-                    const_cast<tls_context_data*>(&cd));
-            }
+                // Native wolfSSL APIs work without OPENSSL_EXTRA
+                std::string password = cd.password_callback(
+                    256, tls_password_purpose::for_reading);
 
-            int format = (cd.private_key_format == tls_file_format::pem)
-                ? WOLFSSL_FILETYPE_PEM : WOLFSSL_FILETYPE_ASN1;
-            wolfSSL_CTX_use_PrivateKey_buffer(ctx,
-                reinterpret_cast<unsigned char const*>(cd.private_key.data()),
-                static_cast<long>(cd.private_key.size()),
-                format);
+                if(cd.private_key_format == tls_file_format::pem)
+                {
+                    std::vector<unsigned char> der_buf(cd.private_key.size());
+                    int der_len = wc_KeyPemToDer(
+                        reinterpret_cast<unsigned char const*>(cd.private_key.data()),
+                        static_cast<int>(cd.private_key.size()),
+                        der_buf.data(),
+                        static_cast<int>(der_buf.size()),
+                        password.c_str());
+
+                    if(der_len > 0)
+                        wolfSSL_CTX_use_PrivateKey_buffer(ctx,
+                            der_buf.data(), der_len, WOLFSSL_FILETYPE_ASN1);
+                }
+                else
+                {
+                    // Encrypted PKCS#8 DER - decrypt in place on a copy
+                    std::vector<unsigned char> der_buf(
+                        cd.private_key.begin(), cd.private_key.end());
+                    int dec_len = wc_DecryptPKCS8Key(
+                        der_buf.data(),
+                        static_cast<word32>(der_buf.size()),
+                        password.c_str(),
+                        static_cast<int>(password.size()));
+
+                    if(dec_len > 0)
+                        wolfSSL_CTX_use_PrivateKey_buffer(ctx,
+                            der_buf.data(), dec_len, WOLFSSL_FILETYPE_ASN1);
+                    else
+                        // Not encrypted or decryption failed - try loading directly
+                        wolfSSL_CTX_use_PrivateKey_buffer(ctx,
+                            reinterpret_cast<unsigned char const*>(cd.private_key.data()),
+                            static_cast<long>(cd.private_key.size()),
+                            WOLFSSL_FILETYPE_ASN1);
+                }
+            }
+            else
+            {
+                int format = (cd.private_key_format == tls_file_format::pem)
+                    ? WOLFSSL_FILETYPE_PEM : WOLFSSL_FILETYPE_ASN1;
+                wolfSSL_CTX_use_PrivateKey_buffer(ctx,
+                    reinterpret_cast<unsigned char const*>(cd.private_key.data()),
+                    static_cast<long>(cd.private_key.size()),
+                    format);
+            }
         }
 
         // Apply CA certificates for verification


### PR DESCRIPTION
wc_KeyPemToDer decrypts PEM keys directly, avoiding wolfSSL_CTX_set_default_passwd_cb which requires OPENSSL_EXTRA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved handling of password-protected private keys: inline password processing, clearer DER/PEM loading and fallback paths, and removal of legacy password callback usage.
* **Bug Fix**
  * More reliable loading of encrypted private keys (PEM and encrypted PKCS#8), reducing failures when passwords are supplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->