### PR TITLE
Fix timer fast path starvation when used as a yield point

### DIFF
--- a/src/corosio/src/detail/timer_service.cpp
+++ b/src/corosio/src/detail/timer_service.cpp
@@ -697,14 +697,17 @@ wait(
     std::stop_token token,
     std::error_code* ec)
 {
-    // Already-expired fast path — no waiter_node, no mutex
+    // Already-expired fast path — no waiter_node, no mutex.
+    // Post instead of dispatch so the coroutine yields to the
+    // scheduler, allowing other queued work to run.
     if (heap_index_ == (std::numeric_limits<std::size_t>::max)())
     {
         if (expiry_ <= clock_type::now())
         {
             if (ec)
                 *ec = {};
-            return d.dispatch(h);
+            d.post(h);
+            return std::noop_coroutine();
         }
     }
 


### PR DESCRIPTION
The already-expired timer fast path used dispatch() which does symmetric transfer on the same thread, resuming the coroutine without yielding to the scheduler. This starved queued work (e.g. sub-tasks spawned via run_async) when a 0ns timer was used as a poll/yield mechanism.

Switch to post() + noop_coroutine() so the coroutine enters the scheduler queue, giving other pending work a chance to execute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized timer handling for already-expired timers to yield to the scheduler, allowing other queued work to execute and improving overall responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->