### PR TITLE
Symmetric transfer inlining

### DIFF
--- a/perf/bench/asio/callback/accept_churn_bench.cpp
+++ b/perf/bench/asio/callback/accept_churn_bench.cpp
@@ -8,6 +8,7 @@
 //
 
 #include "benchmarks.hpp"
+#include "../socket_utils.hpp"
 
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/io_context.hpp>
@@ -27,6 +28,8 @@
 
 namespace asio = boost::asio;
 using tcp = asio::ip::tcp;
+using asio_bench::tcp_socket;
+using asio_bench::tcp_acceptor;
 
 namespace asio_callback_bench {
 namespace {
@@ -35,13 +38,13 @@ namespace {
 struct sequential_churn_op
 {
     asio::io_context& ioc;
-    tcp::acceptor& acc;
+    tcp_acceptor& acc;
     tcp::endpoint ep;
     std::atomic<bool>& running;
     int64_t& cycles;
     perf::statistics& latency_stats;
-    std::unique_ptr<tcp::socket> client;
-    std::unique_ptr<tcp::socket> server;
+    std::unique_ptr<tcp_socket> client;
+    std::unique_ptr<tcp_socket> server;
     perf::stopwatch sw;
     char byte = 'X';
     char recv_byte = 0;
@@ -56,8 +59,8 @@ struct sequential_churn_op
         sw.reset();
         connect_done = false;
         accept_done = false;
-        client = std::make_unique<tcp::socket>( ioc );
-        server = std::make_unique<tcp::socket>( ioc );
+        client = std::make_unique<tcp_socket>( ioc.get_executor() );
+        server = std::make_unique<tcp_socket>( ioc.get_executor() );
         client->open( tcp::v4() );
         client->set_option( asio::socket_base::linger( true, 0 ) );
 
@@ -124,8 +127,8 @@ bench::benchmark_result bench_sequential_churn( double duration_s )
     perf::print_header( "Sequential Accept Churn (Asio Callbacks)" );
 
     asio::io_context ioc;
-    tcp::acceptor acc( ioc, tcp::endpoint( tcp::v4(), 0 ) );
-    acc.set_option( tcp::acceptor::reuse_address( true ) );
+    tcp_acceptor acc( ioc.get_executor(), tcp::endpoint( tcp::v4(), 0 ) );
+    acc.set_option( tcp_acceptor::reuse_address( true ) );
     auto ep = tcp::endpoint( asio::ip::address_v4::loopback(), acc.local_endpoint().port() );
 
     std::atomic<bool> running{ true };
@@ -179,13 +182,13 @@ bench::benchmark_result bench_concurrent_churn( int num_loops, double duration_s
     std::vector<int64_t> cycle_counts( num_loops, 0 );
     std::vector<perf::statistics> stats( num_loops );
 
-    std::vector<std::unique_ptr<tcp::acceptor>> acceptors;
+    std::vector<std::unique_ptr<tcp_acceptor>> acceptors;
     acceptors.reserve( num_loops );
     for( int i = 0; i < num_loops; ++i )
     {
-        acceptors.push_back( std::make_unique<tcp::acceptor>(
-            ioc, tcp::endpoint( tcp::v4(), 0 ) ) );
-        acceptors.back()->set_option( tcp::acceptor::reuse_address( true ) );
+        acceptors.push_back( std::make_unique<tcp_acceptor>(
+            ioc.get_executor(), tcp::endpoint( tcp::v4(), 0 ) ) );
+        acceptors.back()->set_option( tcp_acceptor::reuse_address( true ) );
     }
 
     std::vector<std::unique_ptr<sequential_churn_op>> ops;
@@ -254,15 +257,15 @@ bench::benchmark_result bench_concurrent_churn( int num_loops, double duration_s
 struct burst_churn_op
 {
     asio::io_context& ioc;
-    tcp::acceptor& acc;
+    tcp_acceptor& acc;
     tcp::endpoint ep;
     std::atomic<bool>& running;
     int64_t& total_accepted;
     perf::statistics& burst_stats;
     int burst_size;
 
-    std::vector<std::unique_ptr<tcp::socket>> clients;
-    std::vector<std::unique_ptr<tcp::socket>> servers;
+    std::vector<std::unique_ptr<tcp_socket>> clients;
+    std::vector<std::unique_ptr<tcp_socket>> servers;
     int accepted_count = 0;
     perf::stopwatch sw;
 
@@ -282,14 +285,14 @@ struct burst_churn_op
         // Initiate all connects and accepts
         for( int i = 0; i < burst_size; ++i )
         {
-            clients.push_back( std::make_unique<tcp::socket>( ioc ) );
+            clients.push_back( std::make_unique<tcp_socket>( ioc.get_executor() ) );
             clients.back()->open( tcp::v4() );
             clients.back()->set_option(
                 asio::socket_base::linger( true, 0 ) );
             clients.back()->async_connect( ep,
                 [](boost::system::error_code) {} );
 
-            servers.push_back( std::make_unique<tcp::socket>( ioc ) );
+            servers.push_back( std::make_unique<tcp_socket>( ioc.get_executor() ) );
             acc.async_accept( *servers.back(),
                 [this]( boost::system::error_code ec )
                 {
@@ -323,8 +326,8 @@ bench::benchmark_result bench_burst_churn( int burst_size, double duration_s )
     std::cout << "  Burst size: " << burst_size << "\n";
 
     asio::io_context ioc;
-    tcp::acceptor acc( ioc, tcp::endpoint( tcp::v4(), 0 ) );
-    acc.set_option( tcp::acceptor::reuse_address( true ) );
+    tcp_acceptor acc( ioc.get_executor(), tcp::endpoint( tcp::v4(), 0 ) );
+    acc.set_option( tcp_acceptor::reuse_address( true ) );
     auto ep = tcp::endpoint( asio::ip::address_v4::loopback(), acc.local_endpoint().port() );
 
     std::atomic<bool> running{ true };

--- a/perf/bench/asio/callback/fan_out_bench.cpp
+++ b/perf/bench/asio/callback/fan_out_bench.cpp
@@ -29,6 +29,7 @@
 
 namespace asio = boost::asio;
 using tcp = asio::ip::tcp;
+using asio_bench::tcp_socket;
 
 namespace asio_callback_bench {
 namespace {
@@ -36,10 +37,10 @@ namespace {
 // Echo server: reads then writes back, loops via callbacks
 struct echo_server_op : std::enable_shared_from_this<echo_server_op>
 {
-    tcp::socket& sock;
+    tcp_socket& sock;
     char buf[64];
 
-    explicit echo_server_op( tcp::socket& s )
+    explicit echo_server_op( tcp_socket& s )
         : sock( s )
     {
     }
@@ -77,13 +78,13 @@ struct echo_server_op : std::enable_shared_from_this<echo_server_op>
 // Single sub-request: write 64 bytes, read 64 bytes, decrement counter
 struct sub_request_op : std::enable_shared_from_this<sub_request_op>
 {
-    tcp::socket& client;
+    tcp_socket& client;
     std::atomic<int>& remaining;
     std::function<void()> on_join;
     char send_buf[64] = {};
     char recv_buf[64];
 
-    sub_request_op( tcp::socket& c, std::atomic<int>& rem,
+    sub_request_op( tcp_socket& c, std::atomic<int>& rem,
         std::function<void()> join_cb )
         : client( c )
         , remaining( rem )
@@ -127,8 +128,8 @@ struct sub_request_op : std::enable_shared_from_this<sub_request_op>
 struct fork_join_op
 {
     asio::io_context& ioc;
-    std::vector<tcp::socket>& clients;
-    std::vector<tcp::socket>& servers;
+    std::vector<tcp_socket>& clients;
+    std::vector<tcp_socket>& servers;
     int fan_out;
     std::atomic<bool>& running;
     int64_t& cycles;
@@ -175,8 +176,8 @@ bench::benchmark_result bench_fork_join( int fan_out, double duration_s )
 
     asio::io_context ioc;
 
-    std::vector<tcp::socket> clients;
-    std::vector<tcp::socket> servers;
+    std::vector<tcp_socket> clients;
+    std::vector<tcp_socket> servers;
     clients.reserve( fan_out );
     servers.reserve( fan_out );
 
@@ -233,14 +234,14 @@ bench::benchmark_result bench_fork_join( int fan_out, double duration_s )
 struct nested_group_op
 {
     asio::io_context& ioc;
-    std::vector<tcp::socket>& clients;
+    std::vector<tcp_socket>& clients;
     int base_idx;
     int n;
     std::atomic<int>& groups_remaining;
     std::function<void()> on_all_groups_done;
     std::atomic<int> subs_remaining;
 
-    nested_group_op( asio::io_context& io, std::vector<tcp::socket>& cli,
+    nested_group_op( asio::io_context& io, std::vector<tcp_socket>& cli,
         int base, int count, std::atomic<int>& gr,
         std::function<void()> cb )
         : ioc( io )
@@ -275,8 +276,8 @@ struct nested_group_op
 struct nested_op
 {
     asio::io_context& ioc;
-    std::vector<tcp::socket>& clients;
-    std::vector<tcp::socket>& servers;
+    std::vector<tcp_socket>& clients;
+    std::vector<tcp_socket>& servers;
     int groups;
     int subs_per_group;
     std::atomic<bool>& running;
@@ -332,8 +333,8 @@ bench::benchmark_result bench_nested(
 
     asio::io_context ioc;
 
-    std::vector<tcp::socket> clients;
-    std::vector<tcp::socket> servers;
+    std::vector<tcp_socket> clients;
+    std::vector<tcp_socket> servers;
     clients.reserve( total_subs );
     servers.reserve( total_subs );
 
@@ -403,8 +404,8 @@ bench::benchmark_result bench_concurrent_parents(
     int total_subs = num_parents * fan_out;
     asio::io_context ioc;
 
-    std::vector<tcp::socket> clients;
-    std::vector<tcp::socket> servers;
+    std::vector<tcp_socket> clients;
+    std::vector<tcp_socket> servers;
     clients.reserve( total_subs );
     servers.reserve( total_subs );
 
@@ -429,8 +430,8 @@ bench::benchmark_result bench_concurrent_parents(
     struct parent_fork_join_op
     {
         asio::io_context& ioc;
-        std::vector<tcp::socket>& clients;
-        std::vector<tcp::socket>& servers;
+        std::vector<tcp_socket>& clients;
+        std::vector<tcp_socket>& servers;
         int base;
         int fan_out;
         int num_parents;
@@ -442,8 +443,8 @@ bench::benchmark_result bench_concurrent_parents(
         perf::stopwatch sw;
 
         parent_fork_join_op( asio::io_context& io,
-            std::vector<tcp::socket>& cli,
-            std::vector<tcp::socket>& srv,
+            std::vector<tcp_socket>& cli,
+            std::vector<tcp_socket>& srv,
             int b, int fo, int np,
             std::atomic<bool>& run,
             std::atomic<int>& pd,

--- a/perf/bench/asio/callback/http_server_bench.cpp
+++ b/perf/bench/asio/callback/http_server_bench.cpp
@@ -28,6 +28,7 @@
 
 namespace asio = boost::asio;
 using tcp = asio::ip::tcp;
+using asio_bench::tcp_socket;
 
 namespace asio_callback_bench {
 namespace {
@@ -35,7 +36,7 @@ namespace {
 // Two-phase server loop: read request headers, write response
 struct server_op
 {
-    tcp::socket& sock;
+    tcp_socket& sock;
     int64_t& completed_requests;
     std::string buf;
 
@@ -76,7 +77,7 @@ struct server_op
 // Three-phase client loop: write request, read headers, optionally read body
 struct client_op
 {
-    tcp::socket& sock;
+    tcp_socket& sock;
     std::atomic<bool>& running;
     int64_t& request_count;
     perf::statistics& latency_stats;
@@ -87,7 +88,7 @@ struct client_op
     {
         if( !running.load( std::memory_order_relaxed ) )
         {
-            sock.shutdown( tcp::socket::shutdown_send );
+            sock.shutdown( tcp_socket::shutdown_send );
             return;
         }
         sw.reset();
@@ -221,8 +222,8 @@ bench::benchmark_result bench_concurrent_connections( int num_connections, doubl
 
     asio::io_context ioc;
 
-    std::vector<tcp::socket> clients;
-    std::vector<tcp::socket> servers;
+    std::vector<tcp_socket> clients;
+    std::vector<tcp_socket> servers;
     std::vector<int64_t> server_completed( num_connections, 0 );
     std::vector<int64_t> client_counts( num_connections, 0 );
     std::vector<perf::statistics> stats( num_connections );
@@ -312,8 +313,8 @@ bench::benchmark_result bench_multithread(
 
     asio::io_context ioc( num_threads );
 
-    std::vector<tcp::socket> clients;
-    std::vector<tcp::socket> servers;
+    std::vector<tcp_socket> clients;
+    std::vector<tcp_socket> servers;
     std::vector<int64_t> server_completed( num_connections, 0 );
     std::vector<int64_t> client_counts( num_connections, 0 );
     std::vector<perf::statistics> stats( num_connections );

--- a/perf/bench/asio/callback/socket_latency_bench.cpp
+++ b/perf/bench/asio/callback/socket_latency_bench.cpp
@@ -26,6 +26,7 @@
 
 namespace asio = boost::asio;
 using tcp = asio::ip::tcp;
+using asio_bench::tcp_socket;
 
 namespace asio_callback_bench {
 namespace {
@@ -34,8 +35,8 @@ struct pingpong_op
 {
     enum phase { write_client, read_server, write_server, read_client };
 
-    tcp::socket& client;
-    tcp::socket& server;
+    tcp_socket& client;
+    tcp_socket& server;
     std::vector<char> send_buf;
     std::vector<char> recv_buf;
     std::atomic<bool>& running;
@@ -45,8 +46,8 @@ struct pingpong_op
     phase phase_;
 
     pingpong_op(
-        tcp::socket& c,
-        tcp::socket& s,
+        tcp_socket& c,
+        tcp_socket& s,
         std::size_t message_size,
         std::atomic<bool>& r,
         int64_t& iters,
@@ -66,7 +67,7 @@ struct pingpong_op
     {
         if( !running.load( std::memory_order_relaxed ) )
         {
-            client.shutdown( tcp::socket::shutdown_send );
+            client.shutdown( tcp_socket::shutdown_send );
             return;
         }
         sw.reset();
@@ -171,8 +172,8 @@ bench::benchmark_result bench_concurrent_latency(
 
     asio::io_context ioc;
 
-    std::vector<tcp::socket> clients;
-    std::vector<tcp::socket> servers;
+    std::vector<tcp_socket> clients;
+    std::vector<tcp_socket> servers;
     std::vector<perf::statistics> stats( num_pairs );
     std::vector<int64_t> iters( num_pairs, 0 );
 

--- a/perf/bench/asio/callback/socket_throughput_bench.cpp
+++ b/perf/bench/asio/callback/socket_throughput_bench.cpp
@@ -25,13 +25,14 @@
 
 namespace asio = boost::asio;
 using tcp = asio::ip::tcp;
+using asio_bench::tcp_socket;
 
 namespace asio_callback_bench {
 namespace {
 
 struct write_op
 {
-    tcp::socket& sock;
+    tcp_socket& sock;
     std::vector<char>& buf;
     std::size_t chunk_size;
     std::atomic<bool>& running;
@@ -41,7 +42,7 @@ struct write_op
     {
         if( !running.load( std::memory_order_relaxed ) )
         {
-            sock.shutdown( tcp::socket::shutdown_send );
+            sock.shutdown( tcp_socket::shutdown_send );
             return;
         }
         sock.async_write_some(
@@ -58,7 +59,7 @@ struct write_op
 
 struct read_op
 {
-    tcp::socket& sock;
+    tcp_socket& sock;
     std::vector<char>& buf;
     std::size_t& total_read;
 

--- a/perf/bench/asio/callback/timer_bench.cpp
+++ b/perf/bench/asio/callback/timer_bench.cpp
@@ -8,6 +8,7 @@
 //
 
 #include "benchmarks.hpp"
+#include "../socket_utils.hpp"
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/steady_timer.hpp>
@@ -23,6 +24,7 @@
 #include "../../common/benchmark.hpp"
 
 namespace asio = boost::asio;
+using asio_bench::timer_type;
 
 namespace asio_callback_bench {
 namespace {
@@ -45,7 +47,7 @@ bench::benchmark_result bench_schedule_cancel( double duration_s )
     {
         for( int i = 0; i < batch_size; ++i )
         {
-            asio::steady_timer t( ioc );
+            timer_type t( ioc.get_executor() );
             t.expires_after( std::chrono::hours( 1 ) );
             t.cancel();
             ++counter;
@@ -73,12 +75,12 @@ bench::benchmark_result bench_schedule_cancel( double duration_s )
 
 struct fire_rate_op
 {
-    asio::steady_timer timer;
+    timer_type timer;
     std::atomic<bool>& running;
     int64_t& counter;
 
     fire_rate_op( asio::io_context& ioc, std::atomic<bool>& r, int64_t& c )
-        : timer( ioc )
+        : timer( ioc.get_executor() )
         , running( r )
         , counter( c )
     {
@@ -141,7 +143,7 @@ bench::benchmark_result bench_fire_rate( double duration_s )
 
 struct concurrent_timer_op
 {
-    asio::steady_timer timer;
+    timer_type timer;
     std::atomic<bool>& running;
     std::chrono::microseconds interval;
     int64_t& fire_count;
@@ -154,7 +156,7 @@ struct concurrent_timer_op
         std::chrono::microseconds iv,
         int64_t& fc,
         perf::statistics& st )
-        : timer( ioc )
+        : timer( ioc.get_executor() )
         , running( r )
         , interval( iv )
         , fire_count( fc )

--- a/perf/bench/asio/coroutine/accept_churn_bench.cpp
+++ b/perf/bench/asio/coroutine/accept_churn_bench.cpp
@@ -13,7 +13,7 @@
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
 #include <boost/asio/awaitable.hpp>
-#include <boost/asio/use_awaitable.hpp>
+#include <boost/asio/deferred.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/read.hpp>
 #include <boost/asio/write.hpp>
@@ -40,15 +40,15 @@ bench::benchmark_result bench_sequential_churn( double duration_s )
     perf::print_header( "Sequential Accept Churn (Asio Coroutines)" );
 
     asio::io_context ioc;
-    tcp::acceptor acc( ioc, tcp::endpoint( tcp::v4(), 0 ) );
-    acc.set_option( tcp::acceptor::reuse_address( true ) );
+    tcp_acceptor acc( ioc.get_executor(), tcp::endpoint( tcp::v4(), 0 ) );
+    acc.set_option( tcp_acceptor::reuse_address( true ) );
     auto ep = tcp::endpoint( asio::ip::address_v4::loopback(), acc.local_endpoint().port() );
 
     std::atomic<bool> running{ true };
     int64_t cycles = 0;
     perf::statistics latency_stats;
 
-    auto task = [&]() -> asio::awaitable<void>
+    auto task = [&]() -> asio::awaitable<void, executor_type>
     {
         try
         {
@@ -56,29 +56,29 @@ bench::benchmark_result bench_sequential_churn( double duration_s )
             {
                 perf::stopwatch sw;
 
-                auto client = std::make_unique<tcp::socket>( ioc );
-                auto server = std::make_unique<tcp::socket>( ioc );
+                auto client = std::make_unique<tcp_socket>( ioc );
+                auto server = std::make_unique<tcp_socket>( ioc );
                 client->open( tcp::v4() );
                 client->set_option( asio::socket_base::linger( true, 0 ) );
 
                 // Spawn connect, await accept
                 asio::co_spawn( ioc,
-                    [](tcp::socket& c, tcp::endpoint ep) -> asio::awaitable<void>
+                    [](tcp_socket& c, tcp::endpoint ep) -> asio::awaitable<void, executor_type>
                     {
-                        co_await c.async_connect( ep, asio::use_awaitable );
+                        co_await c.async_connect( ep, asio::deferred );
                     }(*client, ep),
                     asio::detached );
 
-                *server = co_await acc.async_accept( asio::use_awaitable );
+                *server = co_await acc.async_accept( asio::deferred );
 
                 // Exchange 1 byte
                 char byte = 'X';
                 co_await asio::async_write(
-                    *client, asio::buffer( &byte, 1 ), asio::use_awaitable );
+                    *client, asio::buffer( &byte, 1 ), asio::deferred );
 
                 char recv = 0;
                 co_await asio::async_read(
-                    *server, asio::buffer( &recv, 1 ), asio::use_awaitable );
+                    *server, asio::buffer( &recv, 1 ), asio::deferred );
 
                 client->close();
                 server->close();
@@ -138,16 +138,16 @@ bench::benchmark_result bench_concurrent_churn( int num_loops, double duration_s
     std::vector<perf::statistics> stats( num_loops );
 
     // Each loop gets its own acceptor
-    std::vector<std::unique_ptr<tcp::acceptor>> acceptors;
+    std::vector<std::unique_ptr<tcp_acceptor>> acceptors;
     acceptors.reserve( num_loops );
     for( int i = 0; i < num_loops; ++i )
     {
-        acceptors.push_back( std::make_unique<tcp::acceptor>(
-            ioc, tcp::endpoint( tcp::v4(), 0 ) ) );
-        acceptors.back()->set_option( tcp::acceptor::reuse_address( true ) );
+        acceptors.push_back( std::make_unique<tcp_acceptor>(
+            ioc.get_executor(), tcp::endpoint( tcp::v4(), 0 ) ) );
+        acceptors.back()->set_option( tcp_acceptor::reuse_address( true ) );
     }
 
-    auto loop_task = [&]( int idx ) -> asio::awaitable<void>
+    auto loop_task = [&]( int idx ) -> asio::awaitable<void, executor_type>
     {
         auto& acc = *acceptors[idx];
         auto ep = tcp::endpoint( asio::ip::address_v4::loopback(), acc.local_endpoint().port() );
@@ -158,27 +158,27 @@ bench::benchmark_result bench_concurrent_churn( int num_loops, double duration_s
             {
                 perf::stopwatch sw;
 
-                auto client = std::make_unique<tcp::socket>( ioc );
-                auto server = std::make_unique<tcp::socket>( ioc );
+                auto client = std::make_unique<tcp_socket>( ioc );
+                auto server = std::make_unique<tcp_socket>( ioc );
                 client->open( tcp::v4() );
                 client->set_option( asio::socket_base::linger( true, 0 ) );
 
                 asio::co_spawn( ioc,
-                    [](tcp::socket& c, tcp::endpoint ep) -> asio::awaitable<void>
+                    [](tcp_socket& c, tcp::endpoint ep) -> asio::awaitable<void, executor_type>
                     {
-                        co_await c.async_connect( ep, asio::use_awaitable );
+                        co_await c.async_connect( ep, asio::deferred );
                     }(*client, ep),
                     asio::detached );
 
-                *server = co_await acc.async_accept( asio::use_awaitable );
+                *server = co_await acc.async_accept( asio::deferred );
 
                 char byte = 'X';
                 co_await asio::async_write(
-                    *client, asio::buffer( &byte, 1 ), asio::use_awaitable );
+                    *client, asio::buffer( &byte, 1 ), asio::deferred );
 
                 char recv = 0;
                 co_await asio::async_read(
-                    *server, asio::buffer( &recv, 1 ), asio::use_awaitable );
+                    *server, asio::buffer( &recv, 1 ), asio::deferred );
 
                 client->close();
                 server->close();
@@ -250,15 +250,15 @@ bench::benchmark_result bench_burst_churn( int burst_size, double duration_s )
     std::cout << "  Burst size: " << burst_size << "\n";
 
     asio::io_context ioc;
-    tcp::acceptor acc( ioc, tcp::endpoint( tcp::v4(), 0 ) );
-    acc.set_option( tcp::acceptor::reuse_address( true ) );
+    tcp_acceptor acc( ioc.get_executor(), tcp::endpoint( tcp::v4(), 0 ) );
+    acc.set_option( tcp_acceptor::reuse_address( true ) );
     auto ep = tcp::endpoint( asio::ip::address_v4::loopback(), acc.local_endpoint().port() );
 
     std::atomic<bool> running{ true };
     int64_t total_accepted = 0;
     perf::statistics burst_stats;
 
-    auto task = [&]() -> asio::awaitable<void>
+    auto task = [&]() -> asio::awaitable<void, executor_type>
     {
         try
         {
@@ -266,22 +266,22 @@ bench::benchmark_result bench_burst_churn( int burst_size, double duration_s )
             {
                 perf::stopwatch sw;
 
-                std::vector<std::unique_ptr<tcp::socket>> clients;
-                std::vector<tcp::socket> servers;
+                std::vector<std::unique_ptr<tcp_socket>> clients;
+                std::vector<tcp_socket> servers;
                 clients.reserve( burst_size );
                 servers.reserve( burst_size );
 
                 // Spawn all connects
                 for( int i = 0; i < burst_size; ++i )
                 {
-                    clients.push_back( std::make_unique<tcp::socket>( ioc ) );
+                    clients.push_back( std::make_unique<tcp_socket>( ioc ) );
                     clients.back()->open( tcp::v4() );
                     clients.back()->set_option(
                         asio::socket_base::linger( true, 0 ) );
                     asio::co_spawn( ioc,
-                        [](tcp::socket& c, tcp::endpoint ep) -> asio::awaitable<void>
+                        [](tcp_socket& c, tcp::endpoint ep) -> asio::awaitable<void, executor_type>
                         {
-                            co_await c.async_connect( ep, asio::use_awaitable );
+                            co_await c.async_connect( ep, asio::deferred );
                         }(*clients.back(), ep),
                         asio::detached );
                 }
@@ -289,7 +289,7 @@ bench::benchmark_result bench_burst_churn( int burst_size, double duration_s )
                 // Accept all
                 for( int i = 0; i < burst_size; ++i )
                 {
-                    servers.push_back( co_await acc.async_accept( asio::use_awaitable ) );
+                    servers.push_back( co_await acc.async_accept( asio::deferred ) );
                     ++total_accepted;
                 }
 

--- a/perf/bench/asio/coroutine/fan_out_bench.cpp
+++ b/perf/bench/asio/coroutine/fan_out_bench.cpp
@@ -13,7 +13,7 @@
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
 #include <boost/asio/awaitable.hpp>
-#include <boost/asio/use_awaitable.hpp>
+#include <boost/asio/deferred.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/read.hpp>
 #include <boost/asio/steady_timer.hpp>
@@ -34,7 +34,7 @@ using tcp = asio::ip::tcp;
 namespace asio_bench {
 namespace {
 
-asio::awaitable<void> echo_server( tcp::socket& sock )
+asio::awaitable<void, executor_type> echo_server( tcp_socket& sock )
 {
     char buf[64];
     try
@@ -42,16 +42,16 @@ asio::awaitable<void> echo_server( tcp::socket& sock )
         for( ;; )
         {
             auto n = co_await sock.async_read_some(
-                asio::buffer( buf, 64 ), asio::use_awaitable );
+                asio::buffer( buf, 64 ), asio::deferred );
             co_await asio::async_write(
-                sock, asio::buffer( buf, n ), asio::use_awaitable );
+                sock, asio::buffer( buf, n ), asio::deferred );
         }
     }
     catch( std::exception const& ) {}
 }
 
-asio::awaitable<void> sub_request(
-    tcp::socket& client,
+asio::awaitable<void, executor_type> sub_request(
+    tcp_socket& client,
     std::atomic<int>& remaining )
 {
     char send_buf[64] = {};
@@ -60,9 +60,9 @@ asio::awaitable<void> sub_request(
     try
     {
         co_await asio::async_write(
-            client, asio::buffer( send_buf, 64 ), asio::use_awaitable );
+            client, asio::buffer( send_buf, 64 ), asio::deferred );
         co_await asio::async_read(
-            client, asio::buffer( recv_buf, 64 ), asio::use_awaitable );
+            client, asio::buffer( recv_buf, 64 ), asio::deferred );
     }
     catch( std::exception const& ) {}
 
@@ -78,8 +78,8 @@ bench::benchmark_result bench_fork_join( int fan_out, double duration_s )
 
     asio::io_context ioc;
 
-    std::vector<tcp::socket> clients;
-    std::vector<tcp::socket> servers;
+    std::vector<tcp_socket> clients;
+    std::vector<tcp_socket> servers;
     clients.reserve( fan_out );
     servers.reserve( fan_out );
 
@@ -97,9 +97,9 @@ bench::benchmark_result bench_fork_join( int fan_out, double duration_s )
     int64_t cycles = 0;
     perf::statistics latency_stats;
 
-    auto parent = [&]() -> asio::awaitable<void>
+    auto parent = [&]() -> asio::awaitable<void, executor_type>
     {
-        asio::steady_timer t( ioc );
+        timer_type t( ioc );
         try
         {
             while( running.load( std::memory_order_relaxed ) )
@@ -115,7 +115,7 @@ bench::benchmark_result bench_fork_join( int fan_out, double duration_s )
                 while( remaining.load( std::memory_order_acquire ) > 0 )
                 {
                     t.expires_after( std::chrono::nanoseconds( 0 ) );
-                    co_await t.async_wait( asio::use_awaitable );
+                    co_await t.async_wait( asio::deferred );
                 }
 
                 latency_stats.add( sw.elapsed_us() );
@@ -173,8 +173,8 @@ bench::benchmark_result bench_nested(
 
     asio::io_context ioc;
 
-    std::vector<tcp::socket> clients;
-    std::vector<tcp::socket> servers;
+    std::vector<tcp_socket> clients;
+    std::vector<tcp_socket> servers;
     clients.reserve( total_subs );
     servers.reserve( total_subs );
 
@@ -194,7 +194,7 @@ bench::benchmark_result bench_nested(
 
     auto group_task = [&](
         int base_idx, int n, std::atomic<int>& groups_remaining )
-            -> asio::awaitable<void>
+            -> asio::awaitable<void, executor_type>
     {
         std::atomic<int> subs_remaining{ n };
         for( int i = 0; i < n; ++i )
@@ -202,13 +202,13 @@ bench::benchmark_result bench_nested(
                 sub_request( clients[base_idx + i], subs_remaining ),
                 asio::detached );
 
-        asio::steady_timer t( ioc );
+        timer_type t( ioc );
         try
         {
             while( subs_remaining.load( std::memory_order_acquire ) > 0 )
             {
                 t.expires_after( std::chrono::nanoseconds( 0 ) );
-                co_await t.async_wait( asio::use_awaitable );
+                co_await t.async_wait( asio::deferred );
             }
         }
         catch( std::exception const& ) {}
@@ -216,9 +216,9 @@ bench::benchmark_result bench_nested(
         groups_remaining.fetch_sub( 1, std::memory_order_release );
     };
 
-    auto parent = [&]() -> asio::awaitable<void>
+    auto parent = [&]() -> asio::awaitable<void, executor_type>
     {
-        asio::steady_timer t( ioc );
+        timer_type t( ioc );
         try
         {
             while( running.load( std::memory_order_relaxed ) )
@@ -235,7 +235,7 @@ bench::benchmark_result bench_nested(
                 while( groups_remaining.load( std::memory_order_acquire ) > 0 )
                 {
                     t.expires_after( std::chrono::nanoseconds( 0 ) );
-                    co_await t.async_wait( asio::use_awaitable );
+                    co_await t.async_wait( asio::deferred );
                 }
 
                 latency_stats.add( sw.elapsed_us() );
@@ -296,8 +296,8 @@ bench::benchmark_result bench_concurrent_parents(
     int total_subs = num_parents * fan_out;
     asio::io_context ioc;
 
-    std::vector<tcp::socket> clients;
-    std::vector<tcp::socket> servers;
+    std::vector<tcp_socket> clients;
+    std::vector<tcp_socket> servers;
     clients.reserve( total_subs );
     servers.reserve( total_subs );
 
@@ -316,10 +316,10 @@ bench::benchmark_result bench_concurrent_parents(
     std::vector<perf::statistics> stats( num_parents );
     std::atomic<int> parents_done{ 0 };
 
-    auto parent_task = [&]( int parent_idx ) -> asio::awaitable<void>
+    auto parent_task = [&]( int parent_idx ) -> asio::awaitable<void, executor_type>
     {
         int base = parent_idx * fan_out;
-        asio::steady_timer t( ioc );
+        timer_type t( ioc );
 
         try
         {
@@ -336,7 +336,7 @@ bench::benchmark_result bench_concurrent_parents(
                 while( remaining.load( std::memory_order_acquire ) > 0 )
                 {
                     t.expires_after( std::chrono::nanoseconds( 0 ) );
-                    co_await t.async_wait( asio::use_awaitable );
+                    co_await t.async_wait( asio::deferred );
                 }
 
                 stats[parent_idx].add( sw.elapsed_us() );

--- a/perf/bench/asio/coroutine/http_server_bench.cpp
+++ b/perf/bench/asio/coroutine/http_server_bench.cpp
@@ -13,7 +13,7 @@
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
 #include <boost/asio/awaitable.hpp>
-#include <boost/asio/use_awaitable.hpp>
+#include <boost/asio/deferred.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/read.hpp>
 #include <boost/asio/read_until.hpp>
@@ -34,8 +34,8 @@ namespace asio_bench {
 namespace {
 
 // Server: loop until read error (EOF from client shutdown)
-asio::awaitable<void> server_task(
-    tcp::socket& sock,
+asio::awaitable<void, executor_type> server_task(
+    tcp_socket& sock,
     int64_t& completed_requests )
 {
     std::string buf;
@@ -48,12 +48,12 @@ asio::awaitable<void> server_task(
                 sock,
                 asio::dynamic_buffer( buf ),
                 "\r\n\r\n",
-                asio::use_awaitable );
+                asio::deferred );
 
             co_await asio::async_write(
                 sock,
                 asio::buffer( bench::http::small_response, bench::http::small_response_size ),
-                asio::use_awaitable );
+                asio::deferred );
 
             ++completed_requests;
             buf.erase( 0, n );
@@ -63,8 +63,8 @@ asio::awaitable<void> server_task(
 }
 
 // Client: loop while running, then shutdown
-asio::awaitable<void> client_task(
-    tcp::socket& sock,
+asio::awaitable<void, executor_type> client_task(
+    tcp_socket& sock,
     std::atomic<bool>& running,
     int64_t& request_count,
     perf::statistics& latency_stats )
@@ -80,13 +80,13 @@ asio::awaitable<void> client_task(
             co_await asio::async_write(
                 sock,
                 asio::buffer( bench::http::small_request, bench::http::small_request_size ),
-                asio::use_awaitable );
+                asio::deferred );
 
             std::size_t header_end = co_await asio::async_read_until(
                 sock,
                 asio::dynamic_buffer( buf ),
                 "\r\n\r\n",
-                asio::use_awaitable );
+                asio::deferred );
 
             std::string_view headers( buf.data(), header_end );
             std::size_t content_length = 0;
@@ -110,7 +110,7 @@ asio::awaitable<void> client_task(
                 co_await asio::async_read(
                     sock,
                     asio::buffer( buf.data() + old_size, need ),
-                    asio::use_awaitable );
+                    asio::deferred );
             }
 
             double latency_us = sw.elapsed_us();
@@ -120,7 +120,7 @@ asio::awaitable<void> client_task(
             buf.erase( 0, total_size );
         }
 
-        sock.shutdown( tcp::socket::shutdown_send );
+        sock.shutdown( tcp_socket::shutdown_send );
     }
     catch( std::exception const& ) {}
 }
@@ -182,8 +182,8 @@ bench::benchmark_result bench_concurrent_connections( int num_connections, doubl
 
     asio::io_context ioc;
 
-    std::vector<tcp::socket> clients;
-    std::vector<tcp::socket> servers;
+    std::vector<tcp_socket> clients;
+    std::vector<tcp_socket> servers;
     std::vector<int64_t> server_completed( num_connections, 0 );
     std::vector<int64_t> client_counts( num_connections, 0 );
     std::vector<perf::statistics> stats( num_connections );
@@ -268,8 +268,8 @@ bench::benchmark_result bench_multithread(
 
     asio::io_context ioc( num_threads );
 
-    std::vector<tcp::socket> clients;
-    std::vector<tcp::socket> servers;
+    std::vector<tcp_socket> clients;
+    std::vector<tcp_socket> servers;
     std::vector<int64_t> server_completed( num_connections, 0 );
     std::vector<int64_t> client_counts( num_connections, 0 );
     std::vector<perf::statistics> stats( num_connections );

--- a/perf/bench/asio/coroutine/socket_latency_bench.cpp
+++ b/perf/bench/asio/coroutine/socket_latency_bench.cpp
@@ -13,7 +13,7 @@
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
 #include <boost/asio/awaitable.hpp>
-#include <boost/asio/use_awaitable.hpp>
+#include <boost/asio/deferred.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/read.hpp>
 #include <boost/asio/write.hpp>
@@ -31,9 +31,9 @@ namespace asio_bench {
 namespace {
 
 // Pattern C: coroutine loops check running flag
-asio::awaitable<void> pingpong_client_task(
-    tcp::socket& client,
-    tcp::socket& server,
+asio::awaitable<void, executor_type> pingpong_client_task(
+    tcp_socket& client,
+    tcp_socket& server,
     std::size_t message_size,
     std::atomic<bool>& running,
     int64_t& iterations,
@@ -51,29 +51,29 @@ asio::awaitable<void> pingpong_client_task(
             co_await asio::async_write(
                 client,
                 asio::buffer( send_buf.data(), send_buf.size() ),
-                asio::use_awaitable );
+                asio::deferred );
 
             co_await asio::async_read(
                 server,
                 asio::buffer( recv_buf.data(), recv_buf.size() ),
-                asio::use_awaitable );
+                asio::deferred );
 
             co_await asio::async_write(
                 server,
                 asio::buffer( recv_buf.data(), recv_buf.size() ),
-                asio::use_awaitable );
+                asio::deferred );
 
             co_await asio::async_read(
                 client,
                 asio::buffer( recv_buf.data(), recv_buf.size() ),
-                asio::use_awaitable );
+                asio::deferred );
 
             double rtt_us = sw.elapsed_us();
             stats.add( rtt_us );
             ++iterations;
         }
 
-        client.shutdown( tcp::socket::shutdown_send );
+        client.shutdown( tcp_socket::shutdown_send );
     }
     catch( std::exception const& ) {}
 }
@@ -124,8 +124,8 @@ bench::benchmark_result bench_concurrent_latency(
 
     asio::io_context ioc;
 
-    std::vector<tcp::socket> clients;
-    std::vector<tcp::socket> servers;
+    std::vector<tcp_socket> clients;
+    std::vector<tcp_socket> servers;
     std::vector<perf::statistics> stats( num_pairs );
     std::vector<int64_t> iters( num_pairs, 0 );
 

--- a/perf/bench/asio/coroutine/socket_throughput_bench.cpp
+++ b/perf/bench/asio/coroutine/socket_throughput_bench.cpp
@@ -13,7 +13,7 @@
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
 #include <boost/asio/awaitable.hpp>
-#include <boost/asio/use_awaitable.hpp>
+#include <boost/asio/deferred.hpp>
 #include <boost/asio/write.hpp>
 #include <boost/asio/read.hpp>
 #include <boost/asio/buffer.hpp>
@@ -45,7 +45,7 @@ bench::benchmark_result bench_throughput( std::size_t chunk_size, double duratio
     std::size_t total_written = 0;
     std::size_t total_read = 0;
 
-    auto write_task = [&]() -> asio::awaitable<void>
+    auto write_task = [&]() -> asio::awaitable<void, executor_type>
     {
         try
         {
@@ -53,15 +53,15 @@ bench::benchmark_result bench_throughput( std::size_t chunk_size, double duratio
             {
                 auto n = co_await writer.async_write_some(
                     asio::buffer( write_buf.data(), chunk_size ),
-                    asio::use_awaitable );
+                    asio::deferred );
                 total_written += n;
             }
-            writer.shutdown( tcp::socket::shutdown_send );
+            writer.shutdown( tcp_socket::shutdown_send );
         }
         catch( std::exception const& ) {}
     };
 
-    auto read_task = [&]() -> asio::awaitable<void>
+    auto read_task = [&]() -> asio::awaitable<void, executor_type>
     {
         try
         {
@@ -69,7 +69,7 @@ bench::benchmark_result bench_throughput( std::size_t chunk_size, double duratio
             {
                 auto n = co_await reader.async_read_some(
                     asio::buffer( read_buf.data(), read_buf.size() ),
-                    asio::use_awaitable );
+                    asio::deferred );
                 if( n == 0 )
                     break;
                 total_read += n;
@@ -127,7 +127,7 @@ bench::benchmark_result bench_bidirectional_throughput( std::size_t chunk_size, 
     std::size_t written1 = 0, read1 = 0;
     std::size_t written2 = 0, read2 = 0;
 
-    auto write1_task = [&]() -> asio::awaitable<void>
+    auto write1_task = [&]() -> asio::awaitable<void, executor_type>
     {
         try
         {
@@ -135,15 +135,15 @@ bench::benchmark_result bench_bidirectional_throughput( std::size_t chunk_size, 
             {
                 auto n = co_await sock1.async_write_some(
                     asio::buffer( buf1.data(), chunk_size ),
-                    asio::use_awaitable );
+                    asio::deferred );
                 written1 += n;
             }
-            sock1.shutdown( tcp::socket::shutdown_send );
+            sock1.shutdown( tcp_socket::shutdown_send );
         }
         catch( std::exception const& ) {}
     };
 
-    auto read1_task = [&]() -> asio::awaitable<void>
+    auto read1_task = [&]() -> asio::awaitable<void, executor_type>
     {
         try
         {
@@ -152,7 +152,7 @@ bench::benchmark_result bench_bidirectional_throughput( std::size_t chunk_size, 
             {
                 auto n = co_await sock2.async_read_some(
                     asio::buffer( rbuf.data(), rbuf.size() ),
-                    asio::use_awaitable );
+                    asio::deferred );
                 if( n == 0 ) break;
                 read1 += n;
             }
@@ -160,7 +160,7 @@ bench::benchmark_result bench_bidirectional_throughput( std::size_t chunk_size, 
         catch( std::exception const& ) {}
     };
 
-    auto write2_task = [&]() -> asio::awaitable<void>
+    auto write2_task = [&]() -> asio::awaitable<void, executor_type>
     {
         try
         {
@@ -168,15 +168,15 @@ bench::benchmark_result bench_bidirectional_throughput( std::size_t chunk_size, 
             {
                 auto n = co_await sock2.async_write_some(
                     asio::buffer( buf2.data(), chunk_size ),
-                    asio::use_awaitable );
+                    asio::deferred );
                 written2 += n;
             }
-            sock2.shutdown( tcp::socket::shutdown_send );
+            sock2.shutdown( tcp_socket::shutdown_send );
         }
         catch( std::exception const& ) {}
     };
 
-    auto read2_task = [&]() -> asio::awaitable<void>
+    auto read2_task = [&]() -> asio::awaitable<void, executor_type>
     {
         try
         {
@@ -185,7 +185,7 @@ bench::benchmark_result bench_bidirectional_throughput( std::size_t chunk_size, 
             {
                 auto n = co_await sock1.async_read_some(
                     asio::buffer( rbuf.data(), rbuf.size() ),
-                    asio::use_awaitable );
+                    asio::deferred );
                 if( n == 0 ) break;
                 read2 += n;
             }

--- a/perf/bench/asio/coroutine/timer_bench.cpp
+++ b/perf/bench/asio/coroutine/timer_bench.cpp
@@ -8,11 +8,12 @@
 //
 
 #include "benchmarks.hpp"
+#include "../socket_utils.hpp"
 
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
 #include <boost/asio/awaitable.hpp>
-#include <boost/asio/use_awaitable.hpp>
+#include <boost/asio/deferred.hpp>
 #include <boost/asio/steady_timer.hpp>
 
 #include <atomic>
@@ -48,7 +49,7 @@ bench::benchmark_result bench_schedule_cancel( double duration_s )
     {
         for( int i = 0; i < batch_size; ++i )
         {
-            asio::steady_timer t( ioc );
+            timer_type t( ioc );
             t.expires_after( std::chrono::hours( 1 ) );
             t.cancel();
             ++counter;
@@ -85,15 +86,15 @@ bench::benchmark_result bench_fire_rate( double duration_s )
     std::atomic<bool> running{ true };
     int64_t counter = 0;
 
-    auto task = [&]() -> asio::awaitable<void>
+    auto task = [&]() -> asio::awaitable<void, executor_type>
     {
-        asio::steady_timer t( ioc );
+        timer_type t( ioc );
         try
         {
             while( running.load( std::memory_order_relaxed ) )
             {
                 t.expires_after( std::chrono::nanoseconds( 0 ) );
-                co_await t.async_wait( asio::use_awaitable );
+                co_await t.async_wait( asio::deferred );
                 ++counter;
             }
         }
@@ -140,16 +141,16 @@ bench::benchmark_result bench_concurrent_timers( int num_timers, double duration
     std::vector<int64_t> fire_counts( num_timers, 0 );
     std::vector<perf::statistics> stats( num_timers );
 
-    auto timer_task = [&]( int idx, std::chrono::microseconds interval ) -> asio::awaitable<void>
+    auto timer_task = [&]( int idx, std::chrono::microseconds interval ) -> asio::awaitable<void, executor_type>
     {
-        asio::steady_timer t( ioc );
+        timer_type t( ioc );
         try
         {
             while( running.load( std::memory_order_relaxed ) )
             {
                 perf::stopwatch sw;
                 t.expires_after( interval );
-                co_await t.async_wait( asio::use_awaitable );
+                co_await t.async_wait( asio::deferred );
                 double latency_us = sw.elapsed_us();
                 stats[idx].add( latency_us );
                 ++fire_counts[idx];

--- a/perf/bench/asio/socket_utils.hpp
+++ b/perf/bench/asio/socket_utils.hpp
@@ -12,7 +12,9 @@
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/steady_timer.hpp>
 
+#include <chrono>
 #include <utility>
 
 namespace asio_bench {
@@ -20,14 +22,23 @@ namespace asio_bench {
 namespace asio = boost::asio;
 using tcp = asio::ip::tcp;
 
-/** Create a connected pair of TCP sockets for benchmarking. */
-inline std::pair<tcp::socket, tcp::socket> make_socket_pair( asio::io_context& ioc )
-{
-    tcp::acceptor acceptor( ioc, tcp::endpoint( tcp::v4(), 0 ),
-        true /* reuse_address */ );
+// Concrete (non-type-erased) executor types avoid any_io_executor overhead
+using executor_type = asio::io_context::executor_type;
+using tcp_socket = asio::basic_stream_socket<tcp, executor_type>;
+using tcp_acceptor = asio::basic_socket_acceptor<tcp, executor_type>;
+using timer_type = asio::basic_waitable_timer<
+    std::chrono::steady_clock,
+    asio::wait_traits<std::chrono::steady_clock>,
+    executor_type>;
 
-    tcp::socket client( ioc );
-    tcp::socket server( ioc );
+/** Create a connected pair of TCP sockets for benchmarking. */
+inline std::pair<tcp_socket, tcp_socket> make_socket_pair( asio::io_context& ioc )
+{
+    tcp_acceptor acceptor( ioc.get_executor(),
+        tcp::endpoint( tcp::v4(), 0 ), true /* reuse_address */ );
+
+    tcp_socket client( ioc.get_executor() );
+    tcp_socket server( ioc.get_executor() );
 
     auto endpoint = acceptor.local_endpoint();
     client.connect( tcp::endpoint( asio::ip::address_v4::loopback(), endpoint.port() ) );

--- a/perf/bench/main.cpp
+++ b/perf/bench/main.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 
 #include "../common/backend_selection.hpp"
+#include "../common/perf.hpp"
 #include "common/benchmark.hpp"
 
 namespace {
@@ -256,6 +257,7 @@ int main( int argc, char* argv[] )
                 {
                     if( !want_bench( b ) )
                         continue;
+                    perf::await_conntrack_drain();
                     if( want_corosio )
                         corosio_bench::run_socket_throughput_benchmarks( factory, collector, b, duration_s );
 #ifdef BOOST_COROSIO_BENCH_HAS_ASIO
@@ -274,6 +276,7 @@ int main( int argc, char* argv[] )
                 {
                     if( !want_bench( b ) )
                         continue;
+                    perf::await_conntrack_drain();
                     if( want_corosio )
                         corosio_bench::run_socket_latency_benchmarks( factory, collector, b, duration_s );
 #ifdef BOOST_COROSIO_BENCH_HAS_ASIO
@@ -292,6 +295,7 @@ int main( int argc, char* argv[] )
                 {
                     if( !want_bench( b ) )
                         continue;
+                    perf::await_conntrack_drain();
                     if( want_corosio )
                         corosio_bench::run_http_server_benchmarks( factory, collector, b, duration_s );
 #ifdef BOOST_COROSIO_BENCH_HAS_ASIO
@@ -328,6 +332,7 @@ int main( int argc, char* argv[] )
                 {
                     if( !want_bench( b ) )
                         continue;
+                    perf::await_conntrack_drain();
                     if( want_corosio )
                         corosio_bench::run_accept_churn_benchmarks( factory, collector, b, duration_s );
 #ifdef BOOST_COROSIO_BENCH_HAS_ASIO
@@ -346,6 +351,7 @@ int main( int argc, char* argv[] )
                 {
                     if( !want_bench( b ) )
                         continue;
+                    perf::await_conntrack_drain();
                     if( want_corosio )
                         corosio_bench::run_fan_out_benchmarks( factory, collector, b, duration_s );
 #ifdef BOOST_COROSIO_BENCH_HAS_ASIO

--- a/perf/common/perf.hpp
+++ b/perf/common/perf.hpp
@@ -13,11 +13,13 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <numeric>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace perf {
@@ -233,6 +235,55 @@ inline void print_latency_stats(statistics const& stats, char const* label)
     std::cout << "    p99.9: " << format_latency(stats.p999()) << "\n";
     std::cout << "    min:   " << format_latency((stats.min)()) << "\n";
     std::cout << "    max:   " << format_latency((stats.max)()) << "\n";
+}
+
+/** Wait for the nf_conntrack table to drain below a safe threshold.
+
+    Linux netfilter connection tracking creates an entry for every TCP
+    connection. When the table is full, new SYN packets are silently
+    dropped, causing ~1 s retransmit delays that corrupt benchmark
+    results.  This function polls the table size and blocks until
+    enough headroom exists for the next benchmark run.
+
+    No-op on non-Linux or when conntrack is not loaded.
+*/
+inline void await_conntrack_drain()
+{
+#ifdef __linux__
+    auto read_value = []( char const* path ) -> long
+    {
+        std::ifstream f( path );
+        long v = -1;
+        if( f.is_open() )
+            f >> v;
+        return v;
+    };
+
+    long ct_max = read_value( "/proc/sys/net/netfilter/nf_conntrack_max" );
+    if( ct_max <= 0 )
+        return;
+
+    long threshold = ct_max * 3 / 4;
+    long count = read_value( "/proc/sys/net/netfilter/nf_conntrack_count" );
+    if( count < 0 || count <= threshold )
+        return;
+
+    std::cout << "  [conntrack] table at " << count << "/" << ct_max
+              << " — waiting to drain below " << threshold << " ..." << std::flush;
+
+    using clock = std::chrono::steady_clock;
+    auto deadline = clock::now() + std::chrono::seconds( 30 );
+
+    while( clock::now() < deadline )
+    {
+        std::this_thread::sleep_for( std::chrono::milliseconds( 200 ) );
+        count = read_value( "/proc/sys/net/netfilter/nf_conntrack_count" );
+        if( count < 0 || count <= threshold )
+            break;
+    }
+
+    std::cout << " " << count << "/" << ct_max << "\n";
+#endif
 }
 
 } // namespace perf

--- a/src/corosio/src/detail/epoll/acceptors.cpp
+++ b/src/corosio/src/detail/epoll/acceptors.cpp
@@ -43,6 +43,9 @@ operator()()
 {
     stop_cb.reset();
 
+    static_cast<epoll_acceptor_impl*>(acceptor_impl_)
+        ->service().scheduler().reset_inline_budget();
+
     bool success = (errn == 0 && !cancelled.load(std::memory_order_acquire));
 
     if (ec_out)
@@ -55,77 +58,49 @@ operator()()
             *ec_out = {};
     }
 
-    if (success && accepted_fd >= 0)
+    // Set up the peer socket on success
+    if (success && accepted_fd >= 0 && acceptor_impl_)
     {
-        if (acceptor_impl_)
+        auto* socket_svc = static_cast<epoll_acceptor_impl*>(acceptor_impl_)
+            ->service().socket_service();
+        if (socket_svc)
         {
-            auto* socket_svc = static_cast<epoll_acceptor_impl*>(acceptor_impl_)
-                ->service().socket_service();
-            if (socket_svc)
+            auto& impl = static_cast<epoll_socket_impl&>(socket_svc->create_impl());
+            impl.set_socket(accepted_fd);
+
+            impl.desc_state_.fd = accepted_fd;
             {
-                auto& impl = static_cast<epoll_socket_impl&>(socket_svc->create_impl());
-                impl.set_socket(accepted_fd);
-
-                // Register accepted socket with epoll (edge-triggered mode)
-                impl.desc_state_.fd = accepted_fd;
-                {
-                    std::lock_guard lock(impl.desc_state_.mutex);
-                    impl.desc_state_.read_op = nullptr;
-                    impl.desc_state_.write_op = nullptr;
-                    impl.desc_state_.connect_op = nullptr;
-                }
-                socket_svc->scheduler().register_descriptor(accepted_fd, &impl.desc_state_);
-
-                sockaddr_in local_addr{};
-                socklen_t local_len = sizeof(local_addr);
-                sockaddr_in remote_addr{};
-                socklen_t remote_len = sizeof(remote_addr);
-
-                endpoint local_ep, remote_ep;
-                if (::getsockname(accepted_fd, reinterpret_cast<sockaddr*>(&local_addr), &local_len) == 0)
-                    local_ep = from_sockaddr_in(local_addr);
-                if (::getpeername(accepted_fd, reinterpret_cast<sockaddr*>(&remote_addr), &remote_len) == 0)
-                    remote_ep = from_sockaddr_in(remote_addr);
-
-                impl.set_endpoints(local_ep, remote_ep);
-
-                if (impl_out)
-                    *impl_out = &impl;
-
-                accepted_fd = -1;
+                std::lock_guard lock(impl.desc_state_.mutex);
+                impl.desc_state_.read_op = nullptr;
+                impl.desc_state_.write_op = nullptr;
+                impl.desc_state_.connect_op = nullptr;
             }
-            else
-            {
-                if (ec_out && !*ec_out)
-                    *ec_out = make_err(ENOENT);
-                ::close(accepted_fd);
-                accepted_fd = -1;
-                if (impl_out)
-                    *impl_out = nullptr;
-            }
+            socket_svc->scheduler().register_descriptor(accepted_fd, &impl.desc_state_);
+
+            impl.set_endpoints(
+                static_cast<epoll_acceptor_impl*>(acceptor_impl_)->local_endpoint(),
+                from_sockaddr_in(peer_addr));
+
+            if (impl_out)
+                *impl_out = &impl;
+            accepted_fd = -1;
         }
         else
         {
-            ::close(accepted_fd);
-            accepted_fd = -1;
-            if (impl_out)
-                *impl_out = nullptr;
+            // No socket service — treat as error
+            if (ec_out && !*ec_out)
+                *ec_out = make_err(ENOENT);
+            success = false;
         }
     }
-    else
+
+    if (!success || !acceptor_impl_)
     {
         if (accepted_fd >= 0)
         {
             ::close(accepted_fd);
             accepted_fd = -1;
         }
-
-        if (peer_impl)
-        {
-            peer_impl->release();
-            peer_impl = nullptr;
-        }
-
         if (impl_out)
             *impl_out = nullptr;
     }
@@ -183,54 +158,72 @@ accept(
             std::lock_guard lock(desc_state_.mutex);
             desc_state_.read_ready = false;
         }
+
+        if (svc_.scheduler().try_consume_inline_budget())
+        {
+            auto* socket_svc = svc_.socket_service();
+            if (socket_svc)
+            {
+                auto& impl = static_cast<epoll_socket_impl&>(socket_svc->create_impl());
+                impl.set_socket(accepted);
+
+                impl.desc_state_.fd = accepted;
+                {
+                    std::lock_guard lock(impl.desc_state_.mutex);
+                    impl.desc_state_.read_op = nullptr;
+                    impl.desc_state_.write_op = nullptr;
+                    impl.desc_state_.connect_op = nullptr;
+                }
+                socket_svc->scheduler().register_descriptor(accepted, &impl.desc_state_);
+
+                impl.set_endpoints(local_endpoint_, from_sockaddr_in(addr));
+
+                *ec = {};
+                if (impl_out)
+                    *impl_out = &impl;
+            }
+            else
+            {
+                ::close(accepted);
+                *ec = make_err(ENOENT);
+                if (impl_out)
+                    *impl_out = nullptr;
+            }
+            return ex.dispatch(h);
+        }
+
         op.accepted_fd = accepted;
+        op.peer_addr = addr;
         op.complete(0, 0);
         op.impl_ptr = shared_from_this();
         svc_.post(&op);
-        // completion is always posted to scheduler queue, never inline.
         return std::noop_coroutine();
     }
 
     if (errno == EAGAIN || errno == EWOULDBLOCK)
     {
-        svc_.work_started();
         op.impl_ptr = shared_from_this();
+        svc_.work_started();
 
         std::lock_guard lock(desc_state_.mutex);
+        bool io_done = false;
         if (desc_state_.read_ready)
         {
             desc_state_.read_ready = false;
             op.perform_io();
-            if (op.errn == EAGAIN || op.errn == EWOULDBLOCK)
-            {
+            io_done = (op.errn != EAGAIN && op.errn != EWOULDBLOCK);
+            if (!io_done)
                 op.errn = 0;
-                if (op.cancelled.load(std::memory_order_acquire))
-                {
-                    svc_.post(&op);
-                    svc_.work_finished();
-                }
-                else
-                {
-                    desc_state_.read_op = &op;
-                }
-            }
-            else
-            {
-                svc_.post(&op);
-                svc_.work_finished();
-            }
+        }
+
+        if (io_done || op.cancelled.load(std::memory_order_acquire))
+        {
+            svc_.post(&op);
+            svc_.work_finished();
         }
         else
         {
-            if (op.cancelled.load(std::memory_order_acquire))
-            {
-                svc_.post(&op);
-                svc_.work_finished();
-            }
-            else
-            {
-                desc_state_.read_op = &op;
-            }
+            desc_state_.read_op = &op;
         }
         return std::noop_coroutine();
     }
@@ -246,27 +239,7 @@ void
 epoll_acceptor_impl::
 cancel() noexcept
 {
-    std::shared_ptr<epoll_acceptor_impl> self;
-    try {
-        self = shared_from_this();
-    } catch (const std::bad_weak_ptr&) {
-        return;
-    }
-
-    acc_.request_cancel();
-
-    epoll_op* claimed = nullptr;
-    {
-        std::lock_guard lock(desc_state_.mutex);
-        if (desc_state_.read_op == &acc_)
-            claimed = std::exchange(desc_state_.read_op, nullptr);
-    }
-    if (claimed)
-    {
-        acc_.impl_ptr = self;
-        svc_.post(&acc_);
-        svc_.work_finished();
-    }
+    cancel_single_op(acc_);
 }
 
 void

--- a/src/corosio/src/detail/epoll/acceptors.cpp
+++ b/src/corosio/src/detail/epoll/acceptors.cpp
@@ -48,15 +48,12 @@ operator()()
 
     bool success = (errn == 0 && !cancelled.load(std::memory_order_acquire));
 
-    if (ec_out)
-    {
-        if (cancelled.load(std::memory_order_acquire))
-            *ec_out = capy::error::canceled;
-        else if (errn != 0)
-            *ec_out = make_err(errn);
-        else
-            *ec_out = {};
-    }
+    if (cancelled.load(std::memory_order_acquire))
+        *ec_out = capy::error::canceled;
+    else if (errn != 0)
+        *ec_out = make_err(errn);
+    else
+        *ec_out = {};
 
     // Set up the peer socket on success
     if (success && accepted_fd >= 0 && acceptor_impl_)
@@ -88,8 +85,7 @@ operator()()
         else
         {
             // No socket service — treat as error
-            if (ec_out && !*ec_out)
-                *ec_out = make_err(ENOENT);
+            *ec_out = make_err(ENOENT);
             success = false;
         }
     }

--- a/src/corosio/src/detail/epoll/op.hpp
+++ b/src/corosio/src/detail/epoll/op.hpp
@@ -189,35 +189,8 @@ struct epoll_op : scheduler_op
         acceptor_impl_ = nullptr;
     }
 
-    void operator()() override
-    {
-        stop_cb.reset();
-
-        if (ec_out)
-        {
-            if (cancelled.load(std::memory_order_acquire))
-                *ec_out = capy::error::canceled;
-            else if (errn != 0)
-                *ec_out = make_err(errn);
-            else if (is_read_operation() && bytes_transferred == 0)
-                *ec_out = capy::error::eof;
-            else
-                *ec_out = {};
-        }
-
-        if (bytes_out)
-            *bytes_out = bytes_transferred;
-
-        // Move to stack before resuming coroutine. The coroutine might close
-        // the socket, releasing the last wrapper ref. If impl_ptr were the
-        // last ref and we destroyed it while still in operator(), we'd have
-        // use-after-free. Moving to local ensures destruction happens at
-        // function exit, after all member accesses are complete.
-        capy::executor_ref saved_ex( std::move( ex ) );
-        std::coroutine_handle<> saved_h( std::move( h ) );
-        auto prevent_premature_destruction = std::move(impl_ptr);
-        dispatch_coro(saved_ex, saved_h).resume();
-    }
+    // Defined in sockets.cpp where epoll_socket_impl is complete
+    void operator()() override;
 
     virtual bool is_read_operation() const noexcept { return false; }
     virtual void cancel() noexcept = 0;
@@ -363,24 +336,23 @@ struct epoll_write_op : epoll_op
 struct epoll_accept_op : epoll_op
 {
     int accepted_fd = -1;
-    io_object::io_object_impl* peer_impl = nullptr;
     io_object::io_object_impl** impl_out = nullptr;
+    sockaddr_in peer_addr{};
 
     void reset() noexcept
     {
         epoll_op::reset();
         accepted_fd = -1;
-        peer_impl = nullptr;
         impl_out = nullptr;
+        peer_addr = {};
     }
 
     void perform_io() noexcept override
     {
-        sockaddr_in addr{};
-        socklen_t addrlen = sizeof(addr);
+        socklen_t addrlen = sizeof(peer_addr);
         int new_fd;
         do {
-            new_fd = ::accept4(fd, reinterpret_cast<sockaddr*>(&addr),
+            new_fd = ::accept4(fd, reinterpret_cast<sockaddr*>(&peer_addr),
                                &addrlen, SOCK_NONBLOCK | SOCK_CLOEXEC);
         } while (new_fd < 0 && errno == EINTR);
 

--- a/src/corosio/src/detail/epoll/scheduler.cpp
+++ b/src/corosio/src/detail/epoll/scheduler.cpp
@@ -102,11 +102,13 @@ struct scheduler_context
     scheduler_context* next;
     op_queue private_queue;
     long private_outstanding_work;
+    int inline_budget;
 
     scheduler_context(epoll_scheduler const* k, scheduler_context* n)
         : key(k)
         , next(n)
         , private_outstanding_work(0)
+        , inline_budget(0)
     {
     }
 };
@@ -144,6 +146,29 @@ find_context(epoll_scheduler const* self) noexcept
 }
 
 } // namespace
+
+void
+epoll_scheduler::
+reset_inline_budget() const noexcept
+{
+    if (auto* ctx = find_context(this))
+        ctx->inline_budget = max_inline_budget_;
+}
+
+bool
+epoll_scheduler::
+try_consume_inline_budget() const noexcept
+{
+    if (auto* ctx = find_context(this))
+    {
+        if (ctx->inline_budget > 0)
+        {
+            --ctx->inline_budget;
+            return true;
+        }
+    }
+    return false;
+}
 
 void
 descriptor_state::

--- a/src/corosio/src/detail/epoll/scheduler.hpp
+++ b/src/corosio/src/detail/epoll/scheduler.hpp
@@ -101,6 +101,19 @@ public:
     */
     int epoll_fd() const noexcept { return epoll_fd_; }
 
+    /** Reset the thread's inline completion budget.
+
+        Called at the start of each posted completion handler to
+        grant a fresh budget for speculative inline completions.
+    */
+    void reset_inline_budget() const noexcept;
+
+    /** Consume one unit of inline budget if available.
+
+        @return True if budget was available and consumed.
+    */
+    bool try_consume_inline_budget() const noexcept;
+
     /** Register a descriptor for persistent monitoring.
 
         The fd is registered once and stays registered until explicitly
@@ -235,6 +248,7 @@ private:
     int epoll_fd_;
     int event_fd_;                              // for interrupting reactor
     int timer_fd_;                              // timerfd for kernel-managed timer expiry
+    int max_inline_budget_ = 2;
     mutable std::mutex mutex_;
     mutable std::condition_variable cond_;
     mutable op_queue completed_ops_;

--- a/src/corosio/src/detail/epoll/sockets.cpp
+++ b/src/corosio/src/detail/epoll/sockets.cpp
@@ -30,6 +30,39 @@
 
 namespace boost::corosio::detail {
 
+// Register an op with the reactor, handling cached edge events.
+// Called under the EAGAIN/EINPROGRESS path when speculative I/O failed.
+void
+epoll_socket_impl::
+register_op(
+    epoll_op& op,
+    epoll_op*& desc_slot,
+    bool& ready_flag) noexcept
+{
+    svc_.work_started();
+
+    std::lock_guard lock(desc_state_.mutex);
+    bool io_done = false;
+    if (ready_flag)
+    {
+        ready_flag = false;
+        op.perform_io();
+        io_done = (op.errn != EAGAIN && op.errn != EWOULDBLOCK);
+        if (!io_done)
+            op.errn = 0;
+    }
+
+    if (io_done || op.cancelled.load(std::memory_order_acquire))
+    {
+        svc_.post(&op);
+        svc_.work_finished();
+    }
+    else
+    {
+        desc_slot = &op;
+    }
+}
+
 void
 epoll_op::canceller::
 operator()() const noexcept
@@ -68,10 +101,46 @@ cancel() noexcept
 }
 
 void
+epoll_op::
+operator()()
+{
+    stop_cb.reset();
+
+    socket_impl_->svc_.scheduler().reset_inline_budget();
+
+    if (ec_out)
+    {
+        if (cancelled.load(std::memory_order_acquire))
+            *ec_out = capy::error::canceled;
+        else if (errn != 0)
+            *ec_out = make_err(errn);
+        else if (is_read_operation() && bytes_transferred == 0)
+            *ec_out = capy::error::eof;
+        else
+            *ec_out = {};
+    }
+
+    if (bytes_out)
+        *bytes_out = bytes_transferred;
+
+    // Move to stack before resuming coroutine. The coroutine might close
+    // the socket, releasing the last wrapper ref. If impl_ptr were the
+    // last ref and we destroyed it while still in operator(), we'd have
+    // use-after-free. Moving to local ensures destruction happens at
+    // function exit, after all member accesses are complete.
+    capy::executor_ref saved_ex( std::move( ex ) );
+    std::coroutine_handle<> saved_h( std::move( h ) );
+    auto prevent_premature_destruction = std::move(impl_ptr);
+    dispatch_coro(saved_ex, saved_h).resume();
+}
+
+void
 epoll_connect_op::
 operator()()
 {
     stop_cb.reset();
+
+    socket_impl_->svc_.scheduler().reset_inline_budget();
 
     bool success = (errn == 0 && !cancelled.load(std::memory_order_acquire));
 
@@ -135,236 +204,52 @@ connect(
     std::error_code* ec)
 {
     auto& op = conn_;
-    op.reset();
-    op.h = h;
-    op.ex = ex;
-    op.ec_out = ec;
-    op.fd = fd_;
-    op.target_endpoint = ep;  // Store target for endpoint caching
-    op.start(token, this);
 
     sockaddr_in addr = detail::to_sockaddr_in(ep);
     int result = ::connect(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
 
     if (result == 0)
     {
-        // Sync success - cache endpoints immediately
-        // Remote is always known; local may fail but we still cache remote
         sockaddr_in local_addr{};
         socklen_t local_len = sizeof(local_addr);
         if (::getsockname(fd_, reinterpret_cast<sockaddr*>(&local_addr), &local_len) == 0)
             local_endpoint_ = detail::from_sockaddr_in(local_addr);
         remote_endpoint_ = ep;
-
-        op.complete(0, 0);
-        op.impl_ptr = shared_from_this();
-        svc_.post(&op);
-        // completion is always posted to scheduler queue, never inline.
-        return std::noop_coroutine();
     }
 
-    if (errno == EINPROGRESS)
+    if (result == 0 || errno != EINPROGRESS)
     {
-        svc_.work_started();
+        int err = (result < 0) ? errno : 0;
+        if (svc_.scheduler().try_consume_inline_budget())
+        {
+            *ec = err ? make_err(err) : std::error_code{};
+            return ex.dispatch(h);
+        }
+        op.reset();
+        op.h = h;
+        op.ex = ex;
+        op.ec_out = ec;
+        op.fd = fd_;
+        op.target_endpoint = ep;
+        op.start(token, this);
         op.impl_ptr = shared_from_this();
-
-        std::lock_guard lock(desc_state_.mutex);
-        if (desc_state_.write_ready)
-        {
-            desc_state_.write_ready = false;
-            op.perform_io();
-            if (op.errn == EAGAIN || op.errn == EWOULDBLOCK)
-            {
-                op.errn = 0;
-                if (op.cancelled.load(std::memory_order_acquire))
-                {
-                    svc_.post(&op);
-                    svc_.work_finished();
-                }
-                else
-                {
-                    desc_state_.connect_op = &op;
-                }
-            }
-            else
-            {
-                svc_.post(&op);
-                svc_.work_finished();
-            }
-        }
-        else
-        {
-            if (op.cancelled.load(std::memory_order_acquire))
-            {
-                svc_.post(&op);
-                svc_.work_finished();
-            }
-            else
-            {
-                desc_state_.connect_op = &op;
-            }
-        }
+        op.complete(err, 0);
+        svc_.post(&op);
         return std::noop_coroutine();
     }
 
-    op.complete(errno, 0);
+    // EINPROGRESS — register with reactor
+    op.reset();
+    op.h = h;
+    op.ex = ex;
+    op.ec_out = ec;
+    op.fd = fd_;
+    op.target_endpoint = ep;
+    op.start(token, this);
     op.impl_ptr = shared_from_this();
-    svc_.post(&op);
-    // completion is always posted to scheduler queue, never inline.
+
+    register_op(op, desc_state_.connect_op, desc_state_.write_ready);
     return std::noop_coroutine();
-}
-
-void
-epoll_socket_impl::
-do_read_io()
-{
-    auto& op = rd_;
-
-    ssize_t n;
-    do {
-        n = ::readv(fd_, op.iovecs, op.iovec_count);
-    } while (n < 0 && errno == EINTR);
-
-    if (n > 0)
-    {
-        {
-            std::lock_guard lock(desc_state_.mutex);
-            desc_state_.read_ready = false;
-        }
-        op.complete(0, static_cast<std::size_t>(n));
-        svc_.post(&op);
-        return;
-    }
-
-    if (n == 0)
-    {
-        {
-            std::lock_guard lock(desc_state_.mutex);
-            desc_state_.read_ready = false;
-        }
-        op.complete(0, 0);
-        svc_.post(&op);
-        return;
-    }
-
-    if (errno == EAGAIN || errno == EWOULDBLOCK)
-    {
-        svc_.work_started();
-
-        std::lock_guard lock(desc_state_.mutex);
-        if (desc_state_.read_ready)
-        {
-            desc_state_.read_ready = false;
-            op.perform_io();
-            if (op.errn == EAGAIN || op.errn == EWOULDBLOCK)
-            {
-                op.errn = 0;
-                if (op.cancelled.load(std::memory_order_acquire))
-                {
-                    svc_.post(&op);
-                    svc_.work_finished();
-                }
-                else
-                {
-                    desc_state_.read_op = &op;
-                }
-            }
-            else
-            {
-                svc_.post(&op);
-                svc_.work_finished();
-            }
-        }
-        else
-        {
-            if (op.cancelled.load(std::memory_order_acquire))
-            {
-                svc_.post(&op);
-                svc_.work_finished();
-            }
-            else
-            {
-                desc_state_.read_op = &op;
-            }
-        }
-        return;
-    }
-
-    op.complete(errno, 0);
-    svc_.post(&op);
-}
-
-void
-epoll_socket_impl::
-do_write_io()
-{
-    auto& op = wr_;
-
-    msghdr msg{};
-    msg.msg_iov = op.iovecs;
-    msg.msg_iovlen = static_cast<std::size_t>(op.iovec_count);
-
-    ssize_t n;
-    do {
-        n = ::sendmsg(fd_, &msg, MSG_NOSIGNAL);
-    } while (n < 0 && errno == EINTR);
-
-    if (n > 0)
-    {
-        {
-            std::lock_guard lock(desc_state_.mutex);
-            desc_state_.write_ready = false;
-        }
-        op.complete(0, static_cast<std::size_t>(n));
-        svc_.post(&op);
-        return;
-    }
-
-    if (errno == EAGAIN || errno == EWOULDBLOCK)
-    {
-        svc_.work_started();
-
-        std::lock_guard lock(desc_state_.mutex);
-        if (desc_state_.write_ready)
-        {
-            desc_state_.write_ready = false;
-            op.perform_io();
-            if (op.errn == EAGAIN || op.errn == EWOULDBLOCK)
-            {
-                op.errn = 0;
-                if (op.cancelled.load(std::memory_order_acquire))
-                {
-                    svc_.post(&op);
-                    svc_.work_finished();
-                }
-                else
-                {
-                    desc_state_.write_op = &op;
-                }
-            }
-            else
-            {
-                svc_.post(&op);
-                svc_.work_finished();
-            }
-        }
-        else
-        {
-            if (op.cancelled.load(std::memory_order_acquire))
-            {
-                svc_.post(&op);
-                svc_.work_finished();
-            }
-            else
-            {
-                desc_state_.write_op = &op;
-            }
-        }
-        return;
-    }
-
-    op.complete(errno ? errno : EIO, 0);
-    svc_.post(&op);
 }
 
 std::coroutine_handle<>
@@ -379,21 +264,19 @@ read_some(
 {
     auto& op = rd_;
     op.reset();
-    op.h = h;
-    op.ex = ex;
-    op.ec_out = ec;
-    op.bytes_out = bytes_out;
-    op.fd = fd_;
-    op.start(token, this);
-    op.impl_ptr = shared_from_this();
 
-    // Must prepare buffers before initiator runs
     capy::mutable_buffer bufs[epoll_read_op::max_buffers];
     op.iovec_count = static_cast<int>(param.copy_to(bufs, epoll_read_op::max_buffers));
 
     if (op.iovec_count == 0 || (op.iovec_count == 1 && bufs[0].size() == 0))
     {
         op.empty_buffer_read = true;
+        op.h = h;
+        op.ex = ex;
+        op.ec_out = ec;
+        op.bytes_out = bytes_out;
+        op.start(token, this);
+        op.impl_ptr = shared_from_this();
         op.complete(0, 0);
         svc_.post(&op);
         return std::noop_coroutine();
@@ -405,35 +288,50 @@ read_some(
         op.iovecs[i].iov_len = bufs[i].size();
     }
 
-    // Speculative read: bypass initiator when data is ready
+    // Speculative read
     ssize_t n;
     do {
         n = ::readv(fd_, op.iovecs, op.iovec_count);
     } while (n < 0 && errno == EINTR);
 
-    if (n > 0)
+    if (n >= 0 || (errno != EAGAIN && errno != EWOULDBLOCK))
     {
-        op.complete(0, static_cast<std::size_t>(n));
+        int err = (n < 0) ? errno : 0;
+        auto bytes = (n > 0) ? static_cast<std::size_t>(n) : std::size_t(0);
+
+        if (svc_.scheduler().try_consume_inline_budget())
+        {
+            if (err)
+                *ec = make_err(err);
+            else if (n == 0)
+                *ec = capy::error::eof;
+            else
+                *ec = {};
+            *bytes_out = bytes;
+            return ex.dispatch(h);
+        }
+        op.h = h;
+        op.ex = ex;
+        op.ec_out = ec;
+        op.bytes_out = bytes_out;
+        op.start(token, this);
+        op.impl_ptr = shared_from_this();
+        op.complete(err, bytes);
         svc_.post(&op);
         return std::noop_coroutine();
     }
 
-    if (n == 0)
-    {
-        op.complete(0, 0);
-        svc_.post(&op);
-        return std::noop_coroutine();
-    }
+    // EAGAIN — register with reactor
+    op.h = h;
+    op.ex = ex;
+    op.ec_out = ec;
+    op.bytes_out = bytes_out;
+    op.fd = fd_;
+    op.start(token, this);
+    op.impl_ptr = shared_from_this();
 
-    if (errno != EAGAIN && errno != EWOULDBLOCK)
-    {
-        op.complete(errno, 0);
-        svc_.post(&op);
-        return std::noop_coroutine();
-    }
-
-    // EAGAIN — full async path
-    return read_initiator_.start<&epoll_socket_impl::do_read_io>(this);
+    register_op(op, desc_state_.read_op, desc_state_.read_ready);
+    return std::noop_coroutine();
 }
 
 std::coroutine_handle<>
@@ -448,19 +346,18 @@ write_some(
 {
     auto& op = wr_;
     op.reset();
-    op.h = h;
-    op.ex = ex;
-    op.ec_out = ec;
-    op.bytes_out = bytes_out;
-    op.fd = fd_;
-    op.start(token, this);
-    op.impl_ptr = shared_from_this();
 
     capy::mutable_buffer bufs[epoll_write_op::max_buffers];
     op.iovec_count = static_cast<int>(param.copy_to(bufs, epoll_write_op::max_buffers));
 
     if (op.iovec_count == 0 || (op.iovec_count == 1 && bufs[0].size() == 0))
     {
+        op.h = h;
+        op.ex = ex;
+        op.ec_out = ec;
+        op.bytes_out = bytes_out;
+        op.start(token, this);
+        op.impl_ptr = shared_from_this();
         op.complete(0, 0);
         svc_.post(&op);
         return std::noop_coroutine();
@@ -472,7 +369,7 @@ write_some(
         op.iovecs[i].iov_len = bufs[i].size();
     }
 
-    // Speculative write: bypass initiator when buffer space is ready
+    // Speculative write
     msghdr msg{};
     msg.msg_iov = op.iovecs;
     msg.msg_iovlen = static_cast<std::size_t>(op.iovec_count);
@@ -482,29 +379,39 @@ write_some(
         n = ::sendmsg(fd_, &msg, MSG_NOSIGNAL);
     } while (n < 0 && errno == EINTR);
 
-    if (n > 0)
+    if (n >= 0 || (errno != EAGAIN && errno != EWOULDBLOCK))
     {
-        op.complete(0, static_cast<std::size_t>(n));
+        int err = (n < 0) ? errno : 0;
+        auto bytes = (n > 0) ? static_cast<std::size_t>(n) : std::size_t(0);
+
+        if (svc_.scheduler().try_consume_inline_budget())
+        {
+            *ec = err ? make_err(err) : std::error_code{};
+            *bytes_out = bytes;
+            return ex.dispatch(h);
+        }
+        op.h = h;
+        op.ex = ex;
+        op.ec_out = ec;
+        op.bytes_out = bytes_out;
+        op.start(token, this);
+        op.impl_ptr = shared_from_this();
+        op.complete(err, bytes);
         svc_.post(&op);
         return std::noop_coroutine();
     }
 
-    if (n == 0)
-    {
-        op.complete(0, 0);
-        svc_.post(&op);
-        return std::noop_coroutine();
-    }
+    // EAGAIN — register with reactor
+    op.h = h;
+    op.ex = ex;
+    op.ec_out = ec;
+    op.bytes_out = bytes_out;
+    op.fd = fd_;
+    op.start(token, this);
+    op.impl_ptr = shared_from_this();
 
-    if (errno != EAGAIN && errno != EWOULDBLOCK)
-    {
-        op.complete(errno, 0);
-        svc_.post(&op);
-        return std::noop_coroutine();
-    }
-
-    // EAGAIN — full async path
-    return write_initiator_.start<&epoll_socket_impl::do_write_io>(this);
+    register_op(op, desc_state_.write_op, desc_state_.write_ready);
+    return std::noop_coroutine();
 }
 
 std::error_code

--- a/src/corosio/src/detail/epoll/sockets.cpp
+++ b/src/corosio/src/detail/epoll/sockets.cpp
@@ -108,20 +108,16 @@ operator()()
 
     socket_impl_->svc_.scheduler().reset_inline_budget();
 
-    if (ec_out)
-    {
-        if (cancelled.load(std::memory_order_acquire))
-            *ec_out = capy::error::canceled;
-        else if (errn != 0)
-            *ec_out = make_err(errn);
-        else if (is_read_operation() && bytes_transferred == 0)
-            *ec_out = capy::error::eof;
-        else
-            *ec_out = {};
-    }
+    if (cancelled.load(std::memory_order_acquire))
+        *ec_out = capy::error::canceled;
+    else if (errn != 0)
+        *ec_out = make_err(errn);
+    else if (is_read_operation() && bytes_transferred == 0)
+        *ec_out = capy::error::eof;
+    else
+        *ec_out = {};
 
-    if (bytes_out)
-        *bytes_out = bytes_transferred;
+    *bytes_out = bytes_transferred;
 
     // Move to stack before resuming coroutine. The coroutine might close
     // the socket, releasing the last wrapper ref. If impl_ptr were the
@@ -157,18 +153,12 @@ operator()()
         static_cast<epoll_socket_impl*>(socket_impl_)->set_endpoints(local_ep, target_endpoint);
     }
 
-    if (ec_out)
-    {
-        if (cancelled.load(std::memory_order_acquire))
-            *ec_out = capy::error::canceled;
-        else if (errn != 0)
-            *ec_out = make_err(errn);
-        else
-            *ec_out = {};
-    }
-
-    if (bytes_out)
-        *bytes_out = bytes_transferred;
+    if (cancelled.load(std::memory_order_acquire))
+        *ec_out = capy::error::canceled;
+    else if (errn != 0)
+        *ec_out = make_err(errn);
+    else
+        *ec_out = {};
 
     // Move to stack before resuming. See epoll_op::operator()() for rationale.
     capy::executor_ref saved_ex( std::move( ex ) );

--- a/src/corosio/src/detail/epoll/sockets.hpp
+++ b/src/corosio/src/detail/epoll/sockets.hpp
@@ -21,7 +21,6 @@
 #include "src/detail/intrusive.hpp"
 #include "src/detail/socket_service.hpp"
 
-#include "src/detail/cached_initiator.hpp"
 #include "src/detail/epoll/op.hpp"
 #include "src/detail/epoll/scheduler.hpp"
 
@@ -161,20 +160,19 @@ public:
     /// Per-descriptor state for persistent epoll registration
     descriptor_state desc_state_;
 
-    cached_initiator read_initiator_;
-    cached_initiator write_initiator_;
-
-    /// Execute the read I/O operation (called by initiator coroutine).
-    void do_read_io();
-
-    /// Execute the write I/O operation (called by initiator coroutine).
-    void do_write_io();
-
 private:
     epoll_socket_service& svc_;
     int fd_ = -1;
     endpoint local_endpoint_;
     endpoint remote_endpoint_;
+
+    void register_op(
+        epoll_op& op,
+        epoll_op*& desc_slot,
+        bool& ready_flag) noexcept;
+
+    friend struct epoll_op;
+    friend struct epoll_connect_op;
 };
 
 /** State for epoll socket service. */


### PR DESCRIPTION
Speculative inline completion for epoll socket and acceptor I/O, eliminating scheduler round-trips when data is immediately available. Includes Asio benchmark improvements for fairer comparison and a conntrack drain fix for reliable benchmark results.

### Speculative inline completion (`cb39ca7`)

When a socket read/write/connect/accept syscall succeeds immediately (no EAGAIN), the completion can now be dispatched inline via `ex.dispatch(h)` instead of posting through the scheduler queue. This avoids the mutex lock, queue push/pop, and condvar signal overhead for the common case.

**Inline budget**: Each completion handler gets a budget of 2 inline completions (`max_inline_budget_ = 2`). `reset_inline_budget()` is called at the start of each posted handler; `try_consume_inline_budget()` gates inline dispatch. This prevents unbounded recursion while still allowing short chains (e.g., write → read → write) to complete without scheduler trips.

**Key changes:**
- `scheduler.hpp/cpp`: Add `reset_inline_budget()`, `try_consume_inline_budget()`, `max_inline_budget_`, and `inline_budget` field on `scheduler_context`
- `sockets.cpp`: Restructure `connect()`, `read_some()`, `write_some()` to try inline dispatch on speculative success, fall back to `svc_.post()` when budget is exhausted
- `acceptors.cpp`: Same pattern for `accept()` — inline fast path sets up the peer socket and returns `ex.dispatch(h)` directly
- `op.hpp`: Move `epoll_op::operator()()` to `sockets.cpp` so it can call `reset_inline_budget()` (needs scheduler access); replace `peer_impl` with `peer_addr` field on `epoll_accept_op` to cache the address from `accept4()` and eliminate redundant `getsockname()`/`getpeername()` syscalls
- `sockets.hpp`: Replace `cached_initiator` + `do_read_io()`/`do_write_io()` with a unified `register_op()` helper that handles the EAGAIN async path for all op types
- `acceptors.cpp`: Simplify `cancel()` to delegate to `cancel_single_op()` (removes duplicated logic)

### Asio benchmark improvements (`1b17dba`)

Use concrete executor types (`io_context::executor_type`) and `deferred` completion token in Asio benchmarks instead of `any_io_executor` and default tokens. This removes type-erasure overhead from the Asio side, making the comparison fairer.

### Conntrack drain (`3a25f0c`)

Add `perf::await_conntrack_drain()` that polls `/proc/sys/net/netfilter/nf_conntrack_count` between TCP-heavy benchmark categories. When the conntrack table exceeds 75% capacity, it waits for entries to expire before starting the next benchmark. This prevents silent SYN drops (and ~1s retransmit stalls) that were corrupting burst accept results when running the full `--library all` suite.

## Test plan
- [ ] `cmake --build build -j$(nproc) && ctest --test-dir build` — all 42 tests pass
- [ ] `taskset -c 0-11 build/perf/bench/corosio_bench --library all` — no stalls, burst accept at parity with Asio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wait-for-conntrack drain on Linux before benchmark runs to avoid stale state.

* **Performance**
  * Per-thread inline budget for I/O completion to enable more efficient inline processing and lower latency.
  * Expanded inline completion opportunities for connect/read/write paths when budget permits.

* **Bug Fixes / Reliability**
  * More robust accept/connect/read/write readiness, cancellation, and completion handling for socket operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->