### PR TITLE
Add kqueue backend

### DIFF
--- a/include/boost/corosio/io_context.hpp
+++ b/include/boost/corosio/io_context.hpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -25,7 +26,7 @@
 #endif
 
 #if BOOST_COROSIO_HAS_KQUEUE
-// #include <boost/corosio/kqueue_context.hpp>
+#include <boost/corosio/kqueue_context.hpp>
 #endif
 
 #if BOOST_COROSIO_HAS_SELECT
@@ -43,8 +44,8 @@ namespace boost::corosio {
     This is a type alias for the platform's default I/O backend:
     - Windows: `iocp_context` (I/O Completion Ports)
     - Linux: `epoll_context` (epoll)
-    - BSD/macOS: `kqueue_context` (kqueue) [future]
-    - Other POSIX: `select_context` (select) [future]
+    - BSD/macOS: `kqueue_context` (kqueue) (macOS verified, BSD future)
+    - Other POSIX: `select_context` (select)
 
     For explicit backend selection, use the concrete context types
     directly (e.g., `epoll_context`, `iocp_context`).
@@ -82,8 +83,7 @@ using io_context = iocp_context;
 #elif BOOST_COROSIO_HAS_EPOLL
 using io_context = epoll_context;
 #elif BOOST_COROSIO_HAS_KQUEUE
-// using io_context = kqueue_context;
-using io_context = select_context;  // fallback until kqueue implemented
+using io_context = kqueue_context;
 #elif BOOST_COROSIO_HAS_SELECT
 using io_context = select_context;
 #endif

--- a/include/boost/corosio/kqueue_context.hpp
+++ b/include/boost/corosio/kqueue_context.hpp
@@ -1,0 +1,89 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_KQUEUE_CONTEXT_HPP
+#define BOOST_COROSIO_KQUEUE_CONTEXT_HPP
+
+#include <boost/corosio/detail/config.hpp>
+#include <boost/corosio/detail/platform.hpp>
+
+#if BOOST_COROSIO_HAS_KQUEUE
+
+#include <boost/corosio/basic_io_context.hpp>
+
+namespace boost::corosio {
+
+/** I/O context using BSD kqueue for event multiplexing.
+
+    This context provides an execution environment for async operations
+    using the BSD kqueue API for efficient I/O event notification.
+    It maintains a queue of pending work items and processes them when
+    `run()` is called.
+
+    @par Thread Safety
+    Distinct objects: Safe.@n
+    Shared objects: Safe. Internal synchronization is always present
+    regardless of the concurrency hint.
+
+    @par Example
+    @code
+    kqueue_context ctx;
+    auto ex = ctx.get_executor();
+    run_async(ex)(my_coroutine());
+    ctx.run();  // Process all queued work
+    @endcode
+
+    @see basic_io_context, basic_io_context::get_executor,
+         basic_io_context::run, capy::execution_context
+*/
+class BOOST_COROSIO_DECL kqueue_context : public basic_io_context
+{
+public:
+    /** Construct a kqueue_context with default concurrency.
+
+        The concurrency hint is set to the number of hardware threads
+        available on the system. If more than one thread is available,
+        thread-safe synchronization is used.
+
+        @throws std::system_error if creating the kqueue file descriptor
+            or registering the EVFILT_USER interrupt event fails.
+    */
+    kqueue_context();
+
+    /** Construct a kqueue_context with a concurrency hint.
+
+        @param concurrency_hint A hint for the number of threads that
+            will call `run()`. If greater than 1, thread-safe
+            synchronization is used internally.
+
+        @throws std::system_error if creating the kqueue file descriptor
+            or registering the EVFILT_USER interrupt event fails.
+    */
+    explicit
+    kqueue_context(unsigned concurrency_hint);
+
+    /** Destructor.
+
+        Calls `shutdown()` and `destroy()` to release all resources.
+        Does not throw.
+    */
+    ~kqueue_context();
+
+    // Non-copyable, non-movable
+    kqueue_context(kqueue_context const&) = delete;
+    kqueue_context& operator=(kqueue_context const&) = delete;
+    kqueue_context(kqueue_context&&) = delete;
+    kqueue_context& operator=(kqueue_context&&) = delete;
+};
+
+} // namespace boost::corosio
+
+#endif // BOOST_COROSIO_HAS_KQUEUE
+
+#endif // BOOST_COROSIO_KQUEUE_CONTEXT_HPP

--- a/perf/common/backend_selection.hpp
+++ b/perf/common/backend_selection.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -77,6 +78,16 @@ int dispatch_backend(const char* backend, Func&& func)
         func([]() -> std::unique_ptr<corosio::basic_io_context> {
             return std::make_unique<corosio::epoll_context>();
         }, "epoll");
+        return 0;
+    }
+#endif
+
+#if BOOST_COROSIO_HAS_KQUEUE
+    if (std::strcmp(backend, "kqueue") == 0)
+    {
+        func([]() -> std::unique_ptr<corosio::basic_io_context> {
+            return std::make_unique<corosio::kqueue_context>();
+        }, "kqueue");
         return 0;
     }
 #endif

--- a/src/corosio/src/detail/kqueue/acceptors.cpp
+++ b/src/corosio/src/detail/kqueue/acceptors.cpp
@@ -1,0 +1,572 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#include <boost/corosio/detail/platform.hpp>
+
+#if BOOST_COROSIO_HAS_KQUEUE
+
+#include "src/detail/kqueue/acceptors.hpp"
+#include "src/detail/kqueue/sockets.hpp"
+#include "src/detail/endpoint_convert.hpp"
+#include "src/detail/make_err.hpp"
+#include "src/detail/resume_coro.hpp"
+
+#include <utility>
+
+/*
+    kqueue async accept implementation
+    ===================================
+
+    kqueue_acceptor_impl registers its listening fd with kqueue once
+    (EVFILT_READ, EV_CLEAR for edge-triggered semantics) via
+    desc_state_. A single accept operation can be pending at a time,
+    stored in desc_state_.read_op since accept is a read-like event.
+
+    Async accept control flow
+    -------------------------
+    accept() first attempts a synchronous ::accept(). On EAGAIN the
+    ready flag is checked under the desc_state_ mutex: if set, a retry
+    loop calls perform_io() until the accept succeeds or the flag is
+    exhausted. Otherwise the op is parked in desc_state_.read_op for
+    the reactor to wake later. After parking, a cancellation race-check
+    reclaims the op if a stop was requested between parking and the
+    check.
+
+    Completion and coroutine resumption
+    ------------------------------------
+    kqueue_accept_op::operator()() runs on the scheduler thread. On
+    success it creates a kqueue_socket_impl for the accepted fd,
+    registers it with kqueue, sets SO_NOSIGPIPE, and caches both
+    endpoints. The coroutine is resumed via saved_ex.dispatch() after
+    all member state has been moved to stack locals.
+
+    Lifetime management
+    -------------------
+    shared_from_this() is captured in op.impl_ptr whenever an op is
+    posted to the scheduler. This shared_ptr prevents the acceptor
+    impl from being destroyed while completions are in flight. The
+    desc_state_.impl_ref_ similarly prevents destruction while the
+    descriptor_state itself is enqueued in the scheduler's ready queue.
+
+    Cancellation
+    ------------
+    cancel() and cancel_single_op() set the cancelled flag, then claim
+    the op from desc_state_.read_op under the mutex. If claimed, the
+    op is posted for completion with a cancelled error code and the
+    extra work_started() from registration is balanced by work_finished().
+*/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace boost::corosio::detail {
+
+void
+kqueue_accept_op::
+cancel() noexcept
+{
+    if (acceptor_impl_)
+        acceptor_impl_->cancel_single_op(*this);
+    else
+        request_cancel();
+}
+
+void
+kqueue_accept_op::
+operator()()
+{
+    stop_cb.reset();
+
+    bool success = (errn == 0 && !cancelled.load(std::memory_order_acquire));
+
+    if (ec_out)
+    {
+        if (cancelled.load(std::memory_order_acquire))
+            *ec_out = capy::error::canceled;
+        else if (errn != 0)
+            *ec_out = make_err(errn);
+        else
+            *ec_out = {};
+    }
+
+    if (success && accepted_fd >= 0)
+    {
+        if (acceptor_impl_)
+        {
+            auto* socket_svc = static_cast<kqueue_acceptor_impl*>(acceptor_impl_)
+                ->service().socket_service();
+            if (socket_svc)
+            {
+                auto& impl = static_cast<kqueue_socket_impl&>(socket_svc->create_impl());
+                impl.set_socket(accepted_fd);
+
+                // Register accepted socket with kqueue (edge-triggered via EV_CLEAR)
+                impl.desc_state_.fd = accepted_fd;
+                {
+                    std::lock_guard lock(impl.desc_state_.mutex);
+                    impl.desc_state_.read_op = nullptr;
+                    impl.desc_state_.write_op = nullptr;
+                    impl.desc_state_.connect_op = nullptr;
+                }
+                socket_svc->scheduler().register_descriptor(accepted_fd, &impl.desc_state_);
+
+                // Suppress SIGPIPE on the accepted socket; macOS lacks MSG_NOSIGNAL
+                int one = 1;
+                if (::setsockopt(accepted_fd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one)) == -1)
+                {
+                    if (ec_out)
+                        *ec_out = make_err(errno);
+                    ::close(accepted_fd);
+                    accepted_fd = -1;
+                    socket_svc->destroy_impl(impl);
+                    if (impl_out)
+                        *impl_out = nullptr;
+                }
+                else
+                {
+                    sockaddr_in local_addr{};
+                    socklen_t local_len = sizeof(local_addr);
+                    sockaddr_in remote_addr{};
+                    socklen_t remote_len = sizeof(remote_addr);
+
+                    endpoint local_ep, remote_ep;
+                    if (::getsockname(accepted_fd, reinterpret_cast<sockaddr*>(&local_addr), &local_len) == 0)
+                        local_ep = from_sockaddr_in(local_addr);
+                    if (::getpeername(accepted_fd, reinterpret_cast<sockaddr*>(&remote_addr), &remote_len) == 0)
+                        remote_ep = from_sockaddr_in(remote_addr);
+
+                    impl.set_endpoints(local_ep, remote_ep);
+
+                    if (impl_out)
+                        *impl_out = &impl;
+
+                    accepted_fd = -1;
+                }
+            }
+            else
+            {
+                // Socket service not registered in execution_context
+                if (ec_out && !*ec_out)
+                    *ec_out = make_err(ENOENT);
+                ::close(accepted_fd);
+                accepted_fd = -1;
+                if (impl_out)
+                    *impl_out = nullptr;
+            }
+        }
+        else
+        {
+            ::close(accepted_fd);
+            accepted_fd = -1;
+            if (impl_out)
+                *impl_out = nullptr;
+        }
+    }
+    else
+    {
+        if (accepted_fd >= 0)
+        {
+            ::close(accepted_fd);
+            accepted_fd = -1;
+        }
+
+        if (peer_impl)
+        {
+            peer_impl->release();
+            peer_impl = nullptr;
+        }
+
+        if (impl_out)
+            *impl_out = nullptr;
+    }
+
+    // Move to stack before resuming. See kqueue_op::operator()() for rationale.
+    capy::executor_ref saved_ex( std::move( ex ) );
+    capy::coro saved_h( std::move( h ) );
+    auto prevent_premature_destruction = std::move(impl_ptr);
+    resume_coro(saved_ex, saved_h);
+}
+
+kqueue_acceptor_impl::
+kqueue_acceptor_impl(kqueue_acceptor_service& svc) noexcept
+    : svc_(svc)
+{
+}
+
+void
+kqueue_acceptor_impl::
+release()
+{
+    close_socket();
+    svc_.destroy_acceptor_impl(*this);
+}
+
+std::coroutine_handle<>
+kqueue_acceptor_impl::
+accept(
+    std::coroutine_handle<> h,
+    capy::executor_ref ex,
+    std::stop_token token,
+    std::error_code* ec,
+    io_object::io_object_impl** impl_out)
+{
+    auto& op = acc_;
+    op.reset();
+    op.h = h;
+    op.ex = ex;
+    op.ec_out = ec;
+    op.impl_out = impl_out;
+    op.fd = fd_;
+    op.start(token, this);
+
+    sockaddr_in addr{};
+    socklen_t addrlen = sizeof(addr);
+
+    // FreeBSD: Can use accept4(fd_, addr, addrlen, SOCK_NONBLOCK | SOCK_CLOEXEC)
+    int accepted = ::accept(fd_, reinterpret_cast<sockaddr*>(&addr), &addrlen);
+
+    if (accepted >= 0)
+    {
+        // Set non-blocking and close-on-exec on the accepted socket
+        int flags = ::fcntl(accepted, F_GETFL, 0);
+        if (flags == -1 || ::fcntl(accepted, F_SETFL, flags | O_NONBLOCK) == -1)
+        {
+            int errn = errno;
+            ::close(accepted);
+            op.complete(errn, 0);
+            op.impl_ptr = shared_from_this();
+            svc_.post(&op);
+            return std::noop_coroutine();
+        }
+        if (::fcntl(accepted, F_SETFD, FD_CLOEXEC) == -1)
+        {
+            int errn = errno;
+            ::close(accepted);
+            op.complete(errn, 0);
+            op.impl_ptr = shared_from_this();
+            svc_.post(&op);
+            return std::noop_coroutine();
+        }
+
+        {
+            std::lock_guard lock(desc_state_.mutex);
+            desc_state_.read_ready = false;
+        }
+        op.accepted_fd = accepted;
+        op.complete(0, 0);
+        op.impl_ptr = shared_from_this();
+        svc_.post(&op);
+        return std::noop_coroutine();
+    }
+
+    if (errno == EAGAIN || errno == EWOULDBLOCK)
+    {
+        svc_.work_started();
+        op.impl_ptr = shared_from_this();
+
+        bool perform_now = false;
+        {
+            std::lock_guard lock(desc_state_.mutex);
+            if (desc_state_.read_ready)
+            {
+                desc_state_.read_ready = false;
+                perform_now = true;
+            }
+            else
+            {
+                desc_state_.read_op = &op;
+            }
+        }
+
+        if (perform_now)
+        {
+            for (;;)
+            {
+                op.perform_io();
+                if (op.errn != EAGAIN && op.errn != EWOULDBLOCK)
+                {
+                    svc_.post(&op);
+                    svc_.work_finished();
+                    break;
+                }
+                op.errn = 0;
+                std::lock_guard lock(desc_state_.mutex);
+                if (desc_state_.read_ready)
+                {
+                    desc_state_.read_ready = false;
+                    continue;
+                }
+                desc_state_.read_op = &op;
+                break;
+            }
+            return std::noop_coroutine();
+        }
+
+        if (op.cancelled.load(std::memory_order_acquire))
+        {
+            kqueue_op* claimed = nullptr;
+            {
+                std::lock_guard lock(desc_state_.mutex);
+                if (desc_state_.read_op == &op)
+                    claimed = std::exchange(desc_state_.read_op, nullptr);
+            }
+            if (claimed)
+            {
+                svc_.post(claimed);
+                svc_.work_finished();
+            }
+        }
+        return std::noop_coroutine();
+    }
+
+    op.complete(errno, 0);
+    op.impl_ptr = shared_from_this();
+    svc_.post(&op);
+    return std::noop_coroutine();
+}
+
+void
+kqueue_acceptor_impl::
+cancel() noexcept
+{
+    std::shared_ptr<kqueue_acceptor_impl> self;
+    try {
+        self = shared_from_this();
+    } catch (const std::bad_weak_ptr&) {
+        return;
+    }
+
+    acc_.request_cancel();
+
+    kqueue_op* claimed = nullptr;
+    {
+        std::lock_guard lock(desc_state_.mutex);
+        if (desc_state_.read_op == &acc_)
+            claimed = std::exchange(desc_state_.read_op, nullptr);
+    }
+    if (claimed)
+    {
+        acc_.impl_ptr = self;
+        svc_.post(&acc_);
+        svc_.work_finished();
+    }
+}
+
+void
+kqueue_acceptor_impl::
+cancel_single_op(kqueue_op& op) noexcept
+{
+    op.request_cancel();
+
+    kqueue_op* claimed = nullptr;
+    {
+        std::lock_guard lock(desc_state_.mutex);
+        if (desc_state_.read_op == &op)
+            claimed = std::exchange(desc_state_.read_op, nullptr);
+    }
+    if (claimed)
+    {
+        try {
+            op.impl_ptr = shared_from_this();
+        } catch (const std::bad_weak_ptr&) {}
+        svc_.post(&op);
+        svc_.work_finished();
+    }
+}
+
+void
+kqueue_acceptor_impl::
+close_socket() noexcept
+{
+    cancel();
+
+    if (desc_state_.is_enqueued_.load(std::memory_order_acquire))
+    {
+        try {
+            desc_state_.impl_ref_ = shared_from_this();
+        } catch (std::bad_weak_ptr const&) {}
+    }
+
+    if (fd_ >= 0)
+    {
+        if (desc_state_.registered_events != 0)
+            svc_.scheduler().deregister_descriptor(fd_);
+        ::close(fd_);
+        fd_ = -1;
+    }
+
+    desc_state_.fd = -1;
+    {
+        std::lock_guard lock(desc_state_.mutex);
+        desc_state_.read_op = nullptr;
+        desc_state_.read_ready = false;
+        desc_state_.write_ready = false;
+    }
+    desc_state_.registered_events = 0;
+
+    local_endpoint_ = endpoint{};
+}
+
+kqueue_acceptor_service::
+kqueue_acceptor_service(capy::execution_context& ctx)
+    : ctx_(ctx)
+    , state_(std::make_unique<kqueue_acceptor_state>(ctx.use_service<kqueue_scheduler>()))
+{
+}
+
+kqueue_acceptor_service::
+~kqueue_acceptor_service() = default;
+
+void
+kqueue_acceptor_service::
+shutdown()
+{
+    std::lock_guard lock(state_->mutex_);
+
+    while (auto* impl = state_->acceptor_list_.pop_front())
+        impl->close_socket();
+
+    state_->acceptor_ptrs_.clear();
+}
+
+tcp_acceptor::acceptor_impl&
+kqueue_acceptor_service::
+create_acceptor_impl()
+{
+    auto impl = std::make_shared<kqueue_acceptor_impl>(*this);
+    auto* raw = impl.get();
+
+    std::lock_guard lock(state_->mutex_);
+    state_->acceptor_list_.push_back(raw);
+    state_->acceptor_ptrs_.emplace(raw, std::move(impl));
+
+    return *raw;
+}
+
+void
+kqueue_acceptor_service::
+destroy_acceptor_impl(tcp_acceptor::acceptor_impl& impl)
+{
+    auto* kq_impl = static_cast<kqueue_acceptor_impl*>(&impl);
+    std::lock_guard lock(state_->mutex_);
+    state_->acceptor_list_.remove(kq_impl);
+    state_->acceptor_ptrs_.erase(kq_impl);
+}
+
+std::error_code
+kqueue_acceptor_service::
+open_acceptor(
+    tcp_acceptor::acceptor_impl& impl,
+    endpoint ep,
+    int backlog)
+{
+    auto* kq_impl = static_cast<kqueue_acceptor_impl*>(&impl);
+    kq_impl->close_socket();
+
+    // FreeBSD: Can use socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0)
+    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0)
+        return make_err(errno);
+
+    // Set non-blocking
+    int flags = ::fcntl(fd, F_GETFL, 0);
+    if (flags == -1)
+    {
+        int errn = errno;
+        ::close(fd);
+        return make_err(errn);
+    }
+    if (::fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1)
+    {
+        int errn = errno;
+        ::close(fd);
+        return make_err(errn);
+    }
+
+    // Set close-on-exec
+    if (::fcntl(fd, F_SETFD, FD_CLOEXEC) == -1)
+    {
+        int errn = errno;
+        ::close(fd);
+        return make_err(errn);
+    }
+
+    // Best-effort: failure only affects TIME_WAIT address reuse
+    int reuse = 1;
+    (void)::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+
+    sockaddr_in addr = detail::to_sockaddr_in(ep);
+    if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0)
+    {
+        int errn = errno;
+        ::close(fd);
+        return make_err(errn);
+    }
+
+    if (::listen(fd, backlog) < 0)
+    {
+        int errn = errno;
+        ::close(fd);
+        return make_err(errn);
+    }
+
+    kq_impl->fd_ = fd;
+
+    // Register fd with kqueue (edge-triggered via EV_CLEAR)
+    kq_impl->desc_state_.fd = fd;
+    {
+        std::lock_guard lock(kq_impl->desc_state_.mutex);
+        kq_impl->desc_state_.read_op = nullptr;
+    }
+    scheduler().register_descriptor(fd, &kq_impl->desc_state_);
+
+    // Cache the local endpoint (queries OS for ephemeral port if port was 0)
+    sockaddr_in local_addr{};
+    socklen_t local_len = sizeof(local_addr);
+    if (::getsockname(fd, reinterpret_cast<sockaddr*>(&local_addr), &local_len) == 0)
+        kq_impl->set_local_endpoint(detail::from_sockaddr_in(local_addr));
+
+    return {};
+}
+
+void
+kqueue_acceptor_service::
+post(kqueue_op* op)
+{
+    state_->sched_.post(op);
+}
+
+void
+kqueue_acceptor_service::
+work_started() noexcept
+{
+    state_->sched_.work_started();
+}
+
+void
+kqueue_acceptor_service::
+work_finished() noexcept
+{
+    state_->sched_.work_finished();
+}
+
+kqueue_socket_service*
+kqueue_acceptor_service::
+socket_service() const noexcept
+{
+    auto* svc = ctx_.find_service<detail::socket_service>();
+    return svc ? dynamic_cast<kqueue_socket_service*>(svc) : nullptr;
+}
+
+} // namespace boost::corosio::detail
+
+#endif // BOOST_COROSIO_HAS_KQUEUE

