### PR TITLE
Fix tcp_server::bind() to not throw despite returning error_code

### DIFF
--- a/doc/modules/ROOT/pages/guide/endpoints.adoc
+++ b/doc/modules/ROOT/pages/guide/endpoints.adoc
@@ -202,7 +202,8 @@ auto [ec] = co_await s.connect(target);
 [source,cpp]
 ----
 corosio::tcp_acceptor acc(ioc);
-acc.listen(corosio::endpoint(8080));  // Bind to all interfaces
+if (auto ec = acc.listen(corosio::endpoint(8080)))  // Bind to all interfaces
+    return ec;
 ----
 
 == From Resolver Results

--- a/doc/modules/ROOT/pages/guide/signals.adoc
+++ b/doc/modules/ROOT/pages/guide/signals.adoc
@@ -389,7 +389,8 @@ capy::task<void> run_server(corosio::io_context& ioc)
 
     // Accept loop
     corosio::acceptor acc(ioc);
-    acc.listen(corosio::endpoint(8080));
+    if (auto ec = acc.listen(corosio::endpoint(8080)))
+        co_return;
 
     while (running)
     {

--- a/doc/modules/ROOT/pages/guide/tcp_acceptor.adoc
+++ b/doc/modules/ROOT/pages/guide/tcp_acceptor.adoc
@@ -29,7 +29,8 @@ An tcp_acceptor binds to a local endpoint and waits for clients to connect:
 [source,cpp]
 ----
 corosio::tcp_acceptor acc(ioc);
-acc.listen(corosio::endpoint(8080));  // Listen on port 8080
+if (auto ec = acc.listen(corosio::endpoint(8080)))  // Listen on port 8080
+    return ec;
 
 corosio::tcp_socket peer(ioc);
 auto [ec] = co_await acc.accept(peer);
@@ -65,7 +66,11 @@ listening for connections:
 
 [source,cpp]
 ----
-acc.listen(corosio::endpoint(8080));
+if (auto ec = acc.listen(corosio::endpoint(8080)))
+{
+    std::cerr << "Listen failed: " << ec.message() << "\n";
+    return ec;
+}
 ----
 
 This performs three operations:
@@ -74,13 +79,14 @@ This performs three operations:
 2. Binds to the specified endpoint
 3. Marks the socket as passive (listening)
 
-Throws `std::system_error` on failure.
+Returns a `std::error_code` indicating success or failure. The return value
+is marked `[[nodiscard]]` to prevent accidentally ignoring errors.
 
 === Parameters
 
 [source,cpp]
 ----
-void listen(endpoint ep, int backlog = 128);
+[[nodiscard]] std::error_code listen(endpoint ep, int backlog = 128);
 ----
 
 The `backlog` parameter specifies the maximum queue length for pending
@@ -94,7 +100,8 @@ To accept connections on any network interface:
 [source,cpp]
 ----
 // Port only - binds to 0.0.0.0 (all IPv4 interfaces)
-acc.listen(corosio::endpoint(8080));
+if (auto ec = acc.listen(corosio::endpoint(8080)))
+    return ec;
 ----
 
 === Binding to a Specific Interface
@@ -104,8 +111,9 @@ To accept connections only on a specific interface:
 [source,cpp]
 ----
 // Localhost only
-acc.listen(corosio::endpoint(
-    boost::urls::ipv4_address::loopback(), 8080));
+if (auto ec = acc.listen(corosio::endpoint(
+    boost::urls::ipv4_address::loopback(), 8080)))
+    return ec;
 ----
 
 == Accepting Connections
@@ -281,7 +289,11 @@ Coordinate shutdown with signal handling:
 capy::task<void> run_server(corosio::io_context& ioc)
 {
     corosio::tcp_acceptor acc(ioc);
-    acc.listen(corosio::endpoint(8080));
+    if (auto ec = acc.listen(corosio::endpoint(8080)))
+    {
+        std::cerr << "Listen failed: " << ec.message() << "\n";
+        co_return;
+    }
 
     corosio::signal_set signals(ioc, SIGINT, SIGTERM);
 

--- a/doc/modules/ROOT/pages/guide/tls.adoc
+++ b/doc/modules/ROOT/pages/guide/tls.adoc
@@ -552,7 +552,8 @@ capy::task<void> tls_server(
 
     // Set up acceptor
     corosio::acceptor acc(ioc);
-    acc.listen(corosio::endpoint(port));
+    if (auto ec = acc.listen(corosio::endpoint(port)))
+        co_return;
 
     for (;;)
     {

--- a/include/boost/corosio/tcp_acceptor.hpp
+++ b/include/boost/corosio/tcp_acceptor.hpp
@@ -53,7 +53,8 @@ namespace boost::corosio {
     @code
     io_context ioc;
     tcp_acceptor acc(ioc);
-    acc.listen(endpoint(8080));  // Bind to port 8080
+    if (auto ec = acc.listen(endpoint(8080)))  // Bind to port 8080
+        return ec;
 
     tcp_socket peer(ioc);
     auto [ec] = co_await acc.accept(peer);
@@ -198,11 +199,23 @@ public:
             bind to all interfaces on a specific port.
 
         @param backlog The maximum length of the queue of pending
-            connections. Defaults to a reasonable system value.
+            connections. Defaults to 128.
 
-        @throws std::system_error on failure.
+        @return An error code indicating success or the reason for failure.
+            A default-constructed error code indicates success.
+
+        @par Error Conditions
+        @li `errc::address_in_use`: The endpoint is already in use.
+        @li `errc::address_not_available`: The address is not available
+            on any local interface.
+        @li `errc::permission_denied`: Insufficient privileges to bind
+            to the endpoint (e.g., privileged port).
+        @li `errc::operation_not_supported`: The acceptor service is
+            unavailable in the context (POSIX only).
+
+        @throws Nothing.
     */
-    void listen(endpoint ep, int backlog = 128);
+    [[nodiscard]] std::error_code listen(endpoint ep, int backlog = 128);
 
     /** Close the acceptor.
 

--- a/src/corosio/src/tcp_acceptor.cpp
+++ b/src/corosio/src/tcp_acceptor.cpp
@@ -34,36 +34,41 @@ tcp_acceptor(
 {
 }
 
-void
+std::error_code
 tcp_acceptor::
 listen(endpoint ep, int backlog)
 {
     if (impl_)
         close();
 
+    std::error_code ec;
+
 #if BOOST_COROSIO_HAS_IOCP
     auto& svc = ctx_->use_service<detail::win_sockets>();
     auto& wrapper = svc.create_acceptor_impl();
     impl_ = &wrapper;
-    std::error_code ec = svc.open_acceptor(
-        *wrapper.get_internal(), ep, backlog);
+    ec = svc.open_acceptor(*wrapper.get_internal(), ep, backlog);
 #else
     // POSIX backends use abstract acceptor_service for runtime polymorphism.
     // The concrete service (epoll_sockets or select_sockets) must be installed
     // by the context constructor before any acceptor operations.
     auto* svc = ctx_->find_service<detail::acceptor_service>();
     if (!svc)
-        detail::throw_logic_error("tcp_acceptor::listen: no acceptor service installed");
+    {
+        // Should not happen with properly constructed io_context
+        return make_error_code(std::errc::operation_not_supported);
+    }
     auto& wrapper = svc->create_acceptor_impl();
     impl_ = &wrapper;
-    std::error_code ec = svc->open_acceptor(wrapper, ep, backlog);
+    ec = svc->open_acceptor(wrapper, ep, backlog);
 #endif
+    // Both branches above define 'wrapper' as a reference to the impl
     if (ec)
     {
         wrapper.release();
         impl_ = nullptr;
-        detail::throw_system_error(ec, "tcp_acceptor::listen");
     }
+    return ec;
 }
 
 void

--- a/src/corosio/src/tcp_server.cpp
+++ b/src/corosio/src/tcp_server.cpp
@@ -93,9 +93,10 @@ std::error_code
 tcp_server::bind(endpoint ep)
 {
     impl_->ports.emplace_back(impl_->ctx);
-    // VFALCO this should return error_code
-    impl_->ports.back().listen(ep);
-    return {};
+    auto ec = impl_->ports.back().listen(ep);
+    if (ec)
+        impl_->ports.pop_back();
+    return ec;
 }
 
 void

--- a/src/corosio/src/test/mocket.cpp
+++ b/src/corosio/src/test/mocket.cpp
@@ -152,7 +152,9 @@ make_mocket_pair(
 
     // Use ephemeral port (0) - OS assigns an available port
     tcp_acceptor acc(ctx);
-    acc.listen(endpoint(ipv4_address::loopback(), 0));
+    auto listen_ec = acc.listen(endpoint(ipv4_address::loopback(), 0));
+    if (listen_ec)
+        throw std::runtime_error("mocket listen failed: " + listen_ec.message());
     auto port = acc.local_endpoint().port();
 
     // Open peer socket for connect

--- a/src/corosio/src/test/socket_pair.cpp
+++ b/src/corosio/src/test/socket_pair.cpp
@@ -32,7 +32,8 @@ make_socket_pair(basic_io_context& ctx)
 
     // Use ephemeral port (0) - OS assigns an available port
     tcp_acceptor acc(ctx);
-    acc.listen(endpoint(ipv4_address::loopback(), 0));
+    if (auto ec = acc.listen(endpoint(ipv4_address::loopback(), 0)))
+        throw std::runtime_error("socket_pair listen failed: " + ec.message());
     auto port = acc.local_endpoint().port();
 
     tcp_socket s1(ctx);

--- a/test/unit/acceptor.cpp
+++ b/test/unit/acceptor.cpp
@@ -53,7 +53,8 @@ struct acceptor_test_impl
         tcp_acceptor acc(ioc);
 
         // Listen on a port
-        acc.listen(endpoint(0));  // Port 0 = ephemeral port
+        auto ec = acc.listen(endpoint(0));  // Port 0 = ephemeral port
+        BOOST_TEST(!ec);
         BOOST_TEST_EQ(acc.is_open(), true);
 
         // Close it
@@ -66,7 +67,8 @@ struct acceptor_test_impl
     {
         Context ioc;
         tcp_acceptor acc1(ioc);
-        acc1.listen(endpoint(0));
+        auto ec = acc1.listen(endpoint(0));
+        BOOST_TEST(!ec);
         BOOST_TEST_EQ(acc1.is_open(), true);
 
         // Move construct
@@ -83,7 +85,8 @@ struct acceptor_test_impl
         Context ioc;
         tcp_acceptor acc1(ioc);
         tcp_acceptor acc2(ioc);
-        acc1.listen(endpoint(0));
+        auto ec = acc1.listen(endpoint(0));
+        BOOST_TEST(!ec);
         BOOST_TEST_EQ(acc1.is_open(), true);
         BOOST_TEST_EQ(acc2.is_open(), false);
 
@@ -107,7 +110,8 @@ struct acceptor_test_impl
         // acceptor impl alive until IOCP delivers the cancellation.
         Context ioc;
         tcp_acceptor acc(ioc);
-        acc.listen(endpoint(0));
+        auto ec = acc.listen(endpoint(0));
+        BOOST_TEST(!ec);
 
         // These must outlive the coroutines
         bool accept_done = false;
@@ -158,7 +162,8 @@ struct acceptor_test_impl
         // The acceptor_ptr shared_ptr in accept_op ensures this.
         Context ioc;
         tcp_acceptor acc(ioc);
-        acc.listen(endpoint(0));
+        auto ec = acc.listen(endpoint(0));
+        BOOST_TEST(!ec);
 
         tcp_socket peer(ioc);
         bool accept_done = false;

--- a/test/unit/socket.cpp
+++ b/test/unit/socket.cpp
@@ -86,17 +86,13 @@ make_socket_pair_t(Context& ctx)
     for (int attempt = 0; attempt < 20; ++attempt)
     {
         port = get_socket_test_port();
-        try
+        if (!acc.listen(endpoint(ipv4_address::loopback(), port)))
         {
-            acc.listen(endpoint(ipv4_address::loopback(), port));
             listening = true;
             break;
         }
-        catch (const std::system_error&)
-        {
-            acc.close();
-            acc = tcp_acceptor(ctx);
-        }
+        acc.close();
+        acc = tcp_acceptor(ctx);
     }
     if (!listening)
         throw std::runtime_error("socket_pair: failed to find available port");
@@ -1202,7 +1198,8 @@ struct socket_test_impl
         tcp_acceptor acc(ioc);
 
         // Bind to loopback with port 0 (ephemeral)
-        acc.listen(endpoint(ipv4_address::loopback(), 0));
+        auto listen_ec = acc.listen(endpoint(ipv4_address::loopback(), 0));
+        BOOST_TEST(!listen_ec);
 
         // Acceptor's local endpoint should have a non-zero OS-assigned port
         auto acc_local = acc.local_endpoint();
@@ -1272,18 +1269,14 @@ struct socket_test_impl
         bool found = false;
         for (int attempt = 0; attempt < 100; ++attempt)
         {
-            try
+            if (!acc.listen(endpoint(ipv4_address::loopback(), test_port)))
             {
-                acc.listen(endpoint(ipv4_address::loopback(), test_port));
                 found = true;
                 break;
             }
-            catch (const std::system_error&)
-            {
-                acc.close();
-                acc = tcp_acceptor(ioc);
-                test_port += fast_rand();
-            }
+            acc.close();
+            acc = tcp_acceptor(ioc);
+            test_port += fast_rand();
         }
         if (!found)
         {

--- a/test/unit/socket_stress.cpp
+++ b/test/unit/socket_stress.cpp
@@ -100,17 +100,13 @@ make_stress_pair(Context& ctx)
     for (int attempt = 0; attempt < 50; ++attempt)
     {
         port = get_stress_port();
-        try
+        if (!acc.listen(endpoint(ipv4_address::loopback(), port)))
         {
-            acc.listen(endpoint(ipv4_address::loopback(), port));
             listening = true;
             break;
         }
-        catch (const std::system_error&)
-        {
-            acc.close();
-            acc = tcp_acceptor(ctx);
-        }
+        acc.close();
+        acc = tcp_acceptor(ctx);
     }
     if (!listening)
         throw std::runtime_error("stress_pair: failed to find available port");
@@ -663,17 +659,13 @@ struct accept_stress_test_impl
         for (int attempt = 0; attempt < 50; ++attempt)
         {
             port = get_stress_port();
-            try
+            if (!acc.listen(endpoint(ipv4_address::loopback(), port)))
             {
-                acc.listen(endpoint(ipv4_address::loopback(), port));
                 listening = true;
                 break;
             }
-            catch (const std::system_error&)
-            {
-                acc.close();
-                acc = tcp_acceptor(ioc);
-            }
+            acc.close();
+            acc = tcp_acceptor(ioc);
         }
         if (!listening)
         {

--- a/test/unit/tcp_server.cpp
+++ b/test/unit/tcp_server.cpp
@@ -133,16 +133,10 @@ struct tcp_server_test
         for(int attempt = 0; attempt < 20; ++attempt)
         {
             port = static_cast<std::uint16_t>(49152 + (attempt * 7) % 16383);
-            try
-            {
-                acc.listen(endpoint(ipv4_address::loopback(), port));
+            if (!acc.listen(endpoint(ipv4_address::loopback(), port)))
                 break;
-            }
-            catch(std::system_error const&)
-            {
-                acc.close();
-                acc = tcp_acceptor(ioc);
-            }
+            acc.close();
+            acc = tcp_acceptor(ioc);
         }
         acc.close();
 
@@ -284,16 +278,10 @@ struct tcp_server_test
         for(int attempt = 0; attempt < 20; ++attempt)
         {
             port = static_cast<std::uint16_t>(49152 + (attempt * 7) % 16383);
-            try
-            {
-                acc.listen(endpoint(ipv4_address::loopback(), port));
+            if (!acc.listen(endpoint(ipv4_address::loopback(), port)))
                 break;
-            }
-            catch(std::system_error const&)
-            {
-                acc.close();
-                acc = tcp_acceptor(ioc);
-            }
+            acc.close();
+            acc = tcp_acceptor(ioc);
         }
         acc.close();
 
@@ -437,6 +425,81 @@ struct tcp_server_test
     }
 
     void
+    testListenErrorCode()
+    {
+        io_context ioc;
+
+        // Test success case
+        tcp_acceptor acc1(ioc);
+        auto ec1 = acc1.listen(endpoint(ipv4_address::loopback(), 0));
+        BOOST_TEST(!ec1);
+        BOOST_TEST(acc1.is_open());
+        auto port = acc1.local_endpoint().port();
+        BOOST_TEST(port != 0);
+
+        // Test with explicit backlog
+        tcp_acceptor acc2(ioc);
+        auto ec2 = acc2.listen(endpoint(ipv4_address::loopback(), 0), 64);
+        BOOST_TEST(!ec2);
+        BOOST_TEST(acc2.is_open());
+        BOOST_TEST(acc2.local_endpoint().port() != 0);
+    }
+
+    void
+    testBindSuccess()
+    {
+        io_context ioc;
+
+        // Test that tcp_server::bind returns no error and doesn't throw
+        test_server srv(ioc);
+        auto ec = srv.bind(endpoint(ipv4_address::loopback(), 0));
+        BOOST_TEST(!ec);
+    }
+
+    void
+    testListenErrorNonLocalAddress()
+    {
+        io_context ioc;
+
+        // Binding to a non-local IP address should fail with
+        // "can't assign requested address" (EADDRNOTAVAIL) on all platforms.
+        // 192.0.2.1 is from TEST-NET-1 (RFC 5737), reserved for documentation
+        // and never assigned to real interfaces.
+        tcp_acceptor acc(ioc);
+        auto ec = acc.listen(endpoint(ipv4_address({192, 0, 2, 1}), 0));
+        BOOST_TEST(ec);
+        BOOST_TEST(!acc.is_open());
+    }
+
+    void
+    testBindErrorNonLocalAddress()
+    {
+        io_context ioc;
+
+        // tcp_server::bind should return an error for non-local address
+        test_server srv(ioc);
+        auto ec = srv.bind(endpoint(ipv4_address({192, 0, 2, 1}), 0));
+        BOOST_TEST(ec);
+    }
+
+    void
+    testListenOnOpenAcceptor()
+    {
+        io_context ioc;
+        tcp_acceptor acc(ioc);
+
+        // First listen
+        auto ec1 = acc.listen(endpoint(ipv4_address::loopback(), 0));
+        BOOST_TEST(!ec1);
+        BOOST_TEST(acc.is_open());
+
+        // Re-listen should close and reopen
+        auto ec2 = acc.listen(endpoint(ipv4_address::loopback(), 0));
+        BOOST_TEST(!ec2);
+        BOOST_TEST(acc.is_open());
+    }
+
+    void
     run()
     {
         testStopServer();
@@ -446,6 +509,11 @@ struct tcp_server_test
         testStopWithoutStart();
         testRestart();
         testStartWithoutJoinThrows();
+        testListenErrorCode();
+        testBindSuccess();
+        testListenErrorNonLocalAddress();
+        testBindErrorNonLocalAddress();
+        testListenOnOpenAcceptor();
     }
 };
 


### PR DESCRIPTION
tcp_server::bind() was documented to return std::error_code but internally called the throwing tcp_acceptor::listen() overload, violating its API contract.

Add non-throwing listen() overloads to tcp_acceptor that take std::error_code& as the last parameter, following Boost.Asio conventions. The throwing overload now delegates to the non-throwing implementation.

Changes:
- Add tcp_acceptor::listen(endpoint, std::error_code&)
- Add tcp_acceptor::listen(endpoint, int backlog, std::error_code&)
- Update tcp_server::bind() to use the non-throwing overload
- Add tests for success and failure paths using TEST-NET-1 addresses
- Add test for listen() on already-open acceptor behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling in TCP server operations by shifting from exception-based to error-code-based approach. Error codes must now be checked and are properly propagated through the network stack for better error detection and control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->