### PR TITLE
Add speculative completion fast path for socket I/O

### DIFF
--- a/src/corosio/src/detail/epoll/scheduler.cpp
+++ b/src/corosio/src/detail/epoll/scheduler.cpp
@@ -20,7 +20,6 @@
 #include <boost/corosio/detail/except.hpp>
 #include <boost/corosio/detail/thread_local_ptr.hpp>
 
-#include <atomic>
 #include <chrono>
 #include <limits>
 #include <utility>
@@ -337,7 +336,7 @@ epoll_scheduler(
             [](void* p) {
                 auto* self = static_cast<epoll_scheduler*>(p);
                 self->timerfd_stale_.store(true, std::memory_order_release);
-                if (self->task_running_.load(std::memory_order_relaxed))
+                if (self->task_running_.load(std::memory_order_acquire))
                     self->interrupt_reactor();
             }));
 
@@ -409,7 +408,6 @@ post(capy::coro h) const
         {
             auto h = h_;
             delete this;
-            std::atomic_thread_fence(std::memory_order_acquire);
             h.resume();
         }
 
@@ -1014,7 +1012,7 @@ do_one(std::unique_lock<std::mutex>& lock, long timeout_us, scheduler_context* c
             }
 
             task_interrupted_ = more_handlers || timeout_us == 0;
-            task_running_.store(true, std::memory_order_relaxed);
+            task_running_.store(true, std::memory_order_release);
 
             if (more_handlers)
                 unlock_and_signal_one(lock);

--- a/src/corosio/src/detail/epoll/sockets.cpp
+++ b/src/corosio/src/detail/epoll/sockets.cpp
@@ -433,7 +433,34 @@ read_some(
         op.iovecs[i].iov_len = bufs[i].size();
     }
 
-    // Symmetric transfer ensures caller is suspended before I/O starts
+    // Speculative read: bypass initiator when data is ready
+    ssize_t n;
+    do {
+        n = ::readv(fd_, op.iovecs, op.iovec_count);
+    } while (n < 0 && errno == EINTR);
+
+    if (n > 0)
+    {
+        op.complete(0, static_cast<std::size_t>(n));
+        svc_.post(&op);
+        return std::noop_coroutine();
+    }
+
+    if (n == 0)
+    {
+        op.complete(0, 0);
+        svc_.post(&op);
+        return std::noop_coroutine();
+    }
+
+    if (errno != EAGAIN && errno != EWOULDBLOCK)
+    {
+        op.complete(errno, 0);
+        svc_.post(&op);
+        return std::noop_coroutine();
+    }
+
+    // EAGAIN — full async path
     return read_initiator_.start<&epoll_socket_impl::do_read_io>(this);
 }
 
@@ -457,7 +484,6 @@ write_some(
     op.start(token, this);
     op.impl_ptr = shared_from_this();
 
-    // Must prepare buffers before initiator runs
     capy::mutable_buffer bufs[epoll_write_op::max_buffers];
     op.iovec_count = static_cast<int>(param.copy_to(bufs, epoll_write_op::max_buffers));
 
@@ -474,7 +500,38 @@ write_some(
         op.iovecs[i].iov_len = bufs[i].size();
     }
 
-    // Symmetric transfer ensures caller is suspended before I/O starts
+    // Speculative write: bypass initiator when buffer space is ready
+    msghdr msg{};
+    msg.msg_iov = op.iovecs;
+    msg.msg_iovlen = static_cast<std::size_t>(op.iovec_count);
+
+    ssize_t n;
+    do {
+        n = ::sendmsg(fd_, &msg, MSG_NOSIGNAL);
+    } while (n < 0 && errno == EINTR);
+
+    if (n > 0)
+    {
+        op.complete(0, static_cast<std::size_t>(n));
+        svc_.post(&op);
+        return std::noop_coroutine();
+    }
+
+    if (n == 0)
+    {
+        op.complete(0, 0);
+        svc_.post(&op);
+        return std::noop_coroutine();
+    }
+
+    if (errno != EAGAIN && errno != EWOULDBLOCK)
+    {
+        op.complete(errno, 0);
+        svc_.post(&op);
+        return std::noop_coroutine();
+    }
+
+    // EAGAIN — full async path
     return write_initiator_.start<&epoll_socket_impl::do_write_io>(this);
 }
 


### PR DESCRIPTION
Try readv/sendmsg before launching the initiator coroutine in read_some and write_some. When data is immediately available, this skips the initiator coroutine create/destroy, descriptor state mutex lock, and the retry loop in do_read_io/do_write_io. On EAGAIN, falls through to the existing async path unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster socket I/O: added a speculative fast path that completes reads/writes immediately when data is ready, reducing latency.

* **Bug Fixes**
  * Improved internal synchronization for reactor/timer handling to make task interruption and scheduling more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->