--- a/src/corosio/src/detail/kqueue/acceptors.hpp
+++ b/src/corosio/src/detail/kqueue/acceptors.hpp
@@ -1,0 +1,268 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_DETAIL_KQUEUE_ACCEPTORS_HPP
+#define BOOST_COROSIO_DETAIL_KQUEUE_ACCEPTORS_HPP
+
+#include <boost/corosio/detail/platform.hpp>
+
+#if BOOST_COROSIO_HAS_KQUEUE
+
+#include <boost/corosio/detail/config.hpp>
+#include <boost/corosio/tcp_acceptor.hpp>
+#include <boost/capy/ex/executor_ref.hpp>
+#include <boost/capy/ex/execution_context.hpp>
+#include "src/detail/intrusive.hpp"
+#include "src/detail/socket_service.hpp"
+
+#include "src/detail/kqueue/op.hpp"
+#include "src/detail/kqueue/scheduler.hpp"
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+/*
+    kqueue acceptor components:
+
+    kqueue_acceptor_impl   – per-listener state; owns the listening fd,
+                             a descriptor_state for edge-triggered readiness,
+                             and a single kqueue_accept_op slot (acc_).
+                             Inherits enable_shared_from_this so pending ops
+                             can prevent premature destruction.
+
+    kqueue_acceptor_state  – shared state for the service: an intrusive list
+                             of live acceptor impls, a shared_ptr map for
+                             ownership, and a mutex guarding both.
+
+    kqueue_acceptor_service – execution_context service keyed by
+                              acceptor_service (base class). Creates/destroys
+                              impls, opens listening sockets, and forwards
+                              post/work_started/work_finished to the scheduler.
+                              Shutdown walks the impl list and closes all fds.
+*/
+
+namespace boost::corosio::detail {
+
+class kqueue_acceptor_service;
+class kqueue_acceptor_impl;
+class kqueue_socket_service;
+
+/// Acceptor implementation for kqueue backend.
+class kqueue_acceptor_impl
+    : public tcp_acceptor::acceptor_impl
+    , public std::enable_shared_from_this<kqueue_acceptor_impl>
+    , public intrusive_list<kqueue_acceptor_impl>::node
+{
+    friend class kqueue_acceptor_service;
+
+public:
+    explicit kqueue_acceptor_impl(kqueue_acceptor_service& svc) noexcept;
+
+    void release() override;
+
+    /** Initiate an asynchronous accept on the listening socket.
+
+        Attempts a synchronous accept first. If the socket would block
+        (EAGAIN), the operation is parked in desc_state_ until the
+        reactor delivers a read-readiness event, at which point the
+        accept is retried. On completion (success, error, or
+        cancellation) the operation is posted to the scheduler and
+        @a caller is resumed via @a ex.
+
+        Only one accept may be outstanding at a time; overlapping
+        calls produce undefined behavior.
+
+        @param caller Coroutine handle resumed on completion. The
+            caller must remain valid until completion.
+        @param ex Executor through which @a caller is resumed.
+        @param token Stop token for cancellation. When stop is
+            requested, the pending op completes with
+            capy::error::canceled. Cancellation is asynchronous;
+            the op may complete with success if the accept races
+            ahead of the stop request.
+        @param ec Points to storage for the result error code.
+            Must remain valid until the completion handler runs.
+            Set to {} on success, capy::error::canceled on
+            cancellation, or a POSIX errno mapping on failure.
+        @param out_impl Points to storage for the accepted socket
+            impl. Must remain valid until the completion handler
+            runs. Set to the new socket impl on success, nullptr
+            on error or cancellation.
+
+        @return std::noop_coroutine() unconditionally; the caller
+            is always resumed asynchronously via the scheduler.
+
+        @par Example
+        @code
+        std::error_code ec;
+        io_object::io_object_impl* peer = nullptr;
+        co_await acceptor_impl.accept(
+            my_handle, ex, stop_source.get_token(), &ec, &peer);
+        if (!ec)
+            // peer is a valid kqueue_socket_impl
+        @endcode
+    */
+    std::coroutine_handle<> accept(
+        std::coroutine_handle<> caller,
+        capy::executor_ref ex,
+        std::stop_token token,
+        std::error_code* ec,
+        io_object::io_object_impl** out_impl) override;
+
+    int native_handle() const noexcept { return fd_; }
+    endpoint local_endpoint() const noexcept override { return local_endpoint_; }
+    bool is_open() const noexcept { return fd_ >= 0; }
+
+    /** Cancel any pending accept operation.
+
+        If an accept is parked in desc_state_, it is extracted
+        under the descriptor mutex, posted to the scheduler, and
+        will complete with capy::error::canceled.
+
+        Safe to call from any thread. If no operation is pending,
+        this is a no-op.
+    */
+    void cancel() noexcept override;
+
+    /** Cancel a specific pending operation.
+
+        Called from the stop_token callback when cancellation is
+        requested during the window between parking the op and
+        the reactor delivering an event. Extracts @a op from
+        desc_state_ under the descriptor mutex if it matches.
+
+        Safe to call concurrently with the reactor thread.
+
+        @param op The operation to cancel.
+    */
+    void cancel_single_op(kqueue_op& op) noexcept;
+
+    /** Close the listening socket and cancel pending operations.
+
+        Calls cancel(), deregisters the fd from kqueue, closes
+        the fd, and resets descriptor state. If the descriptor_state
+        is enqueued in the scheduler's ready queue, the impl is
+        prevented from destruction via shared_from_this() until
+        the queued entry is processed.
+
+        Safe to call from any thread. After return, is_open()
+        returns false.
+    */
+    void close_socket() noexcept;
+    void set_local_endpoint(endpoint ep) noexcept { local_endpoint_ = ep; }
+
+    kqueue_acceptor_service& service() noexcept { return svc_; }
+
+private:
+    kqueue_acceptor_service& svc_;
+    kqueue_accept_op acc_;
+    descriptor_state desc_state_;
+    int fd_ = -1;
+    endpoint local_endpoint_;
+};
+
+/** State for kqueue acceptor service. */
+class kqueue_acceptor_state
+{
+    friend class kqueue_acceptor_service;
+
+public:
+    explicit kqueue_acceptor_state(kqueue_scheduler& sched) noexcept
+        : sched_(sched)
+    {
+    }
+
+private:
+    kqueue_scheduler& sched_;
+    std::mutex mutex_;
+    intrusive_list<kqueue_acceptor_impl> acceptor_list_;
+    std::unordered_map<kqueue_acceptor_impl*, std::shared_ptr<kqueue_acceptor_impl>> acceptor_ptrs_;
+};
+
+/** kqueue acceptor service implementation.
+
+    Inherits from acceptor_service to enable runtime polymorphism.
+    Uses key_type = acceptor_service for service lookup.
+*/
+class kqueue_acceptor_service : public acceptor_service
+{
+public:
+    explicit kqueue_acceptor_service(capy::execution_context& ctx);
+    ~kqueue_acceptor_service();
+
+    kqueue_acceptor_service(kqueue_acceptor_service const&) = delete;
+    kqueue_acceptor_service& operator=(kqueue_acceptor_service const&) = delete;
+
+    /** Synchronously close all acceptor fds and cancel pending ops.
+        Idempotent; called by the execution_context during teardown.
+    */
+    void shutdown() override;
+
+    /** Create a new acceptor impl owned by this service.
+        The returned tcp_acceptor::acceptor_impl must be destroyed
+        via destroy_acceptor_impl() or by shutdown().
+    */
+    tcp_acceptor::acceptor_impl& create_acceptor_impl() override;
+
+    /** Remove and destroy an impl previously returned by
+        create_acceptor_impl(). Closes the socket if still open.
+    */
+    void destroy_acceptor_impl(tcp_acceptor::acceptor_impl& impl) override;
+
+    /** Bind and listen on @p ep with the given @p backlog.
+        Registers the fd with kqueue on success and caches the
+        local endpoint. Returns a non-zero std::error_code on
+        any syscall failure (socket, bind, listen, fcntl).
+    */
+    std::error_code open_acceptor(
+        tcp_acceptor::acceptor_impl& impl,
+        endpoint ep,
+        int backlog) override;
+
+    kqueue_scheduler& scheduler() const noexcept { return state_->sched_; }
+
+    /** Post a completed operation to the scheduler for execution.
+
+        Forwards @a op to the scheduler's completion queue. The
+        scheduler takes ownership; the caller must not destroy
+        @a op after this call.
+
+        @param op Operation to enqueue. Must not be null.
+    */
+    void post(kqueue_op* op);
+
+    /** Increment the scheduler's outstanding work count.
+
+        Must be paired with a subsequent call to work_finished().
+        Keeps the scheduler's run() loop alive while the operation
+        is in flight. Thread-safe.
+    */
+    void work_started() noexcept;
+
+    /** Decrement the scheduler's outstanding work count.
+
+        Must be paired with a prior call to work_started(). When
+        the count reaches zero, the scheduler may stop. Thread-safe.
+    */
+    void work_finished() noexcept;
+
+    /** Get the socket service for creating peer sockets during accept. */
+    kqueue_socket_service* socket_service() const noexcept;
+
+private:
+    capy::execution_context& ctx_;
+    std::unique_ptr<kqueue_acceptor_state> state_;
+};
+
+} // namespace boost::corosio::detail
+
+#endif // BOOST_COROSIO_HAS_KQUEUE
+
+#endif // BOOST_COROSIO_DETAIL_KQUEUE_ACCEPTORS_HPP

