### PR TITLE
Fix use-after-free bug in reactor shutdown

### DIFF
--- a/perf/bench/corosio/accept_churn_bench.cpp
+++ b/perf/bench/corosio/accept_churn_bench.cpp
@@ -111,7 +111,6 @@ bench::benchmark_result bench_sequential_churn(
         std::this_thread::sleep_for(
             std::chrono::duration<double>( duration_s ) );
         running.store( false, std::memory_order_relaxed );
-        acc.close();
         ioc->stop();
     } );
 
@@ -219,8 +218,6 @@ bench::benchmark_result bench_concurrent_churn(
         std::this_thread::sleep_for(
             std::chrono::duration<double>( duration_s ) );
         running.store( false, std::memory_order_relaxed );
-        for( auto& a : acceptors )
-            a.close();
         ioc->stop();
     } );
 
@@ -338,7 +335,6 @@ bench::benchmark_result bench_burst_churn(
         std::this_thread::sleep_for(
             std::chrono::duration<double>( duration_s ) );
         running.store( false, std::memory_order_relaxed );
-        acc.close();
         ioc->stop();
     } );
 

--- a/src/corosio/src/detail/epoll/acceptors.cpp
+++ b/src/corosio/src/detail/epoll/acceptors.cpp
@@ -346,7 +346,9 @@ shutdown()
     while (auto* impl = state_->acceptor_list_.pop_front())
         impl->close_socket();
 
-    state_->acceptor_ptrs_.clear();
+    // Don't clear acceptor_ptrs_ here — same rationale as
+    // epoll_socket_service::shutdown(). Let ~state_ release ptrs
+    // after scheduler shutdown has drained all queued ops.
 }
 
 tcp_acceptor::acceptor_impl&

--- a/src/corosio/src/detail/epoll/op.hpp
+++ b/src/corosio/src/detail/epoll/op.hpp
@@ -144,7 +144,9 @@ struct descriptor_state : scheduler_op
     void operator()() override;
 
     /// Destroy without invoking.
-    void destroy() override {}
+    /// Called during scheduler::shutdown() drain. Clear impl_ref_ to break
+    /// the self-referential cycle set by close_socket().
+    void destroy() override { impl_ref_.reset(); }
 };
 
 struct epoll_op : scheduler_op

--- a/src/corosio/src/detail/epoll/sockets.cpp
+++ b/src/corosio/src/detail/epoll/sockets.cpp
@@ -789,7 +789,13 @@ shutdown()
     while (auto* impl = state_->socket_list_.pop_front())
         impl->close_socket();
 
-    state_->socket_ptrs_.clear();
+    // Don't clear socket_ptrs_ here. The scheduler shuts down after us and
+    // drains completed_ops_, calling destroy() on each queued op. If we
+    // released our shared_ptrs now, an epoll_op::destroy() could free the
+    // last ref to an impl whose embedded descriptor_state is still linked
+    // in the queue — use-after-free on the next pop(). Letting ~state_
+    // release the ptrs (during service destruction, after scheduler
+    // shutdown) keeps every impl alive until all ops have been drained.
 }
 
 tcp_socket::socket_impl&

--- a/src/corosio/src/detail/kqueue/acceptors.cpp
+++ b/src/corosio/src/detail/kqueue/acceptors.cpp
@@ -435,7 +435,9 @@ shutdown()
     while (auto* impl = state_->acceptor_list_.pop_front())
         impl->close_socket();
 
-    state_->acceptor_ptrs_.clear();
+    // Don't clear acceptor_ptrs_ here — same rationale as
+    // kqueue_socket_service::shutdown(). Let ~state_ release ptrs
+    // after scheduler shutdown has drained all queued ops.
 }
 
 tcp_acceptor::acceptor_impl&

--- a/src/corosio/src/detail/kqueue/op.hpp
+++ b/src/corosio/src/detail/kqueue/op.hpp
@@ -158,7 +158,9 @@ struct descriptor_state : scheduler_op
     void operator()() override;
 
     /// Destroy without invoking.
-    void destroy() override {}
+    /// Called during scheduler::shutdown() drain. Clear impl_ref_ to break
+    /// the self-referential cycle set by close_socket().
+    void destroy() override { impl_ref_.reset(); }
 };
 
 struct kqueue_op : scheduler_op

--- a/src/corosio/src/detail/kqueue/sockets.cpp
+++ b/src/corosio/src/detail/kqueue/sockets.cpp
@@ -805,7 +805,13 @@ shutdown()
     while (auto* impl = state_->socket_list_.pop_front())
         impl->close_socket();
 
-    state_->socket_ptrs_.clear();
+    // Don't clear socket_ptrs_ here. The scheduler shuts down after us and
+    // drains completed_ops_, calling destroy() on each queued op. If we
+    // released our shared_ptrs now, a kqueue_op::destroy() could free the
+    // last ref to an impl whose embedded descriptor_state is still linked
+    // in the queue — use-after-free on the next pop(). Letting ~state_
+    // release the ptrs (during service destruction, after scheduler
+    // shutdown) keeps every impl alive until all ops have been drained.
 }
 
 tcp_socket::socket_impl&

--- a/src/corosio/src/detail/select/acceptors.cpp
+++ b/src/corosio/src/detail/select/acceptors.cpp
@@ -359,7 +359,9 @@ shutdown()
     while (auto* impl = state_->acceptor_list_.pop_front())
         impl->close_socket();
 
-    state_->acceptor_ptrs_.clear();
+    // Don't clear acceptor_ptrs_ here — same rationale as
+    // select_socket_service::shutdown(). Let ~state_ release ptrs
+    // after scheduler shutdown has drained all queued ops.
 }
 
 tcp_acceptor::acceptor_impl&

--- a/src/corosio/src/detail/select/sockets.cpp
+++ b/src/corosio/src/detail/select/sockets.cpp
@@ -645,7 +645,10 @@ shutdown()
     while (auto* impl = state_->socket_list_.pop_front())
         impl->close_socket();
 
-    state_->socket_ptrs_.clear();
+    // Don't clear socket_ptrs_ here. The scheduler shuts down after us and
+    // drains completed_ops_, calling destroy() on each queued op. Letting
+    // ~state_ release the ptrs (during service destruction, after scheduler
+    // shutdown) keeps every impl alive until all ops have been drained.
 }
 
 tcp_socket::socket_impl&


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential use-after-free errors during shutdown by deferring resource release until queued operations are drained.
  * Improved lifetime management so socket and acceptor resources are released at service teardown, preventing premature destruction.
  * Ensured internal shutdown sequences allow queued operations to complete before underlying resources are destroyed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->