### PR TITLE
kqueue: Call shutdown in the socket close path

### DIFF
--- a/src/corosio/src/detail/kqueue/sockets.cpp
+++ b/src/corosio/src/detail/kqueue/sockets.cpp
@@ -764,6 +764,10 @@ close_socket() noexcept
 
     if (fd_ >= 0)
     {
+        // Send FIN so the peer gets a reliable kqueue notification
+        // before we deregister and close the descriptor.
+        ::shutdown(fd_, SHUT_WR);
+
         if (desc_state_.registered_events != 0)
             svc_.scheduler().deregister_descriptor(fd_);
         ::close(fd_);


### PR DESCRIPTION
On macOS, when a loopback socket with SO_LINGER(true, 0 ) set, RST is processed via an internal kernel optimization that sets ECONNRESET on the socket, but never sends EOF to kqueue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced socket closure to properly handle graceful connection shutdown, ensuring clean termination of network connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->