--- a/src/corosio/src/detail/kqueue/op.hpp
+++ b/src/corosio/src/detail/kqueue/op.hpp
@@ -1,0 +1,439 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_DETAIL_KQUEUE_OP_HPP
+#define BOOST_COROSIO_DETAIL_KQUEUE_OP_HPP
+
+#include <boost/corosio/detail/platform.hpp>
+
+#if BOOST_COROSIO_HAS_KQUEUE
+
+#include <boost/corosio/detail/config.hpp>
+#include <boost/corosio/io_object.hpp>
+#include <boost/corosio/endpoint.hpp>
+#include <boost/capy/ex/executor_ref.hpp>
+#include <boost/capy/coro.hpp>
+#include <boost/capy/error.hpp>
+#include <system_error>
+
+#include "src/detail/make_err.hpp"
+#include "src/detail/resume_coro.hpp"
+#include "src/detail/scheduler_op.hpp"
+#include "src/detail/endpoint_convert.hpp"
+
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stop_token>
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+
+/*
+    kqueue Operation State
+    ======================
+
+    Each async I/O operation has a corresponding kqueue_op-derived struct that
+    holds the operation's state while it's in flight. The socket impl owns
+    fixed slots for each operation type (conn_, rd_, wr_), so only one
+    operation of each type can be pending per socket at a time.
+
+    Persistent Registration
+    -----------------------
+    File descriptors are registered with kqueue once (via descriptor_state) and
+    stay registered until closed. Uses EV_CLEAR for edge-triggered semantics
+    (equivalent to epoll's EPOLLET). The descriptor_state tracks which operations
+    are pending (read_op, write_op, connect_op). When an event arrives, the
+    reactor dispatches to the appropriate pending operation.
+
+    Impl Lifetime Management
+    ------------------------
+    When cancel() posts an op to the scheduler's ready queue, the socket impl
+    might be destroyed before the scheduler processes the op. The `impl_ptr`
+    member holds a shared_ptr to the impl, keeping it alive until the op
+    completes. This is set by cancel() and cleared in operator() after the
+    coroutine is resumed.
+
+    EOF Detection
+    -------------
+    For reads, 0 bytes with no error means EOF. But an empty user buffer also
+    returns 0 bytes. The `empty_buffer_read` flag distinguishes these cases.
+
+    SIGPIPE Prevention
+    ------------------
+    SO_NOSIGPIPE is set on each socket at creation time (see sockets.cpp).
+    Writes use writev() which is safe because the socket-level option suppresses
+    SIGPIPE delivery.
+*/
+
+namespace boost::corosio::detail {
+
+// Ready-event flag constants for descriptor_state::ready_events_.
+// These match the epoll numeric values (EPOLLIN=0x1, EPOLLOUT=0x4,
+// EPOLLERR=0x8) so that descriptor_state::operator()() uses the same
+// flag-checking logic as the epoll backend.
+static constexpr std::uint32_t kqueue_event_read  = 0x001;
+static constexpr std::uint32_t kqueue_event_write = 0x004;
+static constexpr std::uint32_t kqueue_event_error = 0x008;
+
+// Forward declarations
+class kqueue_socket_impl;
+class kqueue_acceptor_impl;
+struct kqueue_op;
+
+class kqueue_scheduler;
+
+/** Per-descriptor state for persistent kqueue registration.
+
+    Tracks pending operations for a file descriptor. The fd is registered
+    once with kqueue (EVFILT_READ + EVFILT_WRITE, both EV_CLEAR) and stays
+    registered until closed.
+
+    This struct extends scheduler_op to support deferred I/O processing.
+    When kqueue events arrive, the reactor sets ready_events and queues
+    this descriptor for processing. When popped from the scheduler queue,
+    operator() performs the actual I/O and queues completion handlers.
+
+    @par Deferred I/O Model
+    The reactor no longer performs I/O directly. Instead:
+    1. Reactor sets ready_events and queues descriptor_state
+    2. Scheduler pops descriptor_state and calls operator()
+    3. operator() performs I/O under mutex and queues completions
+
+    This eliminates per-descriptor mutex locking from the reactor hot path.
+
+    @par Thread Safety
+    The mutex protects operation pointers and ready flags during I/O.
+    ready_events_ and is_enqueued_ are atomic for lock-free reactor access.
+*/
+struct descriptor_state : scheduler_op
+{
+    std::mutex mutex;
+
+    // Protected by mutex
+    kqueue_op* read_op = nullptr;
+    kqueue_op* write_op = nullptr;
+    kqueue_op* connect_op = nullptr;
+
+    // Caches edge events that arrived before an op was registered
+    bool read_ready = false;
+    bool write_ready = false;
+
+    // Set during registration only (no mutex needed)
+    std::uint32_t registered_events = 0;
+    int fd = -1;
+
+    // For deferred I/O - set by reactor, read by scheduler
+    std::atomic<std::uint32_t> ready_events_{0};
+    std::atomic<bool> is_enqueued_{false};
+    kqueue_scheduler const* scheduler_ = nullptr;
+
+    // Prevents impl destruction while this descriptor_state is queued.
+    // Set by close_socket() when is_enqueued_ is true, cleared by operator().
+    std::shared_ptr<void> impl_ref_;
+
+    /// Add ready events atomically.
+    /// Release pairs with the consumer's acquire exchange on
+    /// ready_events_ so the consumer sees all flags. On x86 (TSO)
+    /// this compiles to the same LOCK OR as relaxed.
+    void add_ready_events(std::uint32_t ev) noexcept
+    {
+        ready_events_.fetch_or(ev, std::memory_order_release);
+    }
+
+    /// Perform deferred I/O and queue completions.
+    void operator()() override;
+
+    /// Destroy without invoking.
+    void destroy() override {}
+};
+
+struct kqueue_op : scheduler_op
+{
+    struct canceller
+    {
+        kqueue_op* op;
+        void operator()() const noexcept;
+    };
+
+    capy::coro h;
+    capy::executor_ref ex;
+    std::error_code* ec_out = nullptr;
+    std::size_t* bytes_out = nullptr;
+
+    int fd = -1;
+    int errn = 0;
+    std::size_t bytes_transferred = 0;
+
+    std::atomic<bool> cancelled{false};
+    std::optional<std::stop_callback<canceller>> stop_cb;
+
+    // Prevents use-after-free when socket is closed with pending ops.
+    // See "Impl Lifetime Management" in file header.
+    std::shared_ptr<void> impl_ptr;
+
+    // For stop_token cancellation - pointer to owning socket/acceptor impl.
+    // When stop is requested, we call back to the impl to perform actual I/O cancellation.
+    kqueue_socket_impl* socket_impl_ = nullptr;
+    kqueue_acceptor_impl* acceptor_impl_ = nullptr;
+
+    kqueue_op() = default;
+
+    void reset() noexcept
+    {
+        fd = -1;
+        errn = 0;
+        bytes_transferred = 0;
+        cancelled.store(false, std::memory_order_relaxed);
+        impl_ptr.reset();
+        socket_impl_ = nullptr;
+        acceptor_impl_ = nullptr;
+    }
+
+    void operator()() override
+    {
+        stop_cb.reset();
+
+        if (ec_out)
+        {
+            if (cancelled.load(std::memory_order_acquire))
+                *ec_out = capy::error::canceled;
+            else if (errn != 0)
+                *ec_out = make_err(errn);
+            else if (is_read_operation() && bytes_transferred == 0)
+                *ec_out = capy::error::eof;
+            else
+                *ec_out = {};
+        }
+
+        if (bytes_out)
+            *bytes_out = bytes_transferred;
+
+        // Move to stack before resuming coroutine. The coroutine might close
+        // the socket, releasing the last wrapper ref. If impl_ptr were the
+        // last ref and we destroyed it while still in operator(), we'd have
+        // use-after-free. Moving to local ensures destruction happens at
+        // function exit, after all member accesses are complete.
+        capy::executor_ref saved_ex( std::move( ex ) );
+        capy::coro saved_h( std::move( h ) );
+        auto prevent_premature_destruction = std::move(impl_ptr);
+        resume_coro(saved_ex, saved_h);
+    }
+
+    virtual bool is_read_operation() const noexcept { return false; }
+    virtual void cancel() noexcept = 0;
+
+    void destroy() override
+    {
+        stop_cb.reset();
+        impl_ptr.reset();
+    }
+
+    void request_cancel() noexcept
+    {
+        cancelled.store(true, std::memory_order_release);
+    }
+
+    void start(std::stop_token token, kqueue_socket_impl* impl)
+    {
+        cancelled.store(false, std::memory_order_release);
+        stop_cb.reset();
+        socket_impl_ = impl;
+        acceptor_impl_ = nullptr;
+
+        if (token.stop_possible())
+            stop_cb.emplace(token, canceller{this});
+    }
+
+    void start(std::stop_token token, kqueue_acceptor_impl* impl)
+    {
+        cancelled.store(false, std::memory_order_release);
+        stop_cb.reset();
+        socket_impl_ = nullptr;
+        acceptor_impl_ = impl;
+
+        if (token.stop_possible())
+            stop_cb.emplace(token, canceller{this});
+    }
+
+    void complete(int err, std::size_t bytes) noexcept
+    {
+        errn = err;
+        bytes_transferred = bytes;
+    }
+
+    virtual void perform_io() noexcept {}
+};
+
+
+struct kqueue_connect_op : kqueue_op
+{
+    endpoint target_endpoint;
+
+    void reset() noexcept
+    {
+        kqueue_op::reset();
+        target_endpoint = endpoint{};
+    }
+
+    void perform_io() noexcept override
+    {
+        // connect() completion status is retrieved via SO_ERROR, not return value
+        int err = 0;
+        socklen_t len = sizeof(err);
+        if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &len) < 0)
+            err = errno;
+        complete(err, 0);
+    }
+
+    // Defined in sockets.cpp where kqueue_socket_impl is complete
+    void operator()() override;
+    void cancel() noexcept override;
+};
+
+
+struct kqueue_read_op : kqueue_op
+{
+    static constexpr std::size_t max_buffers = 16;
+    iovec iovecs[max_buffers];
+    int iovec_count = 0;
+    bool empty_buffer_read = false;
+
+    bool is_read_operation() const noexcept override
+    {
+        return !empty_buffer_read;
+    }
+
+    void reset() noexcept
+    {
+        kqueue_op::reset();
+        iovec_count = 0;
+        empty_buffer_read = false;
+    }
+
+    void perform_io() noexcept override
+    {
+        ssize_t n = ::readv(fd, iovecs, iovec_count);
+        if (n >= 0)
+            complete(0, static_cast<std::size_t>(n));
+        else
+            complete(errno, 0);
+    }
+
+    void cancel() noexcept override;
+};
+
+
+struct kqueue_write_op : kqueue_op
+{
+    static constexpr std::size_t max_buffers = 16;
+    iovec iovecs[max_buffers];
+    int iovec_count = 0;
+
+    void reset() noexcept
+    {
+        kqueue_op::reset();
+        iovec_count = 0;
+    }
+
+    void perform_io() noexcept override
+    {
+        // SO_NOSIGPIPE is set on the socket at creation time (see sockets.cpp),
+        // so writev() is safe from SIGPIPE.
+        // FreeBSD: Supports MSG_NOSIGNAL on sendmsg()
+        ssize_t n = ::writev(fd, iovecs, iovec_count);
+        if (n >= 0)
+            complete(0, static_cast<std::size_t>(n));
+        else
+            complete(errno, 0);
+    }
+
+    void cancel() noexcept override;
+};
+
+
+struct kqueue_accept_op : kqueue_op
+{
+    int accepted_fd = -1;
+    io_object::io_object_impl* peer_impl = nullptr;
+    io_object::io_object_impl** impl_out = nullptr;
+
+    void reset() noexcept
+    {
+        kqueue_op::reset();
+        accepted_fd = -1;
+        peer_impl = nullptr;
+        impl_out = nullptr;
+    }
+
+    void perform_io() noexcept override
+    {
+        sockaddr_storage addr_storage{};
+        socklen_t addrlen = sizeof(addr_storage);
+
+        // FreeBSD: Can use accept4(fd, addr, len, SOCK_NONBLOCK | SOCK_CLOEXEC)
+        int new_fd = ::accept(fd, reinterpret_cast<sockaddr*>(&addr_storage), &addrlen);
+
+        if (new_fd >= 0)
+        {
+            // Set non-blocking
+            int flags = ::fcntl(new_fd, F_GETFL, 0);
+            if (flags == -1 || ::fcntl(new_fd, F_SETFL, flags | O_NONBLOCK) == -1)
+            {
+                int err = errno;
+                ::close(new_fd);
+                complete(err, 0);
+                return;
+            }
+
+            // Set close-on-exec
+            if (::fcntl(new_fd, F_SETFD, FD_CLOEXEC) == -1)
+            {
+                int err = errno;
+                ::close(new_fd);
+                complete(err, 0);
+                return;
+            }
+
+            // Suppress SIGPIPE on accepted sockets; macOS lacks MSG_NOSIGNAL
+            int one = 1;
+            if (::setsockopt(new_fd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one)) == -1)
+            {
+                int err = errno;
+                ::close(new_fd);
+                complete(err, 0);
+                return;
+            }
+
+            accepted_fd = new_fd;
+            complete(0, 0);
+        }
+        else
+        {
+            complete(errno, 0);
+        }
+    }
+
+    // Defined in acceptors.cpp where kqueue_acceptor_impl is complete
+    void operator()() override;
+    void cancel() noexcept override;
+};
+
+} // namespace boost::corosio::detail
+
+#endif // BOOST_COROSIO_HAS_KQUEUE
+
+#endif // BOOST_COROSIO_DETAIL_KQUEUE_OP_HPP

--- a/src/corosio/src/detail/kqueue/scheduler.cpp
+++ b/src/corosio/src/detail/kqueue/scheduler.cpp
@@ -1,0 +1,1162 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#include <boost/corosio/detail/platform.hpp>
+
+#if BOOST_COROSIO_HAS_KQUEUE
+
+#include "src/detail/kqueue/scheduler.hpp"
+#include "src/detail/kqueue/op.hpp"
+#include "src/detail/make_err.hpp"
+#include "src/detail/posix/resolver_service.hpp"
+#include "src/detail/posix/signals.hpp"
+
+#include <boost/corosio/detail/except.hpp>
+#include <boost/corosio/detail/thread_local_ptr.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <limits>
+#include <utility>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/event.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+/*
+    kqueue Scheduler - Single Reactor Model
+    ========================================
+
+    This scheduler uses the same thread coordination strategy as the epoll
+    backend to provide handler parallelism and avoid the thundering herd problem.
+    Instead of all threads blocking on kevent(), one thread becomes the
+    "reactor" while others wait on a condition variable for handler work.
+
+    Thread Model
+    ------------
+    - ONE thread runs kevent() at a time (the reactor thread)
+    - OTHER threads wait on cond_ (condition variable) for handlers
+    - When work is posted, exactly one waiting thread wakes via notify_one()
+    - This matches Windows IOCP semantics where N posted items wake N threads
+
+    Event Loop Structure (do_one)
+    -----------------------------
+    1. Lock mutex, try to pop handler from queue
+    2. If got handler: execute it (unlocked), return
+    3. If queue empty and no reactor running: become reactor
+       - Run kevent() (unlocked), queue I/O completions, loop back
+    4. If queue empty and reactor running: wait on condvar for work
+
+    kqueue-Specific Design
+    ----------------------
+    - Uses EVFILT_USER for reactor interruption (no extra fd needed)
+    - Uses EV_CLEAR for edge-triggered semantics (equivalent to EPOLLET)
+    - Timer expiry computed from timer_service, passed as kevent() timeout
+    - No timerfd equivalent; uses software timer queue
+
+    Signaling State (state_)
+    ------------------------
+    Same as epoll: bit 0 = signaled, upper bits = waiter count.
+*/
+
+namespace boost::corosio::detail {
+
+struct scheduler_context
+{
+    kqueue_scheduler const* key;
+    scheduler_context* next;
+    op_queue private_queue;
+    std::int64_t private_outstanding_work;
+
+    scheduler_context(kqueue_scheduler const* k, scheduler_context* n)
+        : key(k)
+        , next(n)
+        , private_outstanding_work(0)
+    {
+    }
+};
+
+namespace {
+
+corosio::detail::thread_local_ptr<scheduler_context> context_stack;
+
+struct thread_context_guard
+{
+    scheduler_context frame_;
+
+    explicit thread_context_guard(
+        kqueue_scheduler const* ctx) noexcept
+        : frame_(ctx, context_stack.get())
+    {
+        context_stack.set(&frame_);
+    }
+
+    ~thread_context_guard() noexcept
+    {
+        if (!frame_.private_queue.empty())
+            frame_.key->drain_thread_queue(frame_.private_queue, frame_.private_outstanding_work);
+        context_stack.set(frame_.next);
+    }
+};
+
+scheduler_context*
+find_context(kqueue_scheduler const* self) noexcept
+{
+    for (auto* c = context_stack.get(); c != nullptr; c = c->next)
+        if (c->key == self)
+            return c;
+    return nullptr;
+}
+
+/// Flush private work count to global counter.
+void
+flush_private_work(
+    scheduler_context* ctx,
+    std::atomic<std::int64_t>& outstanding_work) noexcept
+{
+    if (ctx && ctx->private_outstanding_work > 0)
+    {
+        outstanding_work.fetch_add(
+            ctx->private_outstanding_work, std::memory_order_relaxed);
+        ctx->private_outstanding_work = 0;
+    }
+}
+
+/// Drain private queue to global queue, flushing work count first.
+///
+/// @return True if any ops were drained.
+bool
+drain_private_queue(
+    scheduler_context* ctx,
+    std::atomic<std::int64_t>& outstanding_work,
+    op_queue& completed_ops) noexcept
+{
+    if (!ctx || ctx->private_queue.empty())
+        return false;
+
+    flush_private_work(ctx, outstanding_work);
+    completed_ops.splice(ctx->private_queue);
+    return true;
+}
+
+} // namespace
+
+void
+descriptor_state::
+operator()()
+{
+    // Release ensures the false is visible to the reactor's CAS on other
+    // cores. With relaxed, ARM's store buffer can delay the write,
+    // causing the reactor's CAS to see a stale 'true' and skip
+    // enqueue—permanently losing the edge-triggered event and
+    // eventually deadlocking. On x86 (TSO) release compiles to the
+    // same MOV as relaxed, so there is no cost there.
+    is_enqueued_.store(false, std::memory_order_release);
+
+    // Take ownership of impl ref set by close_socket() to prevent
+    // the owning impl from being freed while we're executing
+    auto prevent_impl_destruction = std::move(impl_ref_);
+
+    std::uint32_t ev = ready_events_.exchange(0, std::memory_order_acquire);
+    if (ev == 0)
+    {
+        scheduler_->compensating_work_started();
+        return;
+    }
+
+    op_queue local_ops;
+
+    int err = 0;
+    if (ev & kqueue_event_error)
+    {
+        socklen_t len = sizeof(err);
+        if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &len) < 0)
+            err = errno;
+        if (err == 0)
+            err = EIO;
+    }
+
+    kqueue_op* rd = nullptr;
+    kqueue_op* wr = nullptr;
+    kqueue_op* cn = nullptr;
+    {
+        std::lock_guard lock(mutex);
+        if (ev & kqueue_event_read)
+        {
+            rd = std::exchange(read_op, nullptr);
+            if (!rd)
+                read_ready = true;
+        }
+        if (ev & kqueue_event_write)
+        {
+            cn = std::exchange(connect_op, nullptr);
+            wr = std::exchange(write_op, nullptr);
+            if (!cn && !wr)
+                write_ready = true;
+        }
+        if (err && !(ev & (kqueue_event_read | kqueue_event_write)))
+        {
+            rd = std::exchange(read_op, nullptr);
+            wr = std::exchange(write_op, nullptr);
+            cn = std::exchange(connect_op, nullptr);
+        }
+    }
+
+    // Non-null after I/O means EAGAIN; re-register under lock below
+    if (rd)
+    {
+        if (err)
+            rd->complete(err, 0);
+        else
+            rd->perform_io();
+
+        if (rd->errn == EAGAIN || rd->errn == EWOULDBLOCK)
+        {
+            rd->errn = 0;
+        }
+        else
+        {
+            local_ops.push(rd);
+            rd = nullptr;
+        }
+    }
+
+    if (cn)
+    {
+        if (err)
+            cn->complete(err, 0);
+        else
+            cn->perform_io();
+        local_ops.push(cn);
+        cn = nullptr;
+    }
+
+    if (wr)
+    {
+        if (err)
+            wr->complete(err, 0);
+        else
+            wr->perform_io();
+
+        if (wr->errn == EAGAIN || wr->errn == EWOULDBLOCK)
+        {
+            wr->errn = 0;
+        }
+        else
+        {
+            local_ops.push(wr);
+            wr = nullptr;
+        }
+    }
+
+    // Re-register EAGAIN ops. A concurrent operator()() invocation may
+    // have set read_ready/write_ready while we held the op (no read_op
+    // was registered, so it cached the edge event). Check the flags
+    // under the same lock as re-registration so no edge is lost.
+    while (rd || wr)
+    {
+        bool retry = false;
+        {
+            std::lock_guard lock(mutex);
+            if (rd)
+            {
+                if (read_ready)
+                {
+                    read_ready = false;
+                    retry = true;
+                }
+                else
+                {
+                    read_op = rd;
+                    rd = nullptr;
+                }
+            }
+            if (wr)
+            {
+                if (write_ready)
+                {
+                    write_ready = false;
+                    retry = true;
+                }
+                else
+                {
+                    write_op = wr;
+                    wr = nullptr;
+                }
+            }
+        }
+
+        if (!retry)
+            break;
+
+        if (rd)
+        {
+            rd->perform_io();
+            if (rd->errn == EAGAIN || rd->errn == EWOULDBLOCK)
+                rd->errn = 0;
+            else
+            {
+                local_ops.push(rd);
+                rd = nullptr;
+            }
+        }
+        if (wr)
+        {
+            wr->perform_io();
+            if (wr->errn == EAGAIN || wr->errn == EWOULDBLOCK)
+                wr->errn = 0;
+            else
+            {
+                local_ops.push(wr);
+                wr = nullptr;
+            }
+        }
+    }
+
+    // Execute first handler inline — the scheduler's work_cleanup
+    // accounts for this as the "consumed" work item
+    scheduler_op* first = local_ops.pop();
+    if (first)
+    {
+        scheduler_->post_deferred_completions(local_ops);
+        (*first)();
+    }
+    else
+    {
+        scheduler_->compensating_work_started();
+    }
+}
+
+kqueue_scheduler::
+kqueue_scheduler(
+    capy::execution_context& ctx,
+    int)
+    : kq_fd_(-1)
+    , outstanding_work_(0)
+    , stopped_(false)
+    , shutdown_(false)
+    , task_running_(false)
+    , task_interrupted_(false)
+    , state_(0)
+{
+    // FreeBSD 13+: kqueue1(O_CLOEXEC) available
+    kq_fd_ = ::kqueue();
+    if (kq_fd_ < 0)
+        detail::throw_system_error(make_err(errno), "kqueue");
+
+    if (::fcntl(kq_fd_, F_SETFD, FD_CLOEXEC) == -1)
+    {
+        int errn = errno;
+        ::close(kq_fd_);
+        detail::throw_system_error(make_err(errn), "fcntl (kqueue FD_CLOEXEC)");
+    }
+
+    // Register EVFILT_USER for reactor interruption (no self-pipe fallback).
+    // Requires FreeBSD 11+ or macOS 10.6+; fails with throw on older kernels.
+    struct kevent ev;
+    EV_SET(&ev, 0, EVFILT_USER, EV_ADD | EV_CLEAR, 0, 0, nullptr);
+    if (::kevent(kq_fd_, &ev, 1, nullptr, 0, nullptr) < 0)
+    {
+        int errn = errno;
+        ::close(kq_fd_);
+        detail::throw_system_error(make_err(errn), "kevent (EVFILT_USER)");
+    }
+
+    timer_svc_ = &get_timer_service(ctx, *this);
+    timer_svc_->set_on_earliest_changed(
+        timer_service::callback(
+            this,
+            [](void* p) { static_cast<kqueue_scheduler*>(p)->interrupt_reactor(); }));
+
+    // Initialize resolver service
+    get_resolver_service(ctx, *this);
+
+    // Initialize signal service
+    get_signal_service(ctx, *this);
+
+    // Push task sentinel to interleave reactor runs with handler execution
+    completed_ops_.push(&task_op_);
+}
+
+kqueue_scheduler::
+~kqueue_scheduler()
+{
+    if (kq_fd_ >= 0)
+        ::close(kq_fd_);
+}
+
+void
+kqueue_scheduler::
+shutdown()
+{
+    {
+        std::unique_lock lock(mutex_);
+        shutdown_ = true;
+
+        while (auto* h = completed_ops_.pop())
+        {
+            if (h == &task_op_)
+                continue;
+            lock.unlock();
+            h->destroy();
+            lock.lock();
+        }
+
+        signal_all(lock);
+    }
+
+    outstanding_work_.store(0, std::memory_order_release);
+
+    if (kq_fd_ >= 0)
+        interrupt_reactor();
+}
+
+void
+kqueue_scheduler::
+post(capy::coro h) const
+{
+    struct post_handler final
+        : scheduler_op
+    {
+        capy::coro h_;
+
+        explicit
+        post_handler(capy::coro h)
+            : h_(h)
+        {
+        }
+
+        ~post_handler() = default;
+
+        void operator()() override
+        {
+            auto h = h_;
+            delete this;
+            // Acquire fence on *this thread* (not the deleted object) ensures
+            // stores made by the posting thread (e.g. coroutine state written
+            // before the cross-thread post) are visible before we resume.
+            std::atomic_thread_fence(std::memory_order_acquire);
+            h.resume();
+        }
+
+        void destroy() override
+        {
+            delete this;
+        }
+    };
+
+    auto ph = std::make_unique<post_handler>(h);
+
+    // Fast path: same thread posts to private queue
+    // Only count locally; work_cleanup batches to global counter
+    if (auto* ctx = find_context(this))
+    {
+        ++ctx->private_outstanding_work;
+        ctx->private_queue.push(ph.release());
+        return;
+    }
+
+    // Slow path: cross-thread post requires mutex
+    outstanding_work_.fetch_add(1, std::memory_order_relaxed);
+
+    std::unique_lock lock(mutex_);
+    completed_ops_.push(ph.release());
+    wake_one_thread_and_unlock(lock);
+}
+
+void
+kqueue_scheduler::
+post(scheduler_op* h) const
+{
+    // Fast path: same thread posts to private queue
+    // Only count locally; work_cleanup batches to global counter
+    if (auto* ctx = find_context(this))
+    {
+        ++ctx->private_outstanding_work;
+        ctx->private_queue.push(h);
+        return;
+    }
+
+    // Slow path: cross-thread post requires mutex
+    outstanding_work_.fetch_add(1, std::memory_order_relaxed);
+
+    std::unique_lock lock(mutex_);
+    completed_ops_.push(h);
+    wake_one_thread_and_unlock(lock);
+}
+
+void
+kqueue_scheduler::
+on_work_started() noexcept
+{
+    outstanding_work_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void
+kqueue_scheduler::
+on_work_finished() noexcept
+{
+    if (outstanding_work_.fetch_sub(1, std::memory_order_acq_rel) == 1)
+        stop();
+}
+
+bool
+kqueue_scheduler::
+running_in_this_thread() const noexcept
+{
+    for (auto* c = context_stack.get(); c != nullptr; c = c->next)
+        if (c->key == this)
+            return true;
+    return false;
+}
+
+void
+kqueue_scheduler::
+stop()
+{
+    std::unique_lock lock(mutex_);
+    if (!stopped_.load(std::memory_order_relaxed))
+    {
+        stopped_.store(true, std::memory_order_release);
+        signal_all(lock);
+        interrupt_reactor();
+    }
+}
+
+bool
+kqueue_scheduler::
+stopped() const noexcept
+{
+    return stopped_.load(std::memory_order_acquire);
+}
+
+void
+kqueue_scheduler::
+restart()
+{
+    std::unique_lock lock(mutex_);
+    stopped_.store(false, std::memory_order_release);
+}
+
+std::size_t
+kqueue_scheduler::
+run()
+{
+    if (outstanding_work_.load(std::memory_order_acquire) == 0)
+    {
+        stop();
+        return 0;
+    }
+
+    thread_context_guard ctx(this);
+    std::unique_lock lock(mutex_);
+
+    std::size_t n = 0;
+    for (;;)
+    {
+        if (!do_one(lock, -1, &ctx.frame_))
+            break;
+        if (n != (std::numeric_limits<std::size_t>::max)())
+            ++n;
+        if (!lock.owns_lock())
+            lock.lock();
+    }
+    return n;
+}
+
+std::size_t
+kqueue_scheduler::
+run_one()
+{
+    if (outstanding_work_.load(std::memory_order_acquire) == 0)
+    {
+        stop();
+        return 0;
+    }
+
+    thread_context_guard ctx(this);
+    std::unique_lock lock(mutex_);
+    return do_one(lock, -1, &ctx.frame_);
+}
+
+std::size_t
+kqueue_scheduler::
+wait_one(long usec)
+{
+    if (outstanding_work_.load(std::memory_order_acquire) == 0)
+    {
+        stop();
+        return 0;
+    }
+
+    thread_context_guard ctx(this);
+    std::unique_lock lock(mutex_);
+    return do_one(lock, usec, &ctx.frame_);
+}
+
+std::size_t
+kqueue_scheduler::
+poll()
+{
+    if (outstanding_work_.load(std::memory_order_acquire) == 0)
+    {
+        stop();
+        return 0;
+    }
+
+    thread_context_guard ctx(this);
+    std::unique_lock lock(mutex_);
+
+    std::size_t n = 0;
+    for (;;)
+    {
+        if (!do_one(lock, 0, &ctx.frame_))
+            break;
+        if (n != (std::numeric_limits<std::size_t>::max)())
+            ++n;
+        if (!lock.owns_lock())
+            lock.lock();
+    }
+    return n;
+}
+
+std::size_t
+kqueue_scheduler::
+poll_one()
+{
+    if (outstanding_work_.load(std::memory_order_acquire) == 0)
+    {
+        stop();
+        return 0;
+    }
+
+    thread_context_guard ctx(this);
+    std::unique_lock lock(mutex_);
+    return do_one(lock, 0, &ctx.frame_);
+}
+
+void
+kqueue_scheduler::
+register_descriptor(int fd, descriptor_state* desc) const
+{
+    struct kevent changes[2];
+    EV_SET(&changes[0], static_cast<uintptr_t>(fd), EVFILT_READ,
+           EV_ADD | EV_CLEAR, 0, 0, desc);
+    EV_SET(&changes[1], static_cast<uintptr_t>(fd), EVFILT_WRITE,
+           EV_ADD | EV_CLEAR, 0, 0, desc);
+
+    if (::kevent(kq_fd_, changes, 2, nullptr, 0, nullptr) < 0)
+        detail::throw_system_error(make_err(errno), "kevent (register)");
+
+    desc->registered_events = kqueue_event_read | kqueue_event_write;
+    desc->fd = fd;
+    desc->scheduler_ = this;
+
+    std::lock_guard lock(desc->mutex);
+    desc->read_ready = false;
+    desc->write_ready = false;
+}
+
+void
+kqueue_scheduler::
+deregister_descriptor(int fd) const
+{
+    struct kevent changes[2];
+    EV_SET(&changes[0], static_cast<uintptr_t>(fd), EVFILT_READ,
+           EV_DELETE, 0, 0, nullptr);
+    EV_SET(&changes[1], static_cast<uintptr_t>(fd), EVFILT_WRITE,
+           EV_DELETE, 0, 0, nullptr);
+    // Ignore errors - fd may already be closed (kqueue auto-removes on close)
+    ::kevent(kq_fd_, changes, 2, nullptr, 0, nullptr);
+}
+
+void
+kqueue_scheduler::
+work_started() const noexcept
+{
+    outstanding_work_.fetch_add(1, std::memory_order_relaxed);
+}
+
+void
+kqueue_scheduler::
+work_finished() const noexcept
+{
+    if (outstanding_work_.fetch_sub(1, std::memory_order_acq_rel) == 1)
+    {
+        // Last work item completed - wake all threads so they can exit.
+        // signal_all() wakes threads waiting on the condvar.
+        // interrupt_reactor() wakes the reactor thread blocked in kevent().
+        // Both are needed because they target different blocking mechanisms.
+        std::unique_lock lock(mutex_);
+        signal_all(lock);
+        if (task_running_ && !task_interrupted_)
+        {
+            task_interrupted_ = true;
+            lock.unlock();
+            interrupt_reactor();
+        }
+    }
+}
+
+void
+kqueue_scheduler::
+compensating_work_started() const noexcept
+{
+    auto* ctx = find_context(this);
+    if (ctx)
+        ++ctx->private_outstanding_work;
+}
+
+void
+kqueue_scheduler::
+drain_thread_queue(op_queue& queue, std::int64_t count) const
+{
+    // Flush private work count to global counter — private posts
+    // only incremented the thread-local counter, not outstanding_work_
+    if (count > 0)
+        outstanding_work_.fetch_add(count, std::memory_order_relaxed);
+
+    std::unique_lock lock(mutex_);
+    completed_ops_.splice(queue);
+    if (count > 0)
+        maybe_unlock_and_signal_one(lock);
+}
+
+void
+kqueue_scheduler::
+post_deferred_completions(op_queue& ops) const
+{
+    if (ops.empty())
+        return;
+
+    // Fast path: if on scheduler thread, use private queue
+    if (auto* ctx = find_context(this))
+    {
+        ctx->private_queue.splice(ops);
+        return;
+    }
+
+    // Slow path: add to global queue and wake a thread
+    std::unique_lock lock(mutex_);
+    completed_ops_.splice(ops);
+    wake_one_thread_and_unlock(lock);
+}
+
+void
+kqueue_scheduler::
+interrupt_reactor() const
+{
+    // Only trigger if not already armed to avoid redundant triggers.
+    // acq_rel: release makes the true store visible to the reactor;
+    // acquire on failure sees the reactor's release store of false,
+    // preventing a stale-true read that would silently drop the trigger.
+    // On x86 (TSO) this compiles to the same LOCK CMPXCHG as before.
+    bool expected = false;
+    if (user_event_armed_.compare_exchange_strong(expected, true,
+            std::memory_order_acq_rel, std::memory_order_acquire))
+    {
+        struct kevent ev;
+        EV_SET(&ev, 0, EVFILT_USER, 0, NOTE_TRIGGER, 0, nullptr);
+        ::kevent(kq_fd_, &ev, 1, nullptr, 0, nullptr);
+    }
+}
+
+void
+kqueue_scheduler::
+signal_all(std::unique_lock<std::mutex>&) const
+{
+    state_ |= signaled_bit;
+    cond_.notify_all();
+}
+
+bool
+kqueue_scheduler::
+maybe_unlock_and_signal_one(std::unique_lock<std::mutex>& lock) const
+{
+    state_ |= signaled_bit;
+    if (state_ > signaled_bit)
+    {
+        lock.unlock();
+        cond_.notify_one();
+        return true;
+    }
+    return false;
+}
+
+void
+kqueue_scheduler::
+unlock_and_signal_one(std::unique_lock<std::mutex>& lock) const
+{
+    state_ |= signaled_bit;
+    bool have_waiters = state_ > signaled_bit;
+    lock.unlock();
+    if (have_waiters)
+        cond_.notify_one();
+}
+
+void
+kqueue_scheduler::
+clear_signal() const
+{
+    state_ &= ~signaled_bit;
+}
+
+void
+kqueue_scheduler::
+wait_for_signal(std::unique_lock<std::mutex>& lock) const
+{
+    while ((state_ & signaled_bit) == 0)
+    {
+        state_ += waiter_increment;
+        cond_.wait(lock);
+        state_ -= waiter_increment;
+    }
+}
+
+void
+kqueue_scheduler::
+wait_for_signal_for(
+    std::unique_lock<std::mutex>& lock,
+    long timeout_us) const
+{
+    if ((state_ & signaled_bit) == 0)
+    {
+        state_ += waiter_increment;
+        cond_.wait_for(lock, std::chrono::microseconds(timeout_us));
+        state_ -= waiter_increment;
+    }
+}
+
+void
+kqueue_scheduler::
+wake_one_thread_and_unlock(std::unique_lock<std::mutex>& lock) const
+{
+    if (maybe_unlock_and_signal_one(lock))
+        return;
+
+    if (task_running_ && !task_interrupted_)
+    {
+        task_interrupted_ = true;
+        lock.unlock();
+        interrupt_reactor();
+    }
+    else
+    {
+        lock.unlock();
+    }
+}
+
+long
+kqueue_scheduler::
+calculate_timeout(long requested_timeout_us) const
+{
+    if (requested_timeout_us == 0)
+        return 0;
+
+    auto nearest = timer_svc_->nearest_expiry();
+    if (nearest == timer_service::time_point::max())
+        return requested_timeout_us;
+
+    auto now = std::chrono::steady_clock::now();
+    if (nearest <= now)
+        return 0;
+
+    auto timer_timeout_us = std::chrono::duration_cast<
+        std::chrono::microseconds>(nearest - now).count();
+
+    // Clamp to [0, LONG_MAX] to prevent truncation on 32-bit long platforms
+    constexpr auto long_max =
+        static_cast<long long>((std::numeric_limits<long>::max)());
+    auto capped_timer_us = std::min(
+        std::max(timer_timeout_us, static_cast<long long>(0)), long_max);
+
+    if (requested_timeout_us < 0)
+        return static_cast<long>(capped_timer_us);
+
+    // requested_timeout_us is already long, so min() result fits in long
+    return static_cast<long>(std::min(
+        static_cast<long long>(requested_timeout_us), capped_timer_us));
+}
+
+/** RAII guard for handler execution work accounting.
+
+    Handler consumes 1 work item, may produce N new items via fast-path posts.
+    Net change = N - 1:
+    - If N > 1: add (N-1) to global (more work produced than consumed)
+    - If N == 1: net zero, do nothing
+    - If N < 1: call work_finished() (work consumed, may trigger stop)
+
+    Also drains private queue to global for other threads to process.
+*/
+struct work_cleanup
+{
+    kqueue_scheduler const* scheduler;
+    std::unique_lock<std::mutex>* lock;
+    scheduler_context* ctx;
+
+    ~work_cleanup()
+    {
+        if (ctx)
+        {
+            std::int64_t produced = ctx->private_outstanding_work;
+            if (produced > 1)
+                scheduler->outstanding_work_.fetch_add(produced - 1, std::memory_order_relaxed);
+            else if (produced < 1)
+                scheduler->work_finished();
+            // produced == 1: net zero, handler consumed what it produced
+            ctx->private_outstanding_work = 0;
+
+            if (!ctx->private_queue.empty())
+            {
+                lock->lock();
+                scheduler->completed_ops_.splice(ctx->private_queue);
+            }
+        }
+        else
+        {
+            // No thread context - slow-path op was already counted globally
+            scheduler->work_finished();
+        }
+    }
+};
+
+/** RAII guard for reactor work accounting.
+
+    Reactor only produces work via timer/signal callbacks posting handlers.
+    Unlike handler execution which consumes 1, the reactor consumes nothing.
+    All produced work must be flushed to global counter.
+*/
+struct task_cleanup
+{
+    kqueue_scheduler const* scheduler;
+    scheduler_context* ctx;
+
+    ~task_cleanup()
+    {
+        if (ctx && ctx->private_outstanding_work > 0)
+        {
+            scheduler->outstanding_work_.fetch_add(
+                ctx->private_outstanding_work, std::memory_order_relaxed);
+            ctx->private_outstanding_work = 0;
+        }
+    }
+};
+
+void
+kqueue_scheduler::
+run_task(std::unique_lock<std::mutex>& lock, scheduler_context* ctx)
+{
+    long effective_timeout_us = task_interrupted_ ? 0 : calculate_timeout(-1);
+
+    if (lock.owns_lock())
+        lock.unlock();
+
+    // Flush private work count when reactor completes
+    task_cleanup on_exit{this, ctx};
+    (void)on_exit;
+
+    // Convert timeout to timespec for kevent()
+    struct timespec ts;
+    struct timespec* ts_ptr = nullptr;
+    if (effective_timeout_us >= 0)
+    {
+        ts.tv_sec = effective_timeout_us / 1000000;
+        ts.tv_nsec = (effective_timeout_us % 1000000) * 1000;
+        ts_ptr = &ts;
+    }
+
+    // Event loop runs without mutex held
+    struct kevent events[128];
+    int nev = ::kevent(kq_fd_, nullptr, 0, events, 128, ts_ptr);
+    int saved_errno = errno;
+
+    if (nev < 0 && saved_errno != EINTR)
+        detail::throw_system_error(make_err(saved_errno), "kevent");
+
+    op_queue local_ops;
+    std::int64_t completions_queued = 0;
+
+    // Process events without holding the mutex
+    for (int i = 0; i < nev; ++i)
+    {
+        if (events[i].filter == EVFILT_USER)
+        {
+            // Interrupt event - clear the armed flag.
+            // Release pairs with the acquire CAS failure path in
+            // interrupt_reactor(), ensuring the reactor sees our
+            // store of false and can re-arm the EVFILT_USER trigger.
+            // On x86 (TSO) this compiles identically to relaxed.
+            user_event_armed_.store(false, std::memory_order_release);
+            continue;
+        }
+
+        auto* desc = static_cast<descriptor_state*>(events[i].udata);
+        if (!desc)
+            continue;
+
+        // Map kqueue events to ready-event flags
+        std::uint32_t ready = 0;
+
+        if (events[i].filter == EVFILT_READ)
+            ready |= kqueue_event_read;
+        else if (events[i].filter == EVFILT_WRITE)
+            ready |= kqueue_event_write;
+
+        if (events[i].flags & EV_ERROR)
+            ready |= kqueue_event_error;
+
+        // EV_EOF: peer closed or error condition
+        if (events[i].flags & EV_EOF)
+        {
+            // EV_EOF on a read filter means the peer closed — deliver as
+            // a read event so the read returns 0 (EOF)
+            if (events[i].filter == EVFILT_READ)
+                ready |= kqueue_event_read;
+            // fflags contains the socket error (if any) when EV_EOF is set
+            if (events[i].fflags != 0)
+                ready |= kqueue_event_error;
+        }
+
+        desc->add_ready_events(ready);
+
+        // Only enqueue if not already enqueued.
+        // acq_rel on success: release makes add_ready_events visible
+        // to the consumer's acquire exchange; acquire pairs with the
+        // consumer's release store of false so we read the latest
+        // value. acquire on failure: ensures the CAS load sees the
+        // consumer's release store on ARM (prevents stale reads from
+        // the store buffer). On x86 (TSO) these compile identically
+        // to the weaker orderings.
+        bool expected = false;
+        if (desc->is_enqueued_.compare_exchange_strong(expected, true,
+                std::memory_order_acq_rel, std::memory_order_acquire))
+        {
+            local_ops.push(desc);
+            ++completions_queued;
+        }
+    }
+
+    // Process timers after kevent returns
+    timer_svc_->process_expired();
+
+    // --- Acquire mutex only for queue operations ---
+    lock.lock();
+
+    if (!local_ops.empty())
+        completed_ops_.splice(local_ops);
+
+    // Drain private queue to global — flush work count BEFORE splicing
+    // so consumer threads can't decrement outstanding_work_ to zero
+    // before the count reflects the newly visible operations.
+    if (ctx && !ctx->private_queue.empty())
+    {
+        if (ctx->private_outstanding_work > 0)
+        {
+            outstanding_work_.fetch_add(
+                ctx->private_outstanding_work, std::memory_order_relaxed);
+            completions_queued += ctx->private_outstanding_work;
+            ctx->private_outstanding_work = 0;
+        }
+        completed_ops_.splice(ctx->private_queue);
+    }
+
+    // Signal and wake one waiter if work is queued
+    if (completions_queued > 0)
+    {
+        if (maybe_unlock_and_signal_one(lock))
+            lock.lock();
+    }
+}
+
+std::size_t
+kqueue_scheduler::
+do_one(std::unique_lock<std::mutex>& lock, long timeout_us, scheduler_context* ctx)
+{
+    for (;;)
+    {
+        if (stopped_.load(std::memory_order_relaxed))
+            return 0;
+
+        scheduler_op* op = completed_ops_.pop();
+
+        // Handle reactor sentinel - time to poll for I/O
+        if (op == &task_op_)
+        {
+            bool more_handlers = !completed_ops_.empty() ||
+                (ctx && !ctx->private_queue.empty());
+
+            // Nothing to run the reactor for: no pending work to wait on,
+            // or caller requested a non-blocking poll
+            if (!more_handlers &&
+                (outstanding_work_.load(std::memory_order_acquire) == 0 ||
+                    timeout_us == 0))
+            {
+                completed_ops_.push(&task_op_);
+                return 0;
+            }
+
+            task_interrupted_ = more_handlers || timeout_us == 0;
+            task_running_ = true;
+
+            if (more_handlers)
+                unlock_and_signal_one(lock);
+
+            try
+            {
+                run_task(lock, ctx);
+            }
+            catch (...)
+            {
+                task_running_ = false;
+                throw;
+            }
+
+            task_running_ = false;
+            completed_ops_.push(&task_op_);
+            continue;
+        }
+
+        // Handle operation
+        if (op != nullptr)
+        {
+            if (!completed_ops_.empty())
+                unlock_and_signal_one(lock);
+            else
+                lock.unlock();
+
+            work_cleanup on_exit{this, &lock, ctx};
+            (void)on_exit;
+
+            (*op)();
+            return 1;
+        }
+
+        // No work from global queue - try private queue before blocking
+        if (drain_private_queue(ctx, outstanding_work_, completed_ops_))
+            continue;
+
+        // No pending work to wait on, or caller requested non-blocking poll
+        if (outstanding_work_.load(std::memory_order_acquire) == 0 ||
+            timeout_us == 0)
+            return 0;
+
+        clear_signal();
+        if (timeout_us < 0)
+            wait_for_signal(lock);
+        else
+            wait_for_signal_for(lock, timeout_us);
+    }
+}
+
+} // namespace boost::corosio::detail
+
+#endif

--- a/src/corosio/src/detail/kqueue/scheduler.hpp
+++ b/src/corosio/src/detail/kqueue/scheduler.hpp
@@ -1,0 +1,311 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_DETAIL_KQUEUE_SCHEDULER_HPP
+#define BOOST_COROSIO_DETAIL_KQUEUE_SCHEDULER_HPP
+
+#include <boost/corosio/detail/platform.hpp>
+
+#if BOOST_COROSIO_HAS_KQUEUE
+
+#include <boost/corosio/detail/config.hpp>
+#include <boost/corosio/detail/scheduler.hpp>
+#include <boost/capy/ex/execution_context.hpp>
+
+#include "src/detail/scheduler_op.hpp"
+#include "src/detail/timer_service.hpp"
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+
+namespace boost::corosio::detail {
+
+struct kqueue_op;
+struct descriptor_state;
+struct scheduler_context;
+
+/** macOS/BSD scheduler using kqueue for I/O multiplexing.
+
+    This scheduler implements the scheduler interface using the BSD kqueue
+    API for efficient I/O event notification. It uses a single reactor model
+    where one thread runs kevent() while other threads
+    wait on a condition variable for handler work. This design provides:
+
+    - Handler parallelism: N posted handlers can execute on N threads
+    - No thundering herd: condition_variable wakes exactly one thread
+    - IOCP parity: Behavior matches Windows I/O completion port semantics
+
+    When threads call run(), they first try to execute queued handlers.
+    If the queue is empty and no reactor is running, one thread becomes
+    the reactor and runs kevent(). Other threads wait on a condition
+    variable until handlers are available.
+
+    kqueue uses EV_CLEAR for edge-triggered semantics (equivalent to
+    epoll's EPOLLET). File descriptors are registered once with both
+    EVFILT_READ and EVFILT_WRITE and stay registered until closed.
+
+    @par Thread Safety
+    All public member functions are thread-safe.
+*/
+class kqueue_scheduler
+    : public scheduler
+    , public capy::execution_context::service
+{
+public:
+    using key_type = scheduler;
+
+    /** Construct the scheduler.
+
+        Creates a kqueue file descriptor via kqueue(), sets
+        close-on-exec, and registers EVFILT_USER for reactor
+        interruption. On failure the kqueue fd is closed before
+        throwing.
+
+        @param ctx Reference to the owning execution_context.
+        @param concurrency_hint Hint for expected thread count (unused).
+
+        @throws std::system_error if kqueue() fails, if setting
+            FD_CLOEXEC on the kqueue fd fails, or if registering
+            the EVFILT_USER event fails. The error code contains
+            the errno from the failed syscall.
+    */
+    kqueue_scheduler(
+        capy::execution_context& ctx,
+        int concurrency_hint = -1);
+
+    /** Destructor.
+
+        Closes the kqueue file descriptor if valid. Does not throw.
+    */
+    ~kqueue_scheduler();
+
+    kqueue_scheduler(kqueue_scheduler const&) = delete;
+    kqueue_scheduler& operator=(kqueue_scheduler const&) = delete;
+
+    void shutdown() override;
+    void post(capy::coro h) const override;
+    void post(scheduler_op* h) const override;
+    // scheduler::on_work_started / on_work_finished — non-const, for executors.
+    // Tracks work that keeps run() alive; the scheduler stops when the
+    // count drops to zero.
+    void on_work_started() noexcept override;
+    void on_work_finished() noexcept override;
+    bool running_in_this_thread() const noexcept override;
+    void stop() override;
+    bool stopped() const noexcept override;
+    void restart() override;
+    std::size_t run() override;
+    std::size_t run_one() override;
+    std::size_t wait_one(long usec) override;
+    std::size_t poll() override;
+    std::size_t poll_one() override;
+
+    /** Return the kqueue file descriptor.
+
+        Used by socket services to register file descriptors
+        for I/O event notification.
+
+        @return The kqueue file descriptor.
+    */
+    int kq_fd() const noexcept { return kq_fd_; }
+
+    /** Register a descriptor for persistent monitoring.
+
+        Adds EVFILT_READ and EVFILT_WRITE (both EV_CLEAR) for @a fd
+        and stores @a desc in the kevent udata field so that the
+        reactor can dispatch events to the correct descriptor_state.
+
+        The caller retains ownership of @a desc. It must remain valid
+        until deregister_descriptor() is called and all pending
+        read/write/connect operations referencing it have completed.
+        The scheduler accesses @a desc asynchronously from the reactor
+        thread when kevent delivers events.
+
+        @param fd The file descriptor to register.
+        @param desc Pointer to the caller-owned descriptor_state.
+
+        @throws std::system_error if kevent(EV_ADD) fails.
+    */
+    void register_descriptor(int fd, descriptor_state* desc) const;
+
+    /** Deregister a persistently registered descriptor.
+
+        Issues kevent(EV_DELETE) for both EVFILT_READ and EVFILT_WRITE.
+        Errors are silently ignored because the fd may already be
+        closed and kqueue automatically removes closed descriptors.
+
+        After this call returns, the reactor will not deliver any
+        further events for @a fd, so the associated descriptor_state
+        may be safely destroyed once all previously queued completions
+        have been processed.
+
+        @param fd The file descriptor to deregister.
+    */
+    void deregister_descriptor(int fd) const;
+
+    // scheduler::work_started / work_finished — const, for I/O services.
+    // Adjusts outstanding_work_ and wakes blocked threads but does not
+    // stop the scheduler when the count reaches zero.
+    void work_started() const noexcept override;
+    void work_finished() const noexcept override;
+
+    /** Offset a forthcoming work_finished from work_cleanup.
+
+        Called by descriptor_state when all I/O returned EAGAIN and no
+        handler will be executed. Must be called from a scheduler thread.
+    */
+    void compensating_work_started() const noexcept;
+
+    /** Drain work from thread context's private queue to global queue.
+
+        Called by thread_context_guard destructor when a thread exits run().
+        Transfers pending work to the global queue under mutex protection.
+
+        @param queue The private queue to drain.
+        @param count Item count for wakeup decisions (wakes other threads if positive).
+    */
+    void drain_thread_queue(op_queue& queue, std::int64_t count) const;
+
+    /** Post completed operations for deferred invocation.
+
+        If called from a thread running this scheduler, operations go to
+        the thread's private queue (fast path). Otherwise, operations are
+        added to the global queue under mutex and a waiter is signaled.
+
+        @par Preconditions
+        work_started() must have been called for each operation.
+
+        @param ops Queue of operations to post.
+    */
+    void post_deferred_completions(op_queue& ops) const;
+
+private:
+    friend struct work_cleanup;
+    friend struct task_cleanup;
+
+    std::size_t do_one(std::unique_lock<std::mutex>& lock, long timeout_us, scheduler_context* ctx);
+    void run_task(std::unique_lock<std::mutex>& lock, scheduler_context* ctx);
+    void wake_one_thread_and_unlock(std::unique_lock<std::mutex>& lock) const;
+    void interrupt_reactor() const;
+    long calculate_timeout(long requested_timeout_us) const;
+
+    /** Set the signaled state and wake all waiting threads.
+
+        @par Preconditions
+        Mutex must be held.
+
+        @param lock The held mutex lock.
+    */
+    void signal_all(std::unique_lock<std::mutex>& lock) const;
+
+    /** Set the signaled state and wake one waiter if any exist.
+
+        Only unlocks and signals if at least one thread is waiting.
+        Use this when the caller needs to perform a fallback action
+        (such as interrupting the reactor) when no waiters exist.
+
+        @par Preconditions
+        Mutex must be held.
+
+        @param lock The held mutex lock.
+
+        @return `true` if unlocked and signaled, `false` if lock still held.
+    */
+    bool maybe_unlock_and_signal_one(std::unique_lock<std::mutex>& lock) const;
+
+    /** Set the signaled state, unlock, and wake one waiter if any exist.
+
+        Always unlocks the mutex. Use this when the caller will release
+        the lock regardless of whether a waiter exists.
+
+        @par Preconditions
+        Mutex must be held.
+
+        @param lock The held mutex lock.
+    */
+    void unlock_and_signal_one(std::unique_lock<std::mutex>& lock) const;
+
+    /** Clear the signaled state before waiting.
+
+        @par Preconditions
+        Mutex must be held.
+    */
+    void clear_signal() const;
+
+    /** Block until the signaled state is set.
+
+        Returns immediately if already signaled (fast-path). Otherwise
+        increments the waiter count, waits on the condition variable,
+        and decrements the waiter count upon waking.
+
+        @par Preconditions
+        Mutex must be held.
+
+        @param lock The held mutex lock.
+    */
+    void wait_for_signal(std::unique_lock<std::mutex>& lock) const;
+
+    /** Block until signaled or timeout expires.
+
+        @par Preconditions
+        Mutex must be held.
+
+        @param lock The held mutex lock.
+        @param timeout_us Maximum time to wait in microseconds.
+    */
+    void wait_for_signal_for(
+        std::unique_lock<std::mutex>& lock,
+        long timeout_us) const;
+
+    int kq_fd_;
+    mutable std::mutex mutex_;
+    mutable std::condition_variable cond_;
+    mutable op_queue completed_ops_;
+    mutable std::atomic<std::int64_t> outstanding_work_{0};
+    std::atomic<bool> stopped_{false};
+    bool shutdown_ = false;
+    timer_service* timer_svc_ = nullptr;
+
+    // True while a thread is blocked in kevent(). Used by
+    // wake_one_thread_and_unlock and work_finished to know when
+    // an EVFILT_USER interrupt is needed instead of a condvar signal.
+    mutable bool task_running_ = false;
+
+    // True when the reactor has been told to do a non-blocking poll
+    // (more handlers queued or poll mode). Prevents redundant EVFILT_USER
+    // triggers and controls the kevent() timeout.
+    mutable bool task_interrupted_ = false;
+
+    // Signaling state: bit 0 = signaled, upper bits = waiter count
+    static constexpr std::size_t signaled_bit     = 1;
+    static constexpr std::size_t waiter_increment = 2;
+    mutable std::size_t state_ = 0;
+
+    // EVFILT_USER idempotency: prevents redundant NOTE_TRIGGER writes
+    mutable std::atomic<bool> user_event_armed_{false};
+
+    // Sentinel operation for interleaving reactor runs with handler execution.
+    // Ensures the reactor runs periodically even when handlers are continuously
+    // posted, preventing starvation of I/O events, timers, and signals.
+    struct task_op final : scheduler_op
+    {
+        void operator()() override {}
+        void destroy() override {}
+    };
+    task_op task_op_;
+};
+
+} // namespace boost::corosio::detail
+
+#endif // BOOST_COROSIO_HAS_KQUEUE
+
+#endif // BOOST_COROSIO_DETAIL_KQUEUE_SCHEDULER_HPP

--- a/src/corosio/src/detail/kqueue/sockets.cpp
+++ b/src/corosio/src/detail/kqueue/sockets.cpp
@@ -1,0 +1,920 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#include <boost/corosio/detail/platform.hpp>
+
+#if BOOST_COROSIO_HAS_KQUEUE
+
+#include "src/detail/kqueue/sockets.hpp"
+#include "src/detail/endpoint_convert.hpp"
+#include "src/detail/make_err.hpp"
+#include "src/detail/resume_coro.hpp"
+
+#include <boost/corosio/detail/except.hpp>
+#include <boost/capy/buffers.hpp>
+
+#include <utility>
+
+/*
+    kqueue socket implementation
+    ============================
+
+    Each kqueue_socket_impl owns a descriptor_state that is persistently
+    registered with kqueue (EVFILT_READ + EVFILT_WRITE, both EV_CLEAR for
+    edge-triggered semantics). The descriptor_state tracks three operation
+    slots (read_op, write_op, connect_op) and two ready flags
+    (read_ready, write_ready) under a per-descriptor mutex.
+
+    Ready-flag protocol
+    -------------------
+    When a kqueue event fires and no operation is pending for that
+    direction, the reactor sets the corresponding ready flag instead of
+    dropping the event. When a new operation starts and finds the ready
+    flag set, it performs I/O immediately rather than parking in the
+    descriptor_state slot. This prevents lost wakeups under edge-triggered
+    notification.
+
+    Edge-triggered retry
+    --------------------
+    Because EV_CLEAR delivers each transition exactly once, a single
+    event may correspond to more data than one I/O call can consume. The
+    retry loops in connect(), do_read_io(), and do_write_io() repeat
+    perform_io() while EAGAIN/EWOULDBLOCK is returned and the ready flag
+    has been re-set. When the flag is clear the operation parks in its
+    descriptor_state slot and waits for the next kqueue event.
+
+    Symmetric transfer and the cached_initiator
+    --------------------------------------------
+    read_some() and write_some() return a coroutine_handle<> for symmetric
+    transfer so the caller is fully suspended before any I/O is attempted.
+    The cached_initiator manages a reusable coroutine frame that calls
+    do_read_io / do_write_io after the caller suspends. This avoids a
+    heap allocation per operation and guarantees the caller's state is
+    consistent if a cancellation races with completion.
+*/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace boost::corosio::detail {
+
+void
+kqueue_op::canceller::
+operator()() const noexcept
+{
+    op->cancel();
+}
+
+void
+kqueue_connect_op::
+cancel() noexcept
+{
+    if (socket_impl_)
+        socket_impl_->cancel_single_op(*this);
+    else
+        request_cancel();
+}
+
+void
+kqueue_read_op::
+cancel() noexcept
+{
+    if (socket_impl_)
+        socket_impl_->cancel_single_op(*this);
+    else
+        request_cancel();
+}
+
+void
+kqueue_write_op::
+cancel() noexcept
+{
+    if (socket_impl_)
+        socket_impl_->cancel_single_op(*this);
+    else
+        request_cancel();
+}
+
+void
+kqueue_connect_op::
+operator()()
+{
+    stop_cb.reset();
+
+    bool success = (errn == 0 && !cancelled.load(std::memory_order_acquire));
+
+    // Cache endpoints on successful connect
+    if (success && socket_impl_)
+    {
+        // Query local endpoint via getsockname (may fail, but remote is always known)
+        endpoint local_ep;
+        sockaddr_in local_addr{};
+        socklen_t local_len = sizeof(local_addr);
+        if (::getsockname(fd, reinterpret_cast<sockaddr*>(&local_addr), &local_len) == 0)
+            local_ep = from_sockaddr_in(local_addr);
+        // Always cache remote endpoint; local may be default if getsockname failed
+        static_cast<kqueue_socket_impl*>(socket_impl_)->set_endpoints(local_ep, target_endpoint);
+    }
+
+    if (ec_out)
+    {
+        if (cancelled.load(std::memory_order_acquire))
+            *ec_out = capy::error::canceled;
+        else if (errn != 0)
+            *ec_out = make_err(errn);
+        else
+            *ec_out = {};
+    }
+
+    if (bytes_out)
+        *bytes_out = bytes_transferred;
+
+    // Move to stack before resuming. See kqueue_op::operator()() for rationale.
+    capy::executor_ref saved_ex( std::move( ex ) );
+    capy::coro saved_h( std::move( h ) );
+    auto prevent_premature_destruction = std::move(impl_ptr);
+    resume_coro(saved_ex, saved_h);
+}
+
+kqueue_socket_impl::
+kqueue_socket_impl(kqueue_socket_service& svc) noexcept
+    : svc_(svc)
+{
+}
+
+kqueue_socket_impl::
+~kqueue_socket_impl() = default;
+
+void
+kqueue_socket_impl::
+release()
+{
+    close_socket();
+    svc_.destroy_impl(*this);
+}
+
+std::coroutine_handle<>
+kqueue_socket_impl::
+connect(
+    std::coroutine_handle<> h,
+    capy::executor_ref ex,
+    endpoint ep,
+    std::stop_token token,
+    std::error_code* ec)
+{
+    auto& op = conn_;
+    op.reset();
+    op.h = h;
+    op.ex = ex;
+    op.ec_out = ec;
+    op.fd = fd_;
+    op.target_endpoint = ep;  // Store target for endpoint caching
+    op.start(token, this);
+
+    sockaddr_in addr = detail::to_sockaddr_in(ep);
+    int result = ::connect(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+
+    if (result == 0)
+    {
+        // Sync success - cache endpoints immediately
+        sockaddr_in local_addr{};
+        socklen_t local_len = sizeof(local_addr);
+        if (::getsockname(fd_, reinterpret_cast<sockaddr*>(&local_addr), &local_len) == 0)
+            local_endpoint_ = detail::from_sockaddr_in(local_addr);
+        remote_endpoint_ = ep;
+
+        op.complete(0, 0);
+        op.impl_ptr = shared_from_this();
+        svc_.post(&op);
+        return std::noop_coroutine();
+    }
+
+    if (errno == EINPROGRESS)
+    {
+        svc_.work_started();
+        op.impl_ptr = shared_from_this();
+
+        bool perform_now = false;
+        {
+            std::lock_guard lock(desc_state_.mutex);
+            if (desc_state_.write_ready)
+            {
+                desc_state_.write_ready = false;
+                perform_now = true;
+            }
+            else
+            {
+                desc_state_.connect_op = &op;
+            }
+        }
+
+        if (perform_now)
+        {
+            for (;;)
+            {
+                op.perform_io();
+                if (op.errn != EAGAIN && op.errn != EWOULDBLOCK)
+                {
+                    svc_.post(&op);
+                    svc_.work_finished();
+                    break;
+                }
+                op.errn = 0;
+                std::lock_guard lock(desc_state_.mutex);
+                if (desc_state_.write_ready)
+                {
+                    desc_state_.write_ready = false;
+                    continue;
+                }
+                desc_state_.connect_op = &op;
+                break;
+            }
+            return std::noop_coroutine();
+        }
+
+        if (op.cancelled.load(std::memory_order_acquire))
+        {
+            kqueue_op* claimed = nullptr;
+            {
+                std::lock_guard lock(desc_state_.mutex);
+                if (desc_state_.connect_op == &op)
+                    claimed = std::exchange(desc_state_.connect_op, nullptr);
+            }
+            if (claimed)
+            {
+                svc_.post(claimed);
+                svc_.work_finished();
+            }
+        }
+        return std::noop_coroutine();
+    }
+
+    op.complete(errno, 0);
+    op.impl_ptr = shared_from_this();
+    svc_.post(&op);
+    return std::noop_coroutine();
+}
+
+void
+kqueue_socket_impl::
+do_read_io()
+{
+    auto& op = rd_;
+
+    ssize_t n = ::readv(fd_, op.iovecs, op.iovec_count);
+
+    if (n > 0)
+    {
+        {
+            std::lock_guard lock(desc_state_.mutex);
+            desc_state_.read_ready = false;
+        }
+        op.complete(0, static_cast<std::size_t>(n));
+        svc_.post(&op);
+        return;
+    }
+
+    if (n == 0)
+    {
+        {
+            std::lock_guard lock(desc_state_.mutex);
+            desc_state_.read_ready = false;
+        }
+        op.complete(0, 0);
+        svc_.post(&op);
+        return;
+    }
+
+    if (errno == EAGAIN || errno == EWOULDBLOCK)
+    {
+        svc_.work_started();
+
+        bool perform_now = false;
+        {
+            std::lock_guard lock(desc_state_.mutex);
+            if (desc_state_.read_ready)
+            {
+                desc_state_.read_ready = false;
+                perform_now = true;
+            }
+            else
+            {
+                desc_state_.read_op = &op;
+            }
+        }
+
+        if (perform_now)
+        {
+            for (;;)
+            {
+                op.perform_io();
+                if (op.errn != EAGAIN && op.errn != EWOULDBLOCK)
+                {
+                    svc_.post(&op);
+                    svc_.work_finished();
+                    return;
+                }
+                op.errn = 0;
+                std::lock_guard lock(desc_state_.mutex);
+                if (desc_state_.read_ready)
+                {
+                    desc_state_.read_ready = false;
+                    continue;
+                }
+                desc_state_.read_op = &op;
+                break;
+            }
+            return;
+        }
+
+        if (op.cancelled.load(std::memory_order_acquire))
+        {
+            kqueue_op* claimed = nullptr;
+            {
+                std::lock_guard lock(desc_state_.mutex);
+                if (desc_state_.read_op == &op)
+                    claimed = std::exchange(desc_state_.read_op, nullptr);
+            }
+            if (claimed)
+            {
+                svc_.post(claimed);
+                svc_.work_finished();
+            }
+        }
+        return;
+    }
+
+    op.complete(errno, 0);
+    svc_.post(&op);
+}
+
+void
+kqueue_socket_impl::
+do_write_io()
+{
+    auto& op = wr_;
+
+    // SO_NOSIGPIPE is set on the socket at creation time, so writev() is safe.
+    // FreeBSD: Supports MSG_NOSIGNAL on sendmsg()
+    ssize_t n = ::writev(fd_, op.iovecs, op.iovec_count);
+
+    if (n >= 0)
+    {
+        {
+            std::lock_guard lock(desc_state_.mutex);
+            desc_state_.write_ready = false;
+        }
+        op.complete(0, static_cast<std::size_t>(n));
+        svc_.post(&op);
+        return;
+    }
+
+    if (errno == EAGAIN || errno == EWOULDBLOCK)
+    {
+        svc_.work_started();
+
+        bool perform_now = false;
+        {
+            std::lock_guard lock(desc_state_.mutex);
+            if (desc_state_.write_ready)
+            {
+                desc_state_.write_ready = false;
+                perform_now = true;
+            }
+            else
+            {
+                desc_state_.write_op = &op;
+            }
+        }
+
+        if (perform_now)
+        {
+            for (;;)
+            {
+                op.perform_io();
+                if (op.errn != EAGAIN && op.errn != EWOULDBLOCK)
+                {
+                    svc_.post(&op);
+                    svc_.work_finished();
+                    return;
+                }
+                op.errn = 0;
+                std::lock_guard lock(desc_state_.mutex);
+                if (desc_state_.write_ready)
+                {
+                    desc_state_.write_ready = false;
+                    continue;
+                }
+                desc_state_.write_op = &op;
+                break;
+            }
+            return;
+        }
+
+        if (op.cancelled.load(std::memory_order_acquire))
+        {
+            kqueue_op* claimed = nullptr;
+            {
+                std::lock_guard lock(desc_state_.mutex);
+                if (desc_state_.write_op == &op)
+                    claimed = std::exchange(desc_state_.write_op, nullptr);
+            }
+            if (claimed)
+            {
+                svc_.post(claimed);
+                svc_.work_finished();
+            }
+        }
+        return;
+    }
+
+    op.complete(errno, 0);
+    svc_.post(&op);
+}
+
+std::coroutine_handle<>
+kqueue_socket_impl::
+read_some(
+    std::coroutine_handle<> h,
+    capy::executor_ref ex,
+    io_buffer_param param,
+    std::stop_token token,
+    std::error_code* ec,
+    std::size_t* bytes_out)
+{
+    auto& op = rd_;
+    op.reset();
+    op.h = h;
+    op.ex = ex;
+    op.ec_out = ec;
+    op.bytes_out = bytes_out;
+    op.fd = fd_;
+    op.start(token, this);
+    op.impl_ptr = shared_from_this();
+
+    // Must prepare buffers before initiator runs
+    capy::mutable_buffer bufs[kqueue_read_op::max_buffers];
+    op.iovec_count = static_cast<int>(param.copy_to(bufs, kqueue_read_op::max_buffers));
+
+    if (op.iovec_count == 0 || (op.iovec_count == 1 && bufs[0].size() == 0))
+    {
+        op.empty_buffer_read = true;
+        op.complete(0, 0);
+        svc_.post(&op);
+        return std::noop_coroutine();
+    }
+
+    for (int i = 0; i < op.iovec_count; ++i)
+    {
+        op.iovecs[i].iov_base = bufs[i].data();
+        op.iovecs[i].iov_len = bufs[i].size();
+    }
+
+    // Symmetric transfer ensures caller is suspended before I/O starts
+    return read_initiator_.start<&kqueue_socket_impl::do_read_io>(this);
+}
+
+std::coroutine_handle<>
+kqueue_socket_impl::
+write_some(
+    std::coroutine_handle<> h,
+    capy::executor_ref ex,
+    io_buffer_param param,
+    std::stop_token token,
+    std::error_code* ec,
+    std::size_t* bytes_out)
+{
+    auto& op = wr_;
+    op.reset();
+    op.h = h;
+    op.ex = ex;
+    op.ec_out = ec;
+    op.bytes_out = bytes_out;
+    op.fd = fd_;
+    op.start(token, this);
+    op.impl_ptr = shared_from_this();
+
+    // Must prepare buffers before initiator runs
+    capy::mutable_buffer bufs[kqueue_write_op::max_buffers];
+    op.iovec_count = static_cast<int>(param.copy_to(bufs, kqueue_write_op::max_buffers));
+
+    if (op.iovec_count == 0 || (op.iovec_count == 1 && bufs[0].size() == 0))
+    {
+        op.complete(0, 0);
+        svc_.post(&op);
+        return std::noop_coroutine();
+    }
+
+    for (int i = 0; i < op.iovec_count; ++i)
+    {
+        op.iovecs[i].iov_base = bufs[i].data();
+        op.iovecs[i].iov_len = bufs[i].size();
+    }
+
+    // Symmetric transfer ensures caller is suspended before I/O starts
+    return write_initiator_.start<&kqueue_socket_impl::do_write_io>(this);
+}
+
+std::error_code
+kqueue_socket_impl::
+shutdown(tcp_socket::shutdown_type what) noexcept
+{
+    int how;
+    switch (what)
+    {
+    case tcp_socket::shutdown_receive: how = SHUT_RD;   break;
+    case tcp_socket::shutdown_send:    how = SHUT_WR;   break;
+    case tcp_socket::shutdown_both:    how = SHUT_RDWR; break;
+    default:
+        return make_err(EINVAL);
+    }
+    if (::shutdown(fd_, how) != 0)
+        return make_err(errno);
+    return {};
+}
+
+std::error_code
+kqueue_socket_impl::
+set_no_delay(bool value) noexcept
+{
+    int flag = value ? 1 : 0;
+    if (::setsockopt(fd_, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag)) != 0)
+        return make_err(errno);
+    return {};
+}
+
+bool
+kqueue_socket_impl::
+no_delay(std::error_code& ec) const noexcept
+{
+    int flag = 0;
+    socklen_t len = sizeof(flag);
+    if (::getsockopt(fd_, IPPROTO_TCP, TCP_NODELAY, &flag, &len) != 0)
+    {
+        ec = make_err(errno);
+        return false;
+    }
+    ec = {};
+    return flag != 0;
+}
+
+std::error_code
+kqueue_socket_impl::
+set_keep_alive(bool value) noexcept
+{
+    int flag = value ? 1 : 0;
+    if (::setsockopt(fd_, SOL_SOCKET, SO_KEEPALIVE, &flag, sizeof(flag)) != 0)
+        return make_err(errno);
+    return {};
+}
+
+bool
+kqueue_socket_impl::
+keep_alive(std::error_code& ec) const noexcept
+{
+    int flag = 0;
+    socklen_t len = sizeof(flag);
+    if (::getsockopt(fd_, SOL_SOCKET, SO_KEEPALIVE, &flag, &len) != 0)
+    {
+        ec = make_err(errno);
+        return false;
+    }
+    ec = {};
+    return flag != 0;
+}
+
+std::error_code
+kqueue_socket_impl::
+set_receive_buffer_size(int size) noexcept
+{
+    if (::setsockopt(fd_, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size)) != 0)
+        return make_err(errno);
+    return {};
+}
+
+int
+kqueue_socket_impl::
+receive_buffer_size(std::error_code& ec) const noexcept
+{
+    int size = 0;
+    socklen_t len = sizeof(size);
+    if (::getsockopt(fd_, SOL_SOCKET, SO_RCVBUF, &size, &len) != 0)
+    {
+        ec = make_err(errno);
+        return 0;
+    }
+    ec = {};
+    return size;
+}
+
+std::error_code
+kqueue_socket_impl::
+set_send_buffer_size(int size) noexcept
+{
+    if (::setsockopt(fd_, SOL_SOCKET, SO_SNDBUF, &size, sizeof(size)) != 0)
+        return make_err(errno);
+    return {};
+}
+
+int
+kqueue_socket_impl::
+send_buffer_size(std::error_code& ec) const noexcept
+{
+    int size = 0;
+    socklen_t len = sizeof(size);
+    if (::getsockopt(fd_, SOL_SOCKET, SO_SNDBUF, &size, &len) != 0)
+    {
+        ec = make_err(errno);
+        return 0;
+    }
+    ec = {};
+    return size;
+}
+
+std::error_code
+kqueue_socket_impl::
+set_linger(bool enabled, int timeout) noexcept
+{
+    if (timeout < 0)
+        return make_err(EINVAL);
+    struct ::linger lg;
+    lg.l_onoff = enabled ? 1 : 0;
+    lg.l_linger = timeout;
+    if (::setsockopt(fd_, SOL_SOCKET, SO_LINGER, &lg, sizeof(lg)) != 0)
+        return make_err(errno);
+    return {};
+}
+
+tcp_socket::linger_options
+kqueue_socket_impl::
+linger(std::error_code& ec) const noexcept
+{
+    struct ::linger lg{};
+    socklen_t len = sizeof(lg);
+    if (::getsockopt(fd_, SOL_SOCKET, SO_LINGER, &lg, &len) != 0)
+    {
+        ec = make_err(errno);
+        return {};
+    }
+    ec = {};
+    return {.enabled = lg.l_onoff != 0, .timeout = lg.l_linger};
+}
+
+void
+kqueue_socket_impl::
+cancel() noexcept
+{
+    std::shared_ptr<kqueue_socket_impl> self;
+    try {
+        self = shared_from_this();
+    } catch (const std::bad_weak_ptr&) {
+        return;
+    }
+
+    conn_.request_cancel();
+    rd_.request_cancel();
+    wr_.request_cancel();
+
+    kqueue_op* conn_claimed = nullptr;
+    kqueue_op* rd_claimed = nullptr;
+    kqueue_op* wr_claimed = nullptr;
+    {
+        std::lock_guard lock(desc_state_.mutex);
+        if (desc_state_.connect_op == &conn_)
+            conn_claimed = std::exchange(desc_state_.connect_op, nullptr);
+        if (desc_state_.read_op == &rd_)
+            rd_claimed = std::exchange(desc_state_.read_op, nullptr);
+        if (desc_state_.write_op == &wr_)
+            wr_claimed = std::exchange(desc_state_.write_op, nullptr);
+    }
+
+    if (conn_claimed)
+    {
+        conn_.impl_ptr = self;
+        svc_.post(&conn_);
+        svc_.work_finished();
+    }
+    if (rd_claimed)
+    {
+        rd_.impl_ptr = self;
+        svc_.post(&rd_);
+        svc_.work_finished();
+    }
+    if (wr_claimed)
+    {
+        wr_.impl_ptr = self;
+        svc_.post(&wr_);
+        svc_.work_finished();
+    }
+}
+
+void
+kqueue_socket_impl::
+cancel_single_op(kqueue_op& op) noexcept
+{
+    op.request_cancel();
+
+    kqueue_op** desc_op_ptr = nullptr;
+    if (&op == &conn_) desc_op_ptr = &desc_state_.connect_op;
+    else if (&op == &rd_) desc_op_ptr = &desc_state_.read_op;
+    else if (&op == &wr_) desc_op_ptr = &desc_state_.write_op;
+
+    if (desc_op_ptr)
+    {
+        kqueue_op* claimed = nullptr;
+        {
+            std::lock_guard lock(desc_state_.mutex);
+            if (*desc_op_ptr == &op)
+                claimed = std::exchange(*desc_op_ptr, nullptr);
+        }
+        if (claimed)
+        {
+            try {
+                op.impl_ptr = shared_from_this();
+            } catch (const std::bad_weak_ptr&) {}
+            svc_.post(&op);
+            svc_.work_finished();
+        }
+    }
+}
+
+void
+kqueue_socket_impl::
+close_socket() noexcept
+{
+    cancel();
+
+    // Keep impl alive if descriptor_state is queued in the scheduler.
+    if (desc_state_.is_enqueued_.load(std::memory_order_acquire))
+    {
+        try {
+            desc_state_.impl_ref_ = shared_from_this();
+        } catch (std::bad_weak_ptr const&) {}
+    }
+
+    if (fd_ >= 0)
+    {
+        if (desc_state_.registered_events != 0)
+            svc_.scheduler().deregister_descriptor(fd_);
+        ::close(fd_);
+        fd_ = -1;
+    }
+
+    desc_state_.fd = -1;
+    {
+        std::lock_guard lock(desc_state_.mutex);
+        desc_state_.read_op = nullptr;
+        desc_state_.write_op = nullptr;
+        desc_state_.connect_op = nullptr;
+        desc_state_.read_ready = false;
+        desc_state_.write_ready = false;
+    }
+    desc_state_.registered_events = 0;
+
+    local_endpoint_ = endpoint{};
+    remote_endpoint_ = endpoint{};
+}
+
+kqueue_socket_service::
+kqueue_socket_service(capy::execution_context& ctx)
+    : state_(std::make_unique<kqueue_socket_state>(ctx.use_service<kqueue_scheduler>()))
+{
+}
+
+kqueue_socket_service::
+~kqueue_socket_service()
+{
+}
+
+void
+kqueue_socket_service::
+shutdown()
+{
+    std::lock_guard lock(state_->mutex_);
+
+    while (auto* impl = state_->socket_list_.pop_front())
+        impl->close_socket();
+
+    state_->socket_ptrs_.clear();
+}
+
+tcp_socket::socket_impl&
+kqueue_socket_service::
+create_impl()
+{
+    auto impl = std::make_shared<kqueue_socket_impl>(*this);
+    auto* raw = impl.get();
+
+    {
+        std::lock_guard lock(state_->mutex_);
+        state_->socket_list_.push_back(raw);
+        state_->socket_ptrs_.emplace(raw, std::move(impl));
+    }
+
+    return *raw;
+}
+
+void
+kqueue_socket_service::
+destroy_impl(tcp_socket::socket_impl& impl)
+{
+    auto* kq_impl = static_cast<kqueue_socket_impl*>(&impl);
+    std::lock_guard lock(state_->mutex_);
+    state_->socket_list_.remove(kq_impl);
+    state_->socket_ptrs_.erase(kq_impl);
+}
+
+std::error_code
+kqueue_socket_service::
+open_socket(tcp_socket::socket_impl& impl)
+{
+    auto* kq_impl = static_cast<kqueue_socket_impl*>(&impl);
+    kq_impl->close_socket();
+
+    // FreeBSD: Can use socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0)
+    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0)
+        return make_err(errno);
+
+    // Set non-blocking
+    int flags = ::fcntl(fd, F_GETFL, 0);
+    if (flags == -1)
+    {
+        int errn = errno;
+        ::close(fd);
+        return make_err(errn);
+    }
+    if (::fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1)
+    {
+        int errn = errno;
+        ::close(fd);
+        return make_err(errn);
+    }
+
+    // Set close-on-exec
+    if (::fcntl(fd, F_SETFD, FD_CLOEXEC) == -1)
+    {
+        int errn = errno;
+        ::close(fd);
+        return make_err(errn);
+    }
+
+    // Suppress SIGPIPE on this socket; writev() has no MSG_NOSIGNAL
+    // equivalent, so SO_NOSIGPIPE is required on macOS/FreeBSD.
+    int one = 1;
+    if (::setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one)) != 0)
+    {
+        int errn = errno;
+        ::close(fd);
+        return make_err(errn);
+    }
+
+    kq_impl->fd_ = fd;
+
+    // Register fd with kqueue (edge-triggered mode via EV_CLEAR)
+    kq_impl->desc_state_.fd = fd;
+    {
+        std::lock_guard lock(kq_impl->desc_state_.mutex);
+        kq_impl->desc_state_.read_op = nullptr;
+        kq_impl->desc_state_.write_op = nullptr;
+        kq_impl->desc_state_.connect_op = nullptr;
+    }
+    scheduler().register_descriptor(fd, &kq_impl->desc_state_);
+
+    return {};
+}
+
+void
+kqueue_socket_service::
+post(kqueue_op* op)
+{
+    state_->sched_.post(op);
+}
+
+void
+kqueue_socket_service::
+work_started() noexcept
+{
+    state_->sched_.work_started();
+}
+
+void
+kqueue_socket_service::
+work_finished() noexcept
+{
+    state_->sched_.work_finished();
+}
+
+} // namespace boost::corosio::detail
+
+#endif // BOOST_COROSIO_HAS_KQUEUE

--- a/src/corosio/src/detail/kqueue/sockets.hpp
+++ b/src/corosio/src/detail/kqueue/sockets.hpp
@@ -1,0 +1,219 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_DETAIL_KQUEUE_SOCKETS_HPP
+#define BOOST_COROSIO_DETAIL_KQUEUE_SOCKETS_HPP
+
+#include <boost/corosio/detail/platform.hpp>
+
+#if BOOST_COROSIO_HAS_KQUEUE
+
+#include <boost/corosio/detail/config.hpp>
+#include <boost/corosio/tcp_socket.hpp>
+#include <boost/capy/ex/executor_ref.hpp>
+#include <boost/capy/ex/execution_context.hpp>
+#include "src/detail/intrusive.hpp"
+#include "src/detail/socket_service.hpp"
+
+#include "src/detail/cached_initiator.hpp"
+#include "src/detail/kqueue/op.hpp"
+#include "src/detail/kqueue/scheduler.hpp"
+
+#include <coroutine>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+/*
+    kqueue Socket Implementation
+    ============================
+
+    Each I/O operation follows the same pattern:
+      1. Try the syscall immediately (non-blocking socket)
+      2. If it succeeds or fails with a real error, post to completion queue
+      3. If EAGAIN/EWOULDBLOCK, register with kqueue and wait
+
+    This "try first" approach avoids unnecessary kqueue round-trips for
+    operations that can complete immediately (common for small reads/writes
+    on fast local connections).
+
+    Cancellation
+    ------------
+    See op.hpp for the completion/cancellation race handling via the
+    descriptor_state mutex. cancel() must complete pending operations (post
+    them with cancelled flag) so coroutines waiting on them can resume.
+    close_socket() calls cancel() first to ensure this.
+
+    Impl Lifetime with shared_ptr
+    -----------------------------
+    Socket impls use enable_shared_from_this. The service owns impls via
+    shared_ptr maps (socket_ptrs_) keyed by raw pointer for O(1) lookup and
+    removal. When a user calls close(), we call cancel() which posts pending
+    ops to the scheduler.
+
+    CRITICAL: The posted ops must keep the impl alive until they complete.
+    Otherwise the scheduler would process a freed op (use-after-free). The
+    cancel() method captures shared_from_this() into op.impl_ptr before
+    posting. When the op completes, impl_ptr is cleared, allowing the impl
+    to be destroyed if no other references exist.
+
+    Service Ownership
+    -----------------
+    kqueue_socket_service owns all socket impls. destroy_impl() removes the
+    shared_ptr from the map, but the impl may survive if ops still hold
+    impl_ptr refs. shutdown() closes all sockets and clears the map; any
+    in-flight ops will complete and release their refs.
+*/
+
+namespace boost::corosio::detail {
+
+class kqueue_socket_service;
+class kqueue_socket_impl;
+
+/// Socket implementation for kqueue backend.
+class kqueue_socket_impl
+    : public tcp_socket::socket_impl
+    , public std::enable_shared_from_this<kqueue_socket_impl>
+    , public intrusive_list<kqueue_socket_impl>::node
+{
+    friend class kqueue_socket_service;
+
+public:
+    explicit kqueue_socket_impl(kqueue_socket_service& svc) noexcept;
+    ~kqueue_socket_impl();
+
+    void release() override;
+
+    std::coroutine_handle<> connect(
+        std::coroutine_handle<>,
+        capy::executor_ref,
+        endpoint,
+        std::stop_token,
+        std::error_code*) override;
+
+    std::coroutine_handle<> read_some(
+        std::coroutine_handle<>,
+        capy::executor_ref,
+        io_buffer_param,
+        std::stop_token,
+        std::error_code*,
+        std::size_t*) override;
+
+    std::coroutine_handle<> write_some(
+        std::coroutine_handle<>,
+        capy::executor_ref,
+        io_buffer_param,
+        std::stop_token,
+        std::error_code*,
+        std::size_t*) override;
+
+    std::error_code shutdown(tcp_socket::shutdown_type what) noexcept override;
+
+    native_handle_type native_handle() const noexcept override { return fd_; }
+
+    // Socket options
+    std::error_code set_no_delay(bool value) noexcept override;
+    bool no_delay(std::error_code& ec) const noexcept override;
+
+    std::error_code set_keep_alive(bool value) noexcept override;
+    bool keep_alive(std::error_code& ec) const noexcept override;
+
+    std::error_code set_receive_buffer_size(int size) noexcept override;
+    int receive_buffer_size(std::error_code& ec) const noexcept override;
+
+    std::error_code set_send_buffer_size(int size) noexcept override;
+    int send_buffer_size(std::error_code& ec) const noexcept override;
+
+    std::error_code set_linger(bool enabled, int timeout) noexcept override;
+    tcp_socket::linger_options linger(std::error_code& ec) const noexcept override;
+
+    endpoint local_endpoint() const noexcept override { return local_endpoint_; }
+    endpoint remote_endpoint() const noexcept override { return remote_endpoint_; }
+    bool is_open() const noexcept { return fd_ >= 0; }
+    void cancel() noexcept override;
+    void cancel_single_op(kqueue_op& op) noexcept;
+    void close_socket() noexcept;
+    void set_socket(int fd) noexcept { fd_ = fd; }
+    void set_endpoints(endpoint local, endpoint remote) noexcept
+    {
+        local_endpoint_ = local;
+        remote_endpoint_ = remote;
+    }
+
+    // Public for internal integration with the scheduler and reactor —
+    // not part of the external API. The descriptor_state is accessed by
+    // the reactor thread (lock-free atomics) and by op completion under
+    // desc_state_.mutex; the op slots and initiators are only touched
+    // by the thread that owns the current I/O call.
+    kqueue_connect_op conn_;
+    kqueue_read_op rd_;
+    kqueue_write_op wr_;
+    descriptor_state desc_state_;
+    cached_initiator read_initiator_;
+    cached_initiator write_initiator_;
+
+    void do_read_io();
+    void do_write_io();
+
+private:
+    kqueue_socket_service& svc_;
+    int fd_ = -1;
+    endpoint local_endpoint_;
+    endpoint remote_endpoint_;
+};
+
+/** State for kqueue socket service. */
+class kqueue_socket_state
+{
+public:
+    explicit kqueue_socket_state(kqueue_scheduler& sched) noexcept
+        : sched_(sched)
+    {
+    }
+
+    kqueue_scheduler& sched_;
+    std::mutex mutex_;
+    intrusive_list<kqueue_socket_impl> socket_list_;
+    std::unordered_map<kqueue_socket_impl*, std::shared_ptr<kqueue_socket_impl>> socket_ptrs_;
+};
+
+/** kqueue socket service implementation.
+
+    Inherits from socket_service to enable runtime polymorphism.
+    Uses key_type = socket_service for service lookup.
+*/
+class kqueue_socket_service : public socket_service
+{
+public:
+    explicit kqueue_socket_service(capy::execution_context& ctx);
+    ~kqueue_socket_service();
+
+    kqueue_socket_service(kqueue_socket_service const&) = delete;
+    kqueue_socket_service& operator=(kqueue_socket_service const&) = delete;
+
+    void shutdown() override;
+
+    tcp_socket::socket_impl& create_impl() override;
+    void destroy_impl(tcp_socket::socket_impl& impl) override;
+    std::error_code open_socket(tcp_socket::socket_impl& impl) override;
+
+    kqueue_scheduler& scheduler() const noexcept { return state_->sched_; }
+    void post(kqueue_op* op);
+    void work_started() noexcept;
+    void work_finished() noexcept;
+
+private:
+    std::unique_ptr<kqueue_socket_state> state_;
+};
+
+} // namespace boost::corosio::detail
+
+#endif // BOOST_COROSIO_HAS_KQUEUE
+
+#endif // BOOST_COROSIO_DETAIL_KQUEUE_SOCKETS_HPP

--- a/src/corosio/src/kqueue_context.cpp
+++ b/src/corosio/src/kqueue_context.cpp
@@ -1,0 +1,63 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#include <boost/corosio/kqueue_context.hpp>
+
+#if BOOST_COROSIO_HAS_KQUEUE
+
+#include "src/detail/kqueue/scheduler.hpp"
+#include "src/detail/kqueue/sockets.hpp"
+#include "src/detail/kqueue/acceptors.hpp"
+
+#include <algorithm>
+#include <thread>
+
+/*
+    kqueue_context owns the lifecycle of all kqueue-based I/O services.
+    Construction creates the kqueue_scheduler first (passing the concurrency
+    hint), then registers kqueue_socket_service and kqueue_acceptor_service.
+    Those services are keyed by their base classes (socket_service /
+    acceptor_service), so higher-level code discovers them through
+    execution_context::use_service without knowing the kqueue concrete type.
+    The scheduler must outlive both services because they post completions
+    and track outstanding work through it.
+*/
+
+namespace boost::corosio {
+
+kqueue_context::
+kqueue_context()
+    : kqueue_context(std::max(std::thread::hardware_concurrency(), 1u))
+{
+}
+
+kqueue_context::
+kqueue_context(
+    unsigned concurrency_hint)
+{
+    sched_ = &make_service<detail::kqueue_scheduler>(
+        static_cast<int>(concurrency_hint));
+
+    // Install socket/acceptor services.
+    // These use socket_service and acceptor_service as key_type,
+    // enabling runtime polymorphism.
+    make_service<detail::kqueue_socket_service>();
+    make_service<detail::kqueue_acceptor_service>();
+}
+
+kqueue_context::
+~kqueue_context()
+{
+    shutdown();
+    destroy();
+}
+
+} // namespace boost::corosio
+
+#endif // BOOST_COROSIO_HAS_KQUEUE

--- a/test/unit/acceptor.cpp
+++ b/test/unit/acceptor.cpp
@@ -10,18 +10,13 @@
 // Test that header file is self-contained.
 #include <boost/corosio/tcp_acceptor.hpp>
 
-#include <boost/corosio/io_context.hpp>
 #include <boost/corosio/timer.hpp>
+
 #include <boost/capy/cond.hpp>
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/task.hpp>
 
-// Include platform-specific context headers for multi-backend testing
-#include <boost/corosio/detail/platform.hpp>
-#if BOOST_COROSIO_HAS_SELECT
-#include <boost/corosio/select_context.hpp>
-#endif
-
+#include "context.hpp"
 #include "test_suite.hpp"
 
 namespace boost::corosio {
@@ -34,7 +29,7 @@ namespace boost::corosio {
 //------------------------------------------------
 
 template<class Context>
-struct acceptor_test_impl
+struct acceptor_test
 {
     void
     testConstruction()
@@ -217,18 +212,6 @@ struct acceptor_test_impl
     }
 };
 
-//------------------------------------------------
-// Register test suites for each available backend
-//------------------------------------------------
-
-// Default io_context (platform default backend)
-struct tcp_acceptor_test : acceptor_test_impl<io_context> {};
-TEST_SUITE(tcp_acceptor_test, "boost.corosio.acceptor");
-
-// POSIX: also test with select_context explicitly
-#if BOOST_COROSIO_HAS_SELECT
-struct tcp_acceptor_test_select : acceptor_test_impl<select_context> {};
-TEST_SUITE(tcp_acceptor_test_select, "boost.corosio.acceptor.select");
-#endif
+COROSIO_BACKEND_TESTS(acceptor_test, "boost.corosio.acceptor")
 
 } // namespace boost::corosio

--- a/test/unit/context.hpp
+++ b/test/unit/context.hpp
@@ -1,0 +1,85 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_TEST_CONTEXT_HPP
+#define BOOST_COROSIO_TEST_CONTEXT_HPP
+
+/* Backend context includes and test registration macro.
+
+   Include this header in test files that are templated on the context
+   type. The COROSIO_BACKEND_TESTS macro generates a struct + TEST_SUITE
+   registration for every backend available on the current platform.
+
+   Test names use dot-separated backend suffixes so that the test runner's
+   prefix matching works correctly:
+     boost.corosio.timer          -> runs all backends
+     boost.corosio.timer.kqueue   -> runs only kqueue
+     boost.corosio.timer.select   -> runs only select
+*/
+
+#include <boost/corosio/detail/platform.hpp>
+#include <boost/corosio/io_context.hpp>
+
+#if BOOST_COROSIO_HAS_IOCP
+#include <boost/corosio/iocp_context.hpp>
+#endif
+
+#if BOOST_COROSIO_HAS_EPOLL
+#include <boost/corosio/epoll_context.hpp>
+#endif
+
+#if BOOST_COROSIO_HAS_KQUEUE
+#include <boost/corosio/kqueue_context.hpp>
+#endif
+
+#if BOOST_COROSIO_HAS_SELECT
+#include <boost/corosio/select_context.hpp>
+#endif
+
+// Per-backend registration macros (empty when backend not available)
+
+#if BOOST_COROSIO_HAS_IOCP
+#define COROSIO_TEST_IOCP_(impl, name) \
+    struct impl##_iocp : impl<iocp_context> {}; \
+    TEST_SUITE(impl##_iocp, name ".iocp");
+#else
+#define COROSIO_TEST_IOCP_(impl, name)
+#endif
+
+#if BOOST_COROSIO_HAS_EPOLL
+#define COROSIO_TEST_EPOLL_(impl, name) \
+    struct impl##_epoll : impl<epoll_context> {}; \
+    TEST_SUITE(impl##_epoll, name ".epoll");
+#else
+#define COROSIO_TEST_EPOLL_(impl, name)
+#endif
+
+#if BOOST_COROSIO_HAS_KQUEUE
+#define COROSIO_TEST_KQUEUE_(impl, name) \
+    struct impl##_kqueue : impl<kqueue_context> {}; \
+    TEST_SUITE(impl##_kqueue, name ".kqueue");
+#else
+#define COROSIO_TEST_KQUEUE_(impl, name)
+#endif
+
+#if BOOST_COROSIO_HAS_SELECT
+#define COROSIO_TEST_SELECT_(impl, name) \
+    struct impl##_select : impl<select_context> {}; \
+    TEST_SUITE(impl##_select, name ".select");
+#else
+#define COROSIO_TEST_SELECT_(impl, name)
+#endif
+
+#define COROSIO_BACKEND_TESTS(impl, name) \
+    COROSIO_TEST_IOCP_(impl, name)        \
+    COROSIO_TEST_EPOLL_(impl, name)       \
+    COROSIO_TEST_KQUEUE_(impl, name)      \
+    COROSIO_TEST_SELECT_(impl, name)
+
+#endif

--- a/test/unit/signal_set.cpp
+++ b/test/unit/signal_set.cpp
@@ -10,21 +10,16 @@
 // Test that header file is self-contained.
 #include <boost/corosio/signal_set.hpp>
 
-#include <boost/corosio/io_context.hpp>
 #include <boost/corosio/timer.hpp>
+
 #include <boost/capy/cond.hpp>
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/task.hpp>
 
-// Include platform-specific context headers for multi-backend testing
-#include <boost/corosio/detail/platform.hpp>
-#if BOOST_COROSIO_HAS_SELECT
-#include <boost/corosio/select_context.hpp>
-#endif
-
 #include <csignal>
 #include <chrono>
 
+#include "context.hpp"
 #include "test_suite.hpp"
 
 namespace boost::corosio {
@@ -37,7 +32,7 @@ namespace boost::corosio {
 //------------------------------------------------
 
 template<class Context>
-struct signal_set_test_impl
+struct signal_set_test
 {
     //--------------------------------------------
     // Construction and move semantics
@@ -832,18 +827,6 @@ struct signal_set_test_impl
     }
 };
 
-//------------------------------------------------
-// Register test suites for each available backend
-//------------------------------------------------
-
-// Default io_context (platform default backend)
-struct signal_set_test : signal_set_test_impl<io_context> {};
-TEST_SUITE(signal_set_test, "boost.corosio.signal_set");
-
-// POSIX: also test with select_context explicitly
-#if BOOST_COROSIO_HAS_SELECT
-struct signal_set_test_select : signal_set_test_impl<select_context> {};
-TEST_SUITE(signal_set_test_select, "boost.corosio.signal_set.select");
-#endif
+COROSIO_BACKEND_TESTS(signal_set_test, "boost.corosio.signal_set")
 
 } // namespace boost::corosio

--- a/test/unit/socket.cpp
+++ b/test/unit/socket.cpp
@@ -11,11 +11,7 @@
 #include <boost/corosio/tcp_socket.hpp>
 
 #include <boost/corosio/tcp_acceptor.hpp>
-#include <boost/corosio/io_context.hpp>
-#include <boost/corosio/detail/platform.hpp>
-#if BOOST_COROSIO_HAS_SELECT
-#include <boost/corosio/select_context.hpp>
-#endif
+
 #include <boost/capy/buffers/string_dynamic_buffer.hpp>
 #include <boost/capy/read.hpp>
 #include <boost/capy/write.hpp>
@@ -31,7 +27,6 @@
 #include <boost/capy/task.hpp>
 
 #include <array>
-#include <atomic>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -44,31 +39,15 @@
 #include <process.h>  // _getpid()
 #endif
 
+#include "context.hpp"
 #include "test_suite.hpp"
 
 namespace boost::corosio {
 namespace {
 
-// Thread-safe port counter for multi-backend tests
-std::atomic<std::uint16_t> next_socket_test_port{0};
-
-std::uint16_t
-get_socket_test_port() noexcept
-{
-    constexpr std::uint16_t port_base = 49152;
-    constexpr std::uint16_t port_range = 16383;
-
-#if BOOST_COROSIO_POSIX
-    auto pid = static_cast<std::uint32_t>(getpid());
-#else
-    auto pid = static_cast<std::uint32_t>(_getpid());
-#endif
-    auto pid_offset = static_cast<std::uint16_t>((pid * 7919) % port_range);
-    auto offset = next_socket_test_port.fetch_add(1, std::memory_order_relaxed);
-    return static_cast<std::uint16_t>(port_base + ((pid_offset + offset) % port_range));
-}
-
-// Template version of make_socket_pair for multi-backend testing
+// Template version of make_socket_pair for multi-backend testing.
+// Uses ephemeral port (port 0) to let the OS assign a free port,
+// avoiding conflicts with other test processes and system services.
 template<class Context>
 std::pair<tcp_socket, tcp_socket>
 make_socket_pair_t(Context& ctx)
@@ -80,22 +59,11 @@ make_socket_pair_t(Context& ctx)
     bool accept_done = false;
     bool connect_done = false;
 
-    std::uint16_t port = 0;
     tcp_acceptor acc(ctx);
-    bool listening = false;
-    for (int attempt = 0; attempt < 20; ++attempt)
-    {
-        port = get_socket_test_port();
-        if (!acc.listen(endpoint(ipv4_address::loopback(), port)))
-        {
-            listening = true;
-            break;
-        }
-        acc.close();
-        acc = tcp_acceptor(ctx);
-    }
-    if (!listening)
-        throw std::runtime_error("socket_pair: failed to find available port");
+    auto ec = acc.listen(endpoint(ipv4_address::loopback(), 0));
+    if (ec)
+        throw std::runtime_error("socket_pair: listen failed");
+    auto port = acc.local_endpoint().port();
 
     tcp_socket s1(ctx);
     tcp_socket s2(ctx);
@@ -142,7 +110,7 @@ static_assert(capy::WriteStream<tcp_socket>);
 // Socket-specific tests
 
 template<class Context>
-struct socket_test_impl
+struct socket_test
 {
     void
     testConstruction()
@@ -1556,14 +1524,6 @@ struct socket_test_impl
     }
 };
 
-// Default backend test (epoll on Linux, IOCP on Windows, etc.)
-struct socket_test : socket_test_impl<io_context> {};
-TEST_SUITE(socket_test, "boost.corosio.tcp_socket");
-
-#if BOOST_COROSIO_HAS_SELECT
-// Select backend test (POSIX platforms)
-struct socket_test_select : socket_test_impl<select_context> {};
-TEST_SUITE(socket_test_select, "boost.corosio.tcp_socket.select");
-#endif
+COROSIO_BACKEND_TESTS(socket_test, "boost.corosio.tcp_socket")
 
 } // namespace boost::corosio

--- a/test/unit/socket_stress.cpp
+++ b/test/unit/socket_stress.cpp
@@ -20,15 +20,10 @@
 //
 // Tests run on all backends (epoll, IOCP, select).
 
-#include <boost/corosio/detail/platform.hpp>
-
 #include <boost/corosio/tcp_socket.hpp>
 #include <boost/corosio/tcp_acceptor.hpp>
-#include <boost/corosio/io_context.hpp>
-#if BOOST_COROSIO_HAS_SELECT
-#include <boost/corosio/select_context.hpp>
-#endif
 #include <boost/corosio/timer.hpp>
+
 #include <boost/capy/cond.hpp>
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/task.hpp>
@@ -40,7 +35,7 @@
 #include <cstring>
 #include <vector>
 
-
+#include "context.hpp"
 #include "test_suite.hpp"
 
 namespace boost::corosio {
@@ -126,7 +121,7 @@ make_stress_pair(Context& ctx)
 //------------------------------------------------------------------------------
 
 template<class Context>
-struct stop_token_stress_test_impl
+struct stop_token_stress_test
 {
     void
     run()
@@ -244,13 +239,7 @@ struct stop_token_stress_test_impl
     }
 };
 
-struct stop_token_stress_test : stop_token_stress_test_impl<io_context> {};
-TEST_SUITE(stop_token_stress_test, "boost.corosio.socket_stress.stop_token");
-
-#if BOOST_COROSIO_HAS_SELECT
-struct stop_token_stress_test_select : stop_token_stress_test_impl<select_context> {};
-TEST_SUITE(stop_token_stress_test_select, "boost.corosio.socket_stress.stop_token.select");
-#endif
+COROSIO_BACKEND_TESTS(stop_token_stress_test, "boost.corosio.socket_stress.stop_token")
 
 //------------------------------------------------------------------------------
 // Stress Test 2: Synchronous Completion Race (ready_ flag)
@@ -260,7 +249,7 @@ TEST_SUITE(stop_token_stress_test_select, "boost.corosio.socket_stress.stop_toke
 //------------------------------------------------------------------------------
 
 template<class Context>
-struct sync_completion_stress_test_impl
+struct sync_completion_stress_test
 {
     void
     run()
@@ -334,13 +323,7 @@ struct sync_completion_stress_test_impl
     }
 };
 
-struct sync_completion_stress_test : sync_completion_stress_test_impl<io_context> {};
-TEST_SUITE(sync_completion_stress_test, "boost.corosio.socket_stress.sync_completion");
-
-#if BOOST_COROSIO_HAS_SELECT
-struct sync_completion_stress_test_select : sync_completion_stress_test_impl<select_context> {};
-TEST_SUITE(sync_completion_stress_test_select, "boost.corosio.socket_stress.sync_completion.select");
-#endif
+COROSIO_BACKEND_TESTS(sync_completion_stress_test, "boost.corosio.socket_stress.sync_completion")
 
 //------------------------------------------------------------------------------
 // Stress Test 3: Rapid Cancel/Close Cycles
@@ -350,7 +333,7 @@ TEST_SUITE(sync_completion_stress_test_select, "boost.corosio.socket_stress.sync
 //------------------------------------------------------------------------------
 
 template<class Context>
-struct cancel_close_stress_test_impl
+struct cancel_close_stress_test
 {
     void
     run()
@@ -479,13 +462,7 @@ struct cancel_close_stress_test_impl
     }
 };
 
-struct cancel_close_stress_test : cancel_close_stress_test_impl<io_context> {};
-TEST_SUITE(cancel_close_stress_test, "boost.corosio.socket_stress.cancel_close");
-
-#if BOOST_COROSIO_HAS_SELECT
-struct cancel_close_stress_test_select : cancel_close_stress_test_impl<select_context> {};
-TEST_SUITE(cancel_close_stress_test_select, "boost.corosio.socket_stress.cancel_close.select");
-#endif
+COROSIO_BACKEND_TESTS(cancel_close_stress_test, "boost.corosio.socket_stress.cancel_close")
 
 //------------------------------------------------------------------------------
 // Stress Test 4: Concurrent Operations
@@ -495,7 +472,7 @@ TEST_SUITE(cancel_close_stress_test_select, "boost.corosio.socket_stress.cancel_
 //------------------------------------------------------------------------------
 
 template<class Context>
-struct concurrent_ops_stress_test_impl
+struct concurrent_ops_stress_test
 {
     void
     run()
@@ -588,13 +565,7 @@ struct concurrent_ops_stress_test_impl
     }
 };
 
-struct concurrent_ops_stress_test : concurrent_ops_stress_test_impl<io_context> {};
-TEST_SUITE(concurrent_ops_stress_test, "boost.corosio.socket_stress.concurrent_ops");
-
-#if BOOST_COROSIO_HAS_SELECT
-struct concurrent_ops_stress_test_select : concurrent_ops_stress_test_impl<select_context> {};
-TEST_SUITE(concurrent_ops_stress_test_select, "boost.corosio.socket_stress.concurrent_ops.select");
-#endif
+COROSIO_BACKEND_TESTS(concurrent_ops_stress_test, "boost.corosio.socket_stress.concurrent_ops")
 
 //------------------------------------------------------------------------------
 // Stress Test 5: Accept/Connect Race
@@ -604,7 +575,7 @@ TEST_SUITE(concurrent_ops_stress_test_select, "boost.corosio.socket_stress.concu
 //------------------------------------------------------------------------------
 
 template<class Context>
-struct accept_stress_test_impl
+struct accept_stress_test
 {
     void
     run()
@@ -686,13 +657,7 @@ struct accept_stress_test_impl
     }
 };
 
-struct accept_stress_test : accept_stress_test_impl<io_context> {};
-TEST_SUITE(accept_stress_test, "boost.corosio.socket_stress.accept");
-
-#if BOOST_COROSIO_HAS_SELECT
-struct accept_stress_test_select : accept_stress_test_impl<select_context> {};
-TEST_SUITE(accept_stress_test_select, "boost.corosio.socket_stress.accept.select");
-#endif
+COROSIO_BACKEND_TESTS(accept_stress_test, "boost.corosio.socket_stress.accept")
 
 } // namespace boost::corosio
 

--- a/test/unit/timer.cpp
+++ b/test/unit/timer.cpp
@@ -10,19 +10,13 @@
 // Test that header file is self-contained.
 #include <boost/corosio/timer.hpp>
 
-#include <boost/corosio/io_context.hpp>
 #include <boost/capy/cond.hpp>
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/task.hpp>
 
-// Include platform-specific context headers for multi-backend testing
-#include <boost/corosio/detail/platform.hpp>
-#if BOOST_COROSIO_HAS_SELECT
-#include <boost/corosio/select_context.hpp>
-#endif
-
 #include <chrono>
 
+#include "context.hpp"
 #include "test_suite.hpp"
 
 namespace boost::corosio {
@@ -35,7 +29,7 @@ namespace boost::corosio {
 //------------------------------------------------
 
 template<class Context>
-struct timer_test_impl
+struct timer_test
 {
     //--------------------------------------------
     // Construction and move semantics
@@ -665,18 +659,6 @@ struct timer_test_impl
     }
 };
 
-//------------------------------------------------
-// Register test suites for each available backend
-//------------------------------------------------
-
-// Default io_context (platform default backend)
-struct timer_test : timer_test_impl<io_context> {};
-TEST_SUITE(timer_test, "boost.corosio.timer");
-
-// POSIX: also test with select_context explicitly
-#if BOOST_COROSIO_HAS_SELECT
-struct timer_test_select : timer_test_impl<select_context> {};
-TEST_SUITE(timer_test_select, "boost.corosio.timer.select");
-#endif
+COROSIO_BACKEND_TESTS(timer_test, "boost.corosio.timer")
 
 } // namespace boost::corosio


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kqueue now becomes the default I/O context on BSD/macOS.
  * Added a complete kqueue-backed backend: reactor/scheduler, async socket I/O, and connection accept support for native, edge-triggered event handling and improved concurrency/cancellation semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->