### PR TITLE
`io_object` lifecycle through handles

### DIFF
--- a/include/boost/corosio/io_object.hpp
+++ b/include/boost/corosio/io_object.hpp
@@ -96,17 +96,14 @@ public:
         ~handle()
         {
             if(impl_)
+            {
+                svc_->close(*this);
                 svc_->destroy(impl_);
+            }
         }
 
         /// Construct an empty handle.
         handle() = default;
-
-        /// Construct a handle bound to a context only.
-        explicit handle(capy::execution_context& ctx) noexcept
-            : ctx_(&ctx)
-        {
-        }
 
         /// Construct a handle bound to a context and service.
         handle(
@@ -132,7 +129,10 @@ public:
             if (this != &other)
             {
                 if (impl_)
+                {
+                    svc_->close(*this);
                     svc_->destroy(impl_);
+                }
                 ctx_ = std::exchange(other.ctx_, nullptr);
                 svc_ = std::exchange(other.svc_, nullptr);
                 impl_ = std::exchange(other.impl_, nullptr);
@@ -219,14 +219,6 @@ public:
 
 protected:
     virtual ~io_object() = default;
-
-    /// Construct an I/O object bound to the given context.
-    explicit
-    io_object(
-        capy::execution_context& ctx) noexcept
-        : h_(ctx)
-    {
-    }
 
     /// Construct an I/O object from a handle.
     explicit

--- a/include/boost/corosio/io_object.hpp
+++ b/include/boost/corosio/io_object.hpp
@@ -49,9 +49,9 @@ public:
 
         Derived classes provide platform-specific operation dispatch.
     */
-    struct io_object_impl
+    struct implementation
     {
-        virtual ~io_object_impl() = default;
+        virtual ~implementation() = default;
     };
 
     /** Service interface for I/O object lifecycle management.
@@ -65,10 +65,10 @@ public:
         virtual ~io_service() = default;
 
         /// Construct a new implementation instance.
-        virtual io_object_impl* construct() = 0;
+        virtual implementation* construct() = 0;
 
         /// Destroy the implementation, closing kernel resources and freeing memory.
-        virtual void destroy(io_object_impl*) = 0;
+        virtual void destroy(implementation*) = 0;
 
         /// Close the I/O object, releasing kernel resources without deallocating.
         virtual void close(handle&) {}
@@ -83,7 +83,7 @@ public:
     {
         capy::execution_context* ctx_ = nullptr;
         io_service* svc_ = nullptr;
-        io_object_impl* impl_ = nullptr;
+        implementation* impl_ = nullptr;
 
     public:
         /// Destroy the handle and its implementation.
@@ -150,7 +150,7 @@ public:
         }
 
         /// Return the platform implementation.
-        io_object_impl* get() const noexcept
+        implementation* get() const noexcept
         {
             return impl_;
         }
@@ -159,7 +159,7 @@ public:
 
             @param p The new implementation to own. May be nullptr.
         */
-        void reset(io_object_impl* p) noexcept
+        void reset(implementation* p) noexcept
         {
             if (impl_)
             {

--- a/include/boost/corosio/io_object.hpp
+++ b/include/boost/corosio/io_object.hpp
@@ -52,15 +52,12 @@ public:
     struct io_object_impl
     {
         virtual ~io_object_impl() = default;
-
-        /// Release associated resources without closing.
-        virtual void release() {}
     };
 
     /** Service interface for I/O object lifecycle management.
 
         Platform backends implement this interface to manage the
-        creation, opening, closing, and destruction of I/O object
+        creation, closing, and destruction of I/O object
         implementations.
     */
     struct io_service
@@ -73,11 +70,8 @@ public:
         /// Destroy the implementation, closing kernel resources and freeing memory.
         virtual void destroy(io_object_impl*) = 0;
 
-        /// Open the I/O object, creating the kernel resource.
-        virtual void open(handle&) = 0;
-
         /// Close the I/O object, releasing kernel resources without deallocating.
-        virtual void close(handle&) = 0;
+        virtual void close(handle&) {}
     };
 
     /** RAII wrapper for I/O object implementation lifetime.
@@ -149,12 +143,6 @@ public:
             return impl_ != nullptr;
         }
 
-        /// Return the execution context.
-        capy::execution_context& context() const noexcept
-        {
-            return *ctx_;
-        }
-
         /// Return the associated I/O service.
         io_service& service() const noexcept
         {
@@ -167,18 +155,6 @@ public:
             return impl_;
         }
 
-        /** Release ownership of the implementation without destroying.
-
-            The caller is responsible for eventually passing the
-            returned pointer to the service's destroy() method.
-
-            @return The implementation pointer, or nullptr if empty.
-        */
-        io_object_impl* release() noexcept
-        {
-            return std::exchange(impl_, nullptr);
-        }
-
         /** Replace the implementation, destroying the old one.
 
             @param p The new implementation to own. May be nullptr.
@@ -186,10 +162,29 @@ public:
         void reset(io_object_impl* p) noexcept
         {
             if (impl_)
+            {
+                svc_->close(*this);
                 svc_->destroy(impl_);
+            }
             impl_ = p;
         }
+
+        /// Return the execution context.
+        capy::execution_context& context() const noexcept
+        {
+            return *ctx_;
+        }
     };
+
+    /// Return the execution context.
+    capy::execution_context&
+    context() const noexcept
+    {
+        return h_.context();
+    }
+
+protected:
+    virtual ~io_object() = default;
 
     /** Create a handle bound to a service found in the context.
 
@@ -209,16 +204,6 @@ public:
                 "io_object::create_handle: service not installed");
         return handle(ctx, *svc);
     }
-
-    /// Return the execution context.
-    capy::execution_context&
-    context() const noexcept
-    {
-        return h_.context();
-    }
-
-protected:
-    virtual ~io_object() = default;
 
     /// Construct an I/O object from a handle.
     explicit

--- a/include/boost/corosio/io_object.hpp
+++ b/include/boost/corosio/io_object.hpp
@@ -11,7 +11,10 @@
 #define BOOST_COROSIO_IO_OBJECT_HPP
 
 #include <boost/corosio/detail/config.hpp>
+#include <boost/corosio/detail/except.hpp>
 #include <boost/capy/ex/execution_context.hpp>
+
+#include <utility>
 
 namespace boost::corosio {
 
@@ -32,18 +35,27 @@ namespace boost::corosio {
     Shared objects: Unsafe. All operations on a single I/O object
     must be serialized.
 
-    @note Intended as a protected base class. The implementation
-        pointer `impl_` is accessible to derived classes.
+    @note Intended as a protected base class. The handle member
+        `h_` is accessible to derived classes.
 
     @see io_stream, tcp_socket, tcp_acceptor
 */
 class BOOST_COROSIO_DECL io_object
 {
 public:
-    /// Forward declaration for platform-specific implementation.
-    struct implementation;
-
     class handle;
+
+    /** Base interface for platform I/O implementations.
+
+        Derived classes provide platform-specific operation dispatch.
+    */
+    struct io_object_impl
+    {
+        virtual ~io_object_impl() = default;
+
+        /// Release associated resources without closing.
+        virtual void release() {}
+    };
 
     /** Service interface for I/O object lifecycle management.
 
@@ -53,17 +65,19 @@ public:
     */
     struct io_service
     {
-        /// Open the I/O object for use.
-        virtual void open(handle&) = 0;
-
-        /// Close the I/O object, releasing kernel resources.
-        virtual void close(handle&) = 0;
-
-        /// Destroy the implementation, freeing memory.
-        virtual void destroy(implementation*) = 0;
+        virtual ~io_service() = default;
 
         /// Construct a new implementation instance.
-        virtual implementation* construct() = 0;
+        virtual io_object_impl* construct() = 0;
+
+        /// Destroy the implementation, closing kernel resources and freeing memory.
+        virtual void destroy(io_object_impl*) = 0;
+
+        /// Open the I/O object, creating the kernel resource.
+        virtual void open(handle&) = 0;
+
+        /// Close the I/O object, releasing kernel resources without deallocating.
+        virtual void close(handle&) = 0;
     };
 
     /** RAII wrapper for I/O object implementation lifetime.
@@ -75,7 +89,7 @@ public:
     {
         capy::execution_context* ctx_ = nullptr;
         io_service* svc_ = nullptr;
-        implementation* impl_ = nullptr;
+        io_object_impl* impl_ = nullptr;
 
     public:
         /// Destroy the handle and its implementation.
@@ -88,6 +102,12 @@ public:
         /// Construct an empty handle.
         handle() = default;
 
+        /// Construct a handle bound to a context only.
+        explicit handle(capy::execution_context& ctx) noexcept
+            : ctx_(&ctx)
+        {
+        }
+
         /// Construct a handle bound to a context and service.
         handle(
             capy::execution_context& ctx,
@@ -99,7 +119,7 @@ public:
         }
 
         /// Move construct from another handle.
-        handle(handle&& other)
+        handle(handle&& other) noexcept
             : ctx_(std::exchange(other.ctx_, nullptr))
             , svc_(std::exchange(other.svc_, nullptr))
             , impl_(std::exchange(other.impl_, nullptr))
@@ -109,10 +129,24 @@ public:
         /// Move assign from another handle.
         handle& operator=(handle&& other) noexcept
         {
-            ctx_ = std::exchange(other.ctx_, nullptr);
-            svc_ = std::exchange(other.svc_, nullptr);
-            impl_ = std::exchange(other.impl_, nullptr);
+            if (this != &other)
+            {
+                if (impl_)
+                    svc_->destroy(impl_);
+                ctx_ = std::exchange(other.ctx_, nullptr);
+                svc_ = std::exchange(other.svc_, nullptr);
+                impl_ = std::exchange(other.impl_, nullptr);
+            }
             return *this;
+        }
+
+        handle(handle const&) = delete;
+        handle& operator=(handle const&) = delete;
+
+        /// Return true if the handle owns an implementation.
+        explicit operator bool() const noexcept
+        {
+            return impl_ != nullptr;
         }
 
         /// Return the execution context.
@@ -128,29 +162,59 @@ public:
         }
 
         /// Return the platform implementation.
-        implementation& get() const noexcept
+        io_object_impl* get() const noexcept
         {
-            return *impl_;
+            return impl_;
+        }
+
+        /** Release ownership of the implementation without destroying.
+
+            The caller is responsible for eventually passing the
+            returned pointer to the service's destroy() method.
+
+            @return The implementation pointer, or nullptr if empty.
+        */
+        io_object_impl* release() noexcept
+        {
+            return std::exchange(impl_, nullptr);
+        }
+
+        /** Replace the implementation, destroying the old one.
+
+            @param p The new implementation to own. May be nullptr.
+        */
+        void reset(io_object_impl* p) noexcept
+        {
+            if (impl_)
+                svc_->destroy(impl_);
+            impl_ = p;
         }
     };
 
-    /** Base interface for platform I/O implementations.
+    /** Create a handle bound to a service found in the context.
 
-        Derived classes provide platform-specific operation dispatch.
+        @tparam Service The service type whose key_type is used for lookup.
+        @param ctx The execution context to search for the service.
+
+        @return A handle owning a freshly constructed implementation.
+
+        @throws std::logic_error if the service is not installed.
     */
-    struct io_object_impl
+    template<class Service>
+    static handle create_handle(capy::execution_context& ctx)
     {
-        virtual ~io_object_impl() = default;
-
-        /// Release associated resources without closing.
-        virtual void release() = 0;
-    };
+        auto* svc = ctx.find_service<Service>();
+        if (!svc)
+            detail::throw_logic_error(
+                "io_object::create_handle: service not installed");
+        return handle(ctx, *svc);
+    }
 
     /// Return the execution context.
     capy::execution_context&
     context() const noexcept
     {
-        return *ctx_;
+        return h_.context();
     }
 
 protected:
@@ -160,12 +224,35 @@ protected:
     explicit
     io_object(
         capy::execution_context& ctx) noexcept
-        : ctx_(&ctx)
+        : h_(ctx)
     {
     }
 
-    capy::execution_context* ctx_ = nullptr;
-    io_object_impl* impl_ = nullptr;
+    /// Construct an I/O object from a handle.
+    explicit
+    io_object(handle h) noexcept
+        : h_(std::move(h))
+    {
+    }
+
+    /// Move construct from another I/O object.
+    io_object(io_object&& other) noexcept
+        : h_(std::move(other.h_))
+    {
+    }
+
+    /// Move assign from another I/O object.
+    io_object& operator=(io_object&& other) noexcept
+    {
+        if (this != &other)
+            h_ = std::move(other.h_);
+        return *this;
+    }
+
+    io_object(io_object const&) = delete;
+    io_object& operator=(io_object const&) = delete;
+
+    handle h_;
 };
 
 } // namespace boost::corosio

--- a/include/boost/corosio/io_stream.hpp
+++ b/include/boost/corosio/io_stream.hpp
@@ -11,7 +11,6 @@
 #define BOOST_COROSIO_IO_STREAM_HPP
 
 #include <boost/corosio/detail/config.hpp>
-#include <boost/corosio/detail/platform.hpp>
 #include <boost/corosio/io_object.hpp>
 #include <boost/capy/io_result.hpp>
 #include <boost/corosio/io_buffer_param.hpp>
@@ -305,14 +304,6 @@ public:
     };
 
 protected:
-    /// Construct stream bound to the given execution context.
-    explicit
-    io_stream(
-        capy::execution_context& ctx) noexcept
-        : io_object(ctx)
-    {
-    }
-
     /// Construct stream from a handle.
     explicit
     io_stream(handle h) noexcept

--- a/include/boost/corosio/io_stream.hpp
+++ b/include/boost/corosio/io_stream.hpp
@@ -282,7 +282,7 @@ public:
         read and write operations for each supported platform (IOCP,
         epoll, kqueue, io_uring).
     */
-    struct io_stream_impl : io_object_impl
+    struct implementation : io_object::implementation
     {
         /// Initiate platform read operation.
         virtual std::coroutine_handle<> read_some(
@@ -313,9 +313,9 @@ protected:
 
 private:
     /// Return implementation downcasted to stream interface.
-    io_stream_impl& get() const noexcept
+    implementation& get() const noexcept
     {
-        return *static_cast<io_stream_impl*>(h_.get());
+        return *static_cast<implementation*>(h_.get());
     }
 };
 

--- a/include/boost/corosio/io_stream.hpp
+++ b/include/boost/corosio/io_stream.hpp
@@ -11,6 +11,7 @@
 #define BOOST_COROSIO_IO_STREAM_HPP
 
 #include <boost/corosio/detail/config.hpp>
+#include <boost/corosio/detail/platform.hpp>
 #include <boost/corosio/io_object.hpp>
 #include <boost/capy/io_result.hpp>
 #include <boost/corosio/io_buffer_param.hpp>
@@ -312,11 +313,18 @@ protected:
     {
     }
 
+    /// Construct stream from a handle.
+    explicit
+    io_stream(handle h) noexcept
+        : io_object(std::move(h))
+    {
+    }
+
 private:
     /// Return implementation downcasted to stream interface.
     io_stream_impl& get() const noexcept
     {
-        return *static_cast<io_stream_impl*>(impl_);
+        return *static_cast<io_stream_impl*>(h_.get());
     }
 };
 

--- a/include/boost/corosio/resolver.hpp
+++ b/include/boost/corosio/resolver.hpp
@@ -446,7 +446,7 @@ public:
     void cancel();
 
 public:
-    struct resolver_impl : io_object_impl
+    struct implementation : io_object::implementation
     {
         virtual std::coroutine_handle<> resolve(
             std::coroutine_handle<>,
@@ -471,9 +471,9 @@ public:
     };
 
 private:
-    inline resolver_impl& get() const noexcept
+    inline implementation& get() const noexcept
     {
-        return *static_cast<resolver_impl*>(h_.get());
+        return *static_cast<implementation*>(h_.get());
     }
 };
 

--- a/include/boost/corosio/resolver.hpp
+++ b/include/boost/corosio/resolver.hpp
@@ -322,10 +322,8 @@ public:
         @param other The resolver to move from.
     */
     resolver(resolver&& other) noexcept
-        : io_object(other.context())
+        : io_object(std::move(other))
     {
-        impl_ = other.impl_;
-        other.impl_ = nullptr;
     }
 
     /** Move assignment operator.
@@ -344,12 +342,10 @@ public:
     {
         if (this != &other)
         {
-            if (ctx_ != other.ctx_)
+            if (&context() != &other.context())
                 detail::throw_logic_error(
                     "cannot move resolver across execution contexts");
-            cancel();
-            impl_ = other.impl_;
-            other.impl_ = nullptr;
+            h_ = std::move(other.h_);
         }
         return *this;
     }
@@ -477,7 +473,7 @@ public:
 private:
     inline resolver_impl& get() const noexcept
     {
-        return *static_cast<resolver_impl*>(impl_);
+        return *static_cast<resolver_impl*>(h_.get());
     }
 };
 

--- a/include/boost/corosio/signal_set.hpp
+++ b/include/boost/corosio/signal_set.hpp
@@ -377,7 +377,7 @@ public:
 private:
     signal_set_impl& get() const noexcept
     {
-        return *static_cast<signal_set_impl*>(impl_);
+        return *static_cast<signal_set_impl*>(h_.get());
     }
 };
 

--- a/include/boost/corosio/signal_set.hpp
+++ b/include/boost/corosio/signal_set.hpp
@@ -46,7 +46,7 @@
        establishes the flags; subsequent registrations must match or use
        dont_care.
 
-    3. Polymorphic implementation: signal_set_impl is an abstract base that
+    3. Polymorphic implementation: implementation is an abstract base that
        platform-specific implementations (posix_signal_impl, win_signal_impl)
        derive from. This allows the public API to be platform-agnostic.
 
@@ -199,7 +199,7 @@ private:
     };
 
 public:
-    struct signal_set_impl : io_object_impl
+    struct implementation : io_object::implementation
     {
         virtual std::coroutine_handle<> wait(
             std::coroutine_handle<>,
@@ -375,9 +375,9 @@ public:
     }
 
 private:
-    signal_set_impl& get() const noexcept
+    implementation& get() const noexcept
     {
-        return *static_cast<signal_set_impl*>(h_.get());
+        return *static_cast<implementation*>(h_.get());
     }
 };
 

--- a/include/boost/corosio/tcp_acceptor.hpp
+++ b/include/boost/corosio/tcp_acceptor.hpp
@@ -11,6 +11,7 @@
 #define BOOST_COROSIO_TCP_ACCEPTOR_HPP
 
 #include <boost/corosio/detail/config.hpp>
+#include <boost/corosio/detail/platform.hpp>
 #include <boost/corosio/detail/except.hpp>
 #include <boost/corosio/io_object.hpp>
 #include <boost/capy/io_result.hpp>
@@ -91,13 +92,8 @@ class BOOST_COROSIO_DECL tcp_acceptor : public io_object
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled)};
             
-            // Transfer the accepted impl to the peer socket
-            // (acceptor is a friend of socket, so we can access impl_)
             if (!ec_ && peer_impl_)
-            {
-                peer_.close();
-                peer_.impl_ = peer_impl_;
-            }
+                peer_.h_.reset(peer_impl_);
             return {ec_};
         }
 
@@ -144,10 +140,8 @@ public:
         @param other The acceptor to move from.
     */
     tcp_acceptor(tcp_acceptor&& other) noexcept
-        : io_object(other.context())
+        : io_object(std::move(other))
     {
-        impl_ = other.impl_;
-        other.impl_ = nullptr;
     }
 
     /** Move assignment operator.
@@ -165,12 +159,11 @@ public:
     {
         if (this != &other)
         {
-            if (ctx_ != other.ctx_)
+            if (&context() != &other.context())
                 detail::throw_logic_error(
                     "cannot move tcp_acceptor across execution contexts");
             close();
-            impl_ = other.impl_;
-            other.impl_ = nullptr;
+            h_ = std::move(other.h_);
         }
         return *this;
     }
@@ -219,7 +212,7 @@ public:
     */
     bool is_open() const noexcept
     {
-        return impl_ != nullptr;
+        return h_ && get().is_open();
     }
 
     /** Initiate an asynchronous accept operation.
@@ -257,7 +250,7 @@ public:
     */
     auto accept(tcp_socket& peer)
     {
-        if (!impl_)
+        if (!is_open())
             detail::throw_logic_error("accept: acceptor not listening");
         return accept_awaitable(*this, peer);
     }
@@ -299,6 +292,9 @@ public:
         /// Returns the cached local endpoint.
         virtual endpoint local_endpoint() const noexcept = 0;
 
+        /// Return true if the acceptor has a kernel resource open.
+        virtual bool is_open() const noexcept = 0;
+
         /** Cancel any pending asynchronous operations.
 
             All outstanding operations complete with operation_canceled error.
@@ -309,7 +305,7 @@ public:
 private:
     inline acceptor_impl& get() const noexcept
     {
-        return *static_cast<acceptor_impl*>(impl_);
+        return *static_cast<acceptor_impl*>(h_.get());
     }
 };
 

--- a/include/boost/corosio/tcp_acceptor.hpp
+++ b/include/boost/corosio/tcp_acceptor.hpp
@@ -73,7 +73,7 @@ class BOOST_COROSIO_DECL tcp_acceptor : public io_object
         tcp_socket& peer_;
         std::stop_token token_;
         mutable std::error_code ec_;
-        mutable io_object::io_object_impl* peer_impl_ = nullptr;
+        mutable io_object::implementation* peer_impl_ = nullptr;
 
         accept_awaitable(tcp_acceptor& acc, tcp_socket& peer) noexcept
             : acc_(acc)
@@ -279,14 +279,14 @@ public:
     */
     endpoint local_endpoint() const noexcept;
 
-    struct acceptor_impl : io_object_impl
+    struct implementation : io_object::implementation
     {
         virtual std::coroutine_handle<> accept(
             std::coroutine_handle<>,
             capy::executor_ref,
             std::stop_token,
             std::error_code*,
-            io_object_impl**) = 0;
+            io_object::implementation**) = 0;
 
         /// Returns the cached local endpoint.
         virtual endpoint local_endpoint() const noexcept = 0;
@@ -302,9 +302,9 @@ public:
     };
 
 private:
-    inline acceptor_impl& get() const noexcept
+    inline implementation& get() const noexcept
     {
-        return *static_cast<acceptor_impl*>(h_.get());
+        return *static_cast<implementation*>(h_.get());
     }
 };
 

--- a/include/boost/corosio/tcp_acceptor.hpp
+++ b/include/boost/corosio/tcp_acceptor.hpp
@@ -11,7 +11,6 @@
 #define BOOST_COROSIO_TCP_ACCEPTOR_HPP
 
 #include <boost/corosio/detail/config.hpp>
-#include <boost/corosio/detail/platform.hpp>
 #include <boost/corosio/detail/except.hpp>
 #include <boost/corosio/io_object.hpp>
 #include <boost/capy/io_result.hpp>

--- a/include/boost/corosio/tcp_socket.hpp
+++ b/include/boost/corosio/tcp_socket.hpp
@@ -206,10 +206,8 @@ public:
         @param other The socket to move from.
     */
     tcp_socket(tcp_socket&& other) noexcept
-        : io_stream(other.context())
+        : io_stream(std::move(other))
     {
-        impl_ = other.impl_;
-        other.impl_ = nullptr;
     }
 
     /** Move assignment operator.
@@ -227,12 +225,11 @@ public:
     {
         if (this != &other)
         {
-            if (ctx_ != other.ctx_)
+            if (&context() != &other.context())
                 detail::throw_logic_error(
                     "cannot move socket across execution contexts");
             close();
-            impl_ = other.impl_;
-            other.impl_ = nullptr;
+            h_ = std::move(other.h_);
         }
         return *this;
     }
@@ -263,7 +260,11 @@ public:
     */
     bool is_open() const noexcept
     {
-        return impl_ != nullptr;
+#if BOOST_COROSIO_HAS_IOCP
+        return h_ && get().native_handle() != ~native_handle_type(0);
+#else
+        return h_ && get().native_handle() >= 0;
+#endif
     }
 
     /** Initiate an asynchronous connect operation.
@@ -300,7 +301,7 @@ public:
     */
     auto connect(endpoint ep)
     {
-        if (!impl_)
+        if (!is_open())
             detail::throw_logic_error("connect: socket not open");
         return connect_awaitable(*this, ep);
     }
@@ -515,7 +516,7 @@ private:
 
     inline socket_impl& get() const noexcept
     {
-        return *static_cast<socket_impl*>(impl_);
+        return *static_cast<socket_impl*>(h_.get());
     }
 };
 

--- a/include/boost/corosio/tcp_socket.hpp
+++ b/include/boost/corosio/tcp_socket.hpp
@@ -95,7 +95,7 @@ public:
         int timeout = 0;  // seconds
     };
 
-    struct socket_impl : io_stream_impl
+    struct implementation : io_stream::implementation
     {
         virtual std::coroutine_handle<> connect(
             std::coroutine_handle<>,
@@ -514,9 +514,9 @@ public:
 private:
     friend class tcp_acceptor;
 
-    inline socket_impl& get() const noexcept
+    inline implementation& get() const noexcept
     {
-        return *static_cast<socket_impl*>(h_.get());
+        return *static_cast<implementation*>(h_.get());
     }
 };
 

--- a/include/boost/corosio/timer.hpp
+++ b/include/boost/corosio/timer.hpp
@@ -327,7 +327,7 @@ private:
     /// Return the underlying implementation.
     timer_impl& get() const noexcept
     {
-        return *static_cast<timer_impl*>(impl_);
+        return *static_cast<timer_impl*>(h_.get());
     }
 };
 

--- a/include/boost/corosio/timer.hpp
+++ b/include/boost/corosio/timer.hpp
@@ -82,7 +82,7 @@ class BOOST_COROSIO_DECL timer : public io_object
             token_ = env->stop_token;
             auto& impl = t_.get();
             // Inline fast path: already expired and not in the heap
-            if (impl.heap_index_ == timer_impl::npos &&
+            if (impl.heap_index_ == implementation::npos &&
                 (impl.expiry_ == (time_point::min)() ||
                     impl.expiry_ <= clock_type::now()))
             {
@@ -97,7 +97,7 @@ class BOOST_COROSIO_DECL timer : public io_object
     };
 
 public:
-    struct timer_impl : io_object_impl
+    struct implementation : io_object::implementation
     {
         static constexpr std::size_t npos =
             (std::numeric_limits<std::size_t>::max)();
@@ -231,7 +231,7 @@ public:
     {
         auto& impl = get();
         impl.expiry_ = t;
-        if (impl.heap_index_ == timer_impl::npos &&
+        if (impl.heap_index_ == implementation::npos &&
             !impl.might_have_pending_waits_)
             return 0;
         return do_update_expiry();
@@ -252,7 +252,7 @@ public:
             impl.expiry_ = (time_point::min)();
         else
             impl.expiry_ = clock_type::now() + d;
-        if (impl.heap_index_ == timer_impl::npos &&
+        if (impl.heap_index_ == implementation::npos &&
             !impl.might_have_pending_waits_)
             return 0;
         return do_update_expiry();
@@ -325,9 +325,9 @@ private:
     std::size_t do_update_expiry();
 
     /// Return the underlying implementation.
-    timer_impl& get() const noexcept
+    implementation& get() const noexcept
     {
-        return *static_cast<timer_impl*>(h_.get());
+        return *static_cast<implementation*>(h_.get());
     }
 };
 

--- a/perf/bench/main.cpp
+++ b/perf/bench/main.cpp
@@ -15,7 +15,6 @@
 #endif
 
 #include <boost/corosio/io_context.hpp>
-#include <boost/corosio/detail/platform.hpp>
 
 #include <cstdlib>
 #include <cstring>

--- a/perf/profile/coroutine_post_bench.cpp
+++ b/perf/profile/coroutine_post_bench.cpp
@@ -18,7 +18,6 @@
 //   - coro.resume() cost
 
 #include <boost/corosio/io_context.hpp>
-#include <boost/corosio/detail/platform.hpp>
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/task.hpp>
 

--- a/perf/profile/queue_depth_bench.cpp
+++ b/perf/profile/queue_depth_bench.cpp
@@ -21,7 +21,6 @@
 //   profile_queue_depth --depth 10000 --threads 4  # Moderate queue, multi-thread dispatch
 
 #include <boost/corosio/io_context.hpp>
-#include <boost/corosio/detail/platform.hpp>
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/task.hpp>
 

--- a/perf/profile/scheduler_contention_bench.cpp
+++ b/perf/profile/scheduler_contention_bench.cpp
@@ -35,7 +35,6 @@
 //   --run-only     Main posts continuously, all threads run
 
 #include <boost/corosio/io_context.hpp>
-#include <boost/corosio/detail/platform.hpp>
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/task.hpp>
 

--- a/src/corosio/src/detail/epoll/acceptors.cpp
+++ b/src/corosio/src/detail/epoll/acceptors.cpp
@@ -62,7 +62,7 @@ operator()()
             ->service().socket_service();
         if (socket_svc)
         {
-            auto& impl = static_cast<epoll_socket_impl&>(socket_svc->create_impl());
+            auto& impl = static_cast<epoll_socket_impl&>(*socket_svc->construct());
             impl.set_socket(accepted_fd);
 
             impl.desc_state_.fd = accepted_fd;
@@ -114,14 +114,6 @@ epoll_acceptor_impl(epoll_acceptor_service& svc) noexcept
 {
 }
 
-void
-epoll_acceptor_impl::
-release()
-{
-    close_socket();
-    svc_.destroy_acceptor_impl(*this);
-}
-
 std::coroutine_handle<>
 epoll_acceptor_impl::
 accept(
@@ -160,7 +152,7 @@ accept(
             auto* socket_svc = svc_.socket_service();
             if (socket_svc)
             {
-                auto& impl = static_cast<epoll_socket_impl&>(socket_svc->create_impl());
+                auto& impl = static_cast<epoll_socket_impl&>(*socket_svc->construct());
                 impl.set_socket(accepted);
 
                 impl.desc_state_.fd = accepted;
@@ -320,9 +312,9 @@ shutdown()
     // after scheduler shutdown has drained all queued ops.
 }
 
-tcp_acceptor::acceptor_impl&
+io_object::io_object_impl*
 epoll_acceptor_service::
-create_acceptor_impl()
+construct()
 {
     auto impl = std::make_shared<epoll_acceptor_impl>(*this);
     auto* raw = impl.get();
@@ -331,17 +323,31 @@ create_acceptor_impl()
     state_->acceptor_list_.push_back(raw);
     state_->acceptor_ptrs_.emplace(raw, std::move(impl));
 
-    return *raw;
+    return raw;
 }
 
 void
 epoll_acceptor_service::
-destroy_acceptor_impl(tcp_acceptor::acceptor_impl& impl)
+destroy(io_object::io_object_impl* impl)
 {
-    auto* epoll_impl = static_cast<epoll_acceptor_impl*>(&impl);
+    auto* epoll_impl = static_cast<epoll_acceptor_impl*>(impl);
+    epoll_impl->close_socket();
     std::lock_guard lock(state_->mutex_);
     state_->acceptor_list_.remove(epoll_impl);
     state_->acceptor_ptrs_.erase(epoll_impl);
+}
+
+void
+epoll_acceptor_service::
+open(io_object::handle&)
+{
+}
+
+void
+epoll_acceptor_service::
+close(io_object::handle& h)
+{
+    static_cast<epoll_acceptor_impl*>(h.get())->close_socket();
 }
 
 std::error_code

--- a/src/corosio/src/detail/epoll/acceptors.cpp
+++ b/src/corosio/src/detail/epoll/acceptors.cpp
@@ -339,12 +339,6 @@ destroy(io_object::io_object_impl* impl)
 
 void
 epoll_acceptor_service::
-open(io_object::handle&)
-{
-}
-
-void
-epoll_acceptor_service::
 close(io_object::handle& h)
 {
     static_cast<epoll_acceptor_impl*>(h.get())->close_socket();

--- a/src/corosio/src/detail/epoll/acceptors.cpp
+++ b/src/corosio/src/detail/epoll/acceptors.cpp
@@ -121,7 +121,7 @@ accept(
     capy::executor_ref ex,
     std::stop_token token,
     std::error_code* ec,
-    io_object::io_object_impl** impl_out)
+    io_object::implementation** impl_out)
 {
     auto& op = acc_;
     op.reset();
@@ -312,7 +312,7 @@ shutdown()
     // after scheduler shutdown has drained all queued ops.
 }
 
-io_object::io_object_impl*
+io_object::implementation*
 epoll_acceptor_service::
 construct()
 {
@@ -328,7 +328,7 @@ construct()
 
 void
 epoll_acceptor_service::
-destroy(io_object::io_object_impl* impl)
+destroy(io_object::implementation* impl)
 {
     auto* epoll_impl = static_cast<epoll_acceptor_impl*>(impl);
     epoll_impl->close_socket();
@@ -347,7 +347,7 @@ close(io_object::handle& h)
 std::error_code
 epoll_acceptor_service::
 open_acceptor(
-    tcp_acceptor::acceptor_impl& impl,
+    tcp_acceptor::implementation& impl,
     endpoint ep,
     int backlog)
 {

--- a/src/corosio/src/detail/epoll/acceptors.cpp
+++ b/src/corosio/src/detail/epoll/acceptors.cpp
@@ -177,7 +177,7 @@ accept(
                 if (impl_out)
                     *impl_out = nullptr;
             }
-            return ex.dispatch(h);
+            return dispatch_coro(ex, h);
         }
 
         op.accepted_fd = accepted;

--- a/src/corosio/src/detail/epoll/acceptors.hpp
+++ b/src/corosio/src/detail/epoll/acceptors.hpp
@@ -104,7 +104,6 @@ public:
 
     io_object::io_object_impl* construct() override;
     void destroy(io_object::io_object_impl*) override;
-    void open(io_object::handle&) override;
     void close(io_object::handle&) override;
     std::error_code open_acceptor(
         tcp_acceptor::acceptor_impl& impl,

--- a/src/corosio/src/detail/epoll/acceptors.hpp
+++ b/src/corosio/src/detail/epoll/acceptors.hpp
@@ -36,7 +36,7 @@ class epoll_socket_service;
 
 /// Acceptor implementation for epoll backend.
 class epoll_acceptor_impl
-    : public tcp_acceptor::acceptor_impl
+    : public tcp_acceptor::implementation
     , public std::enable_shared_from_this<epoll_acceptor_impl>
     , public intrusive_list<epoll_acceptor_impl>::node
 {
@@ -50,7 +50,7 @@ public:
         capy::executor_ref,
         std::stop_token,
         std::error_code*,
-        io_object::io_object_impl**) override;
+        io_object::implementation**) override;
 
     int native_handle() const noexcept { return fd_; }
     endpoint local_endpoint() const noexcept override { return local_endpoint_; }
@@ -102,11 +102,11 @@ public:
 
     void shutdown() override;
 
-    io_object::io_object_impl* construct() override;
-    void destroy(io_object::io_object_impl*) override;
+    io_object::implementation* construct() override;
+    void destroy(io_object::implementation*) override;
     void close(io_object::handle&) override;
     std::error_code open_acceptor(
-        tcp_acceptor::acceptor_impl& impl,
+        tcp_acceptor::implementation& impl,
         endpoint ep,
         int backlog) override;
 

--- a/src/corosio/src/detail/epoll/acceptors.hpp
+++ b/src/corosio/src/detail/epoll/acceptors.hpp
@@ -45,8 +45,6 @@ class epoll_acceptor_impl
 public:
     explicit epoll_acceptor_impl(epoll_acceptor_service& svc) noexcept;
 
-    void release() override;
-
     std::coroutine_handle<> accept(
         std::coroutine_handle<>,
         capy::executor_ref,
@@ -56,7 +54,7 @@ public:
 
     int native_handle() const noexcept { return fd_; }
     endpoint local_endpoint() const noexcept override { return local_endpoint_; }
-    bool is_open() const noexcept { return fd_ >= 0; }
+    bool is_open() const noexcept override { return fd_ >= 0; }
     void cancel() noexcept override;
     void cancel_single_op(epoll_op& op) noexcept;
     void close_socket() noexcept;
@@ -104,8 +102,10 @@ public:
 
     void shutdown() override;
 
-    tcp_acceptor::acceptor_impl& create_acceptor_impl() override;
-    void destroy_acceptor_impl(tcp_acceptor::acceptor_impl& impl) override;
+    io_object::io_object_impl* construct() override;
+    void destroy(io_object::io_object_impl*) override;
+    void open(io_object::handle&) override;
+    void close(io_object::handle&) override;
     std::error_code open_acceptor(
         tcp_acceptor::acceptor_impl& impl,
         endpoint ep,

--- a/src/corosio/src/detail/epoll/op.hpp
+++ b/src/corosio/src/detail/epoll/op.hpp
@@ -346,7 +346,7 @@ struct epoll_write_op : epoll_op
 struct epoll_accept_op : epoll_op
 {
     int accepted_fd = -1;
-    io_object::io_object_impl** impl_out = nullptr;
+    io_object::implementation** impl_out = nullptr;
     sockaddr_in peer_addr{};
 
     void reset() noexcept

--- a/src/corosio/src/detail/epoll/sockets.cpp
+++ b/src/corosio/src/detail/epoll/sockets.cpp
@@ -712,7 +712,7 @@ shutdown()
     // shutdown) keeps every impl alive until all ops have been drained.
 }
 
-io_object::io_object_impl*
+io_object::implementation*
 epoll_socket_service::
 construct()
 {
@@ -730,7 +730,7 @@ construct()
 
 void
 epoll_socket_service::
-destroy(io_object::io_object_impl* impl)
+destroy(io_object::implementation* impl)
 {
     auto* epoll_impl = static_cast<epoll_socket_impl*>(impl);
     epoll_impl->close_socket();
@@ -741,7 +741,7 @@ destroy(io_object::io_object_impl* impl)
 
 std::error_code
 epoll_socket_service::
-open_socket(tcp_socket::socket_impl& impl)
+open_socket(tcp_socket::implementation& impl)
 {
     auto* epoll_impl = static_cast<epoll_socket_impl*>(&impl);
     epoll_impl->close_socket();

--- a/src/corosio/src/detail/epoll/sockets.cpp
+++ b/src/corosio/src/detail/epoll/sockets.cpp
@@ -767,16 +767,6 @@ open_socket(tcp_socket::socket_impl& impl)
 
 void
 epoll_socket_service::
-open(io_object::handle& h)
-{
-    auto ec = open_socket(
-        *static_cast<tcp_socket::socket_impl*>(h.get()));
-    if (ec)
-        detail::throw_system_error(ec, "open");
-}
-
-void
-epoll_socket_service::
 close(io_object::handle& h)
 {
     static_cast<epoll_socket_impl*>(h.get())->close_socket();

--- a/src/corosio/src/detail/epoll/sockets.cpp
+++ b/src/corosio/src/detail/epoll/sockets.cpp
@@ -212,7 +212,7 @@ connect(
         if (svc_.scheduler().try_consume_inline_budget())
         {
             *ec = err ? make_err(err) : std::error_code{};
-            return ex.dispatch(h);
+            return dispatch_coro(ex, h);
         }
         op.reset();
         op.h = h;
@@ -298,7 +298,7 @@ read_some(
             else
                 *ec = {};
             *bytes_out = bytes;
-            return ex.dispatch(h);
+            return dispatch_coro(ex, h);
         }
         op.h = h;
         op.ex = ex;
@@ -379,7 +379,7 @@ write_some(
         {
             *ec = err ? make_err(err) : std::error_code{};
             *bytes_out = bytes;
-            return ex.dispatch(h);
+            return dispatch_coro(ex, h);
         }
         op.h = h;
         op.ex = ex;

--- a/src/corosio/src/detail/epoll/sockets.cpp
+++ b/src/corosio/src/detail/epoll/sockets.cpp
@@ -183,14 +183,6 @@ epoll_socket_impl(epoll_socket_service& svc) noexcept
 epoll_socket_impl::
 ~epoll_socket_impl() = default;
 
-void
-epoll_socket_impl::
-release()
-{
-    close_socket();
-    svc_.destroy_impl(*this);
-}
-
 std::coroutine_handle<>
 epoll_socket_impl::
 connect(
@@ -720,9 +712,9 @@ shutdown()
     // shutdown) keeps every impl alive until all ops have been drained.
 }
 
-tcp_socket::socket_impl&
+io_object::io_object_impl*
 epoll_socket_service::
-create_impl()
+construct()
 {
     auto impl = std::make_shared<epoll_socket_impl>(*this);
     auto* raw = impl.get();
@@ -733,14 +725,15 @@ create_impl()
         state_->socket_ptrs_.emplace(raw, std::move(impl));
     }
 
-    return *raw;
+    return raw;
 }
 
 void
 epoll_socket_service::
-destroy_impl(tcp_socket::socket_impl& impl)
+destroy(io_object::io_object_impl* impl)
 {
-    auto* epoll_impl = static_cast<epoll_socket_impl*>(&impl);
+    auto* epoll_impl = static_cast<epoll_socket_impl*>(impl);
+    epoll_impl->close_socket();
     std::lock_guard lock(state_->mutex_);
     state_->socket_list_.remove(epoll_impl);
     state_->socket_ptrs_.erase(epoll_impl);
@@ -770,6 +763,23 @@ open_socket(tcp_socket::socket_impl& impl)
     scheduler().register_descriptor(fd, &epoll_impl->desc_state_);
 
     return {};
+}
+
+void
+epoll_socket_service::
+open(io_object::handle& h)
+{
+    auto ec = open_socket(
+        *static_cast<tcp_socket::socket_impl*>(h.get()));
+    if (ec)
+        detail::throw_system_error(ec, "open");
+}
+
+void
+epoll_socket_service::
+close(io_object::handle& h)
+{
+    static_cast<epoll_socket_impl*>(h.get())->close_socket();
 }
 
 void

--- a/src/corosio/src/detail/epoll/sockets.hpp
+++ b/src/corosio/src/detail/epoll/sockets.hpp
@@ -95,8 +95,6 @@ public:
     explicit epoll_socket_impl(epoll_socket_service& svc) noexcept;
     ~epoll_socket_impl();
 
-    void release() override;
-
     std::coroutine_handle<> connect(
         std::coroutine_handle<>,
         capy::executor_ref,
@@ -207,8 +205,10 @@ public:
 
     void shutdown() override;
 
-    tcp_socket::socket_impl& create_impl() override;
-    void destroy_impl(tcp_socket::socket_impl& impl) override;
+    io_object::io_object_impl* construct() override;
+    void destroy(io_object::io_object_impl*) override;
+    void open(io_object::handle&) override;
+    void close(io_object::handle&) override;
     std::error_code open_socket(tcp_socket::socket_impl& impl) override;
 
     epoll_scheduler& scheduler() const noexcept { return state_->sched_; }

--- a/src/corosio/src/detail/epoll/sockets.hpp
+++ b/src/corosio/src/detail/epoll/sockets.hpp
@@ -85,7 +85,7 @@ class epoll_socket_impl;
 
 /// Socket implementation for epoll backend.
 class epoll_socket_impl
-    : public tcp_socket::socket_impl
+    : public tcp_socket::implementation
     , public std::enable_shared_from_this<epoll_socket_impl>
     , public intrusive_list<epoll_socket_impl>::node
 {
@@ -205,10 +205,10 @@ public:
 
     void shutdown() override;
 
-    io_object::io_object_impl* construct() override;
-    void destroy(io_object::io_object_impl*) override;
+    io_object::implementation* construct() override;
+    void destroy(io_object::implementation*) override;
     void close(io_object::handle&) override;
-    std::error_code open_socket(tcp_socket::socket_impl& impl) override;
+    std::error_code open_socket(tcp_socket::implementation& impl) override;
 
     epoll_scheduler& scheduler() const noexcept { return state_->sched_; }
     void post(epoll_op* op);

--- a/src/corosio/src/detail/epoll/sockets.hpp
+++ b/src/corosio/src/detail/epoll/sockets.hpp
@@ -207,7 +207,6 @@ public:
 
     io_object::io_object_impl* construct() override;
     void destroy(io_object::io_object_impl*) override;
-    void open(io_object::handle&) override;
     void close(io_object::handle&) override;
     std::error_code open_socket(tcp_socket::socket_impl& impl) override;
 

--- a/src/corosio/src/detail/iocp/resolver_service.cpp
+++ b/src/corosio/src/detail/iocp/resolver_service.cpp
@@ -543,7 +543,7 @@ shutdown()
     }
 }
 
-io_object::io_object_impl*
+io_object::implementation*
 win_resolver_service::
 construct()
 {

--- a/src/corosio/src/detail/iocp/resolver_service.cpp
+++ b/src/corosio/src/detail/iocp/resolver_service.cpp
@@ -551,9 +551,9 @@ shutdown()
     }
 }
 
-win_resolver_impl&
+io_object::io_object_impl*
 win_resolver_service::
-create_impl()
+construct()
 {
     auto ptr = std::make_shared<win_resolver_impl>(*this);
     auto* impl = ptr.get();
@@ -564,7 +564,7 @@ create_impl()
         resolver_ptrs_[impl] = std::move(ptr);
     }
 
-    return *impl;
+    return impl;
 }
 
 void

--- a/src/corosio/src/detail/iocp/resolver_service.cpp
+++ b/src/corosio/src/detail/iocp/resolver_service.cpp
@@ -318,14 +318,6 @@ win_resolver_impl(win_resolver_service& svc) noexcept
 {
 }
 
-void
-win_resolver_impl::
-release()
-{
-    cancel();
-    svc_.destroy_impl(*this);
-}
-
 std::coroutine_handle<>
 win_resolver_impl::
 resolve(

--- a/src/corosio/src/detail/iocp/resolver_service.hpp
+++ b/src/corosio/src/detail/iocp/resolver_service.hpp
@@ -253,9 +253,20 @@ private:
 class win_resolver_service
     : private win_wsa_init
     , public capy::execution_context::service
+    , public io_object::io_service
 {
 public:
     using key_type = win_resolver_service;
+
+    io_object::io_object_impl* construct() override;
+
+    void destroy(io_object::io_object_impl* p) override
+    {
+        static_cast<win_resolver_impl*>(p)->release();
+    }
+
+    void open(io_object::handle&) override {}
+    void close(io_object::handle&) override {}
 
     /** Construct the resolver service.
 
@@ -272,9 +283,6 @@ public:
 
     /** Shut down the service. */
     void shutdown() override;
-
-    /** Create a new resolver implementation. */
-    win_resolver_impl& create_impl();
 
     /** Destroy a resolver implementation. */
     void destroy_impl(win_resolver_impl& impl);

--- a/src/corosio/src/detail/iocp/resolver_service.hpp
+++ b/src/corosio/src/detail/iocp/resolver_service.hpp
@@ -194,7 +194,7 @@ struct reverse_resolve_op : overlapped_op
     @note Internal implementation detail. Users interact with resolver class.
 */
 class win_resolver_impl
-    : public resolver::resolver_impl
+    : public resolver::implementation
     , public std::enable_shared_from_this<win_resolver_impl>
     , public intrusive_list<win_resolver_impl>::node
 {
@@ -256,9 +256,9 @@ class win_resolver_service
 public:
     using key_type = win_resolver_service;
 
-    io_object::io_object_impl* construct() override;
+    io_object::implementation* construct() override;
 
-    void destroy(io_object::io_object_impl* p) override
+    void destroy(io_object::implementation* p) override
     {
         auto& impl = static_cast<win_resolver_impl&>(*p);
         impl.cancel();

--- a/src/corosio/src/detail/iocp/resolver_service.hpp
+++ b/src/corosio/src/detail/iocp/resolver_service.hpp
@@ -204,8 +204,6 @@ class win_resolver_impl
 public:
     explicit win_resolver_impl(win_resolver_service& svc) noexcept;
 
-    void release() override;
-
     std::coroutine_handle<> resolve(
         std::coroutine_handle<>,
         capy::executor_ref,
@@ -262,11 +260,10 @@ public:
 
     void destroy(io_object::io_object_impl* p) override
     {
-        static_cast<win_resolver_impl*>(p)->release();
+        auto& impl = static_cast<win_resolver_impl&>(*p);
+        impl.cancel();
+        destroy_impl(impl);
     }
-
-    void open(io_object::handle&) override {}
-    void close(io_object::handle&) override {}
 
     /** Construct the resolver service.
 

--- a/src/corosio/src/detail/iocp/signals.cpp
+++ b/src/corosio/src/detail/iocp/signals.cpp
@@ -289,7 +289,7 @@ shutdown()
     }
 }
 
-io_object::io_object_impl*
+io_object::implementation*
 win_signals::
 construct()
 {
@@ -305,7 +305,7 @@ construct()
 
 void
 win_signals::
-destroy(io_object::io_object_impl* p)
+destroy(io_object::implementation* p)
 {
     auto& impl = static_cast<win_signal_impl&>(*p);
     impl.clear();

--- a/src/corosio/src/detail/iocp/signals.cpp
+++ b/src/corosio/src/detail/iocp/signals.cpp
@@ -188,16 +188,6 @@ win_signal_impl(win_signals& svc) noexcept
 {
 }
 
-void
-win_signal_impl::
-release()
-{
-    // Clear all signals and cancel pending wait
-    clear();
-    cancel();
-    svc_.destroy_impl(*this);
-}
-
 std::coroutine_handle<>
 win_signal_impl::
 wait(
@@ -317,7 +307,10 @@ void
 win_signals::
 destroy(io_object::io_object_impl* p)
 {
-    static_cast<win_signal_impl*>(p)->release();
+    auto& impl = static_cast<win_signal_impl&>(*p);
+    impl.clear();
+    impl.cancel();
+    destroy_impl(impl);
 }
 
 void

--- a/src/corosio/src/detail/iocp/signals.cpp
+++ b/src/corosio/src/detail/iocp/signals.cpp
@@ -299,9 +299,9 @@ shutdown()
     }
 }
 
-win_signal_impl&
+io_object::io_object_impl*
 win_signals::
-create_impl()
+construct()
 {
     auto* impl = new win_signal_impl(*this);
 
@@ -310,7 +310,14 @@ create_impl()
         impl_list_.push_back(impl);
     }
 
-    return *impl;
+    return impl;
+}
+
+void
+win_signals::
+destroy(io_object::io_object_impl* p)
+{
+    static_cast<win_signal_impl*>(p)->release();
 }
 
 void
@@ -648,25 +655,18 @@ remove_service(win_signals* service)
 } // namespace detail
 
 signal_set::
-~signal_set()
-{
-    if (impl_)
-        impl_->release();
-}
+~signal_set() = default;
 
 signal_set::
 signal_set(capy::execution_context& ctx)
-    : io_object(ctx)
+    : io_object(create_handle<detail::win_signals>(ctx))
 {
-    impl_ = &ctx.use_service<detail::win_signals>().create_impl();
 }
 
 signal_set::
 signal_set(signal_set&& other) noexcept
     : io_object(std::move(other))
 {
-    impl_ = other.impl_;
-    other.impl_ = nullptr;
 }
 
 signal_set&
@@ -675,14 +675,9 @@ operator=(signal_set&& other)
 {
     if (this != &other)
     {
-        if (ctx_ != other.ctx_)
+        if (&context() != &other.context())
             detail::throw_logic_error("signal_set::operator=: context mismatch");
-
-        if (impl_)
-            impl_->release();
-
-        impl_ = other.impl_;
-        other.impl_ = nullptr;
+        h_ = std::move(other.h_);
     }
     return *this;
 }

--- a/src/corosio/src/detail/iocp/signals.hpp
+++ b/src/corosio/src/detail/iocp/signals.hpp
@@ -109,7 +109,7 @@ struct signal_registration
     @note Internal implementation detail. Users interact with signal_set class.
 */
 class win_signal_impl
-    : public signal_set::signal_set_impl
+    : public signal_set::implementation
     , public intrusive_list<win_signal_impl>::node
 {
     friend class win_signals;
@@ -159,8 +159,8 @@ class win_signals
 public:
     using key_type = win_signals;
 
-    io_object::io_object_impl* construct() override;
-    void destroy(io_object::io_object_impl*) override;
+    io_object::implementation* construct() override;
+    void destroy(io_object::implementation*) override;
 
     /** Construct the signal service.
 

--- a/src/corosio/src/detail/iocp/signals.hpp
+++ b/src/corosio/src/detail/iocp/signals.hpp
@@ -154,10 +154,17 @@ public:
 
     @note Only available on Windows platforms.
 */
-class win_signals : public capy::execution_context::service
+class win_signals
+    : public capy::execution_context::service
+    , public io_object::io_service
 {
 public:
     using key_type = win_signals;
+
+    io_object::io_object_impl* construct() override;
+    void destroy(io_object::io_object_impl*) override;
+    void open(io_object::handle&) override {}
+    void close(io_object::handle&) override {}
 
     /** Construct the signal service.
 
@@ -173,9 +180,6 @@ public:
 
     /** Shut down the service. */
     void shutdown() override;
-
-    /** Create a new signal implementation. */
-    win_signal_impl& create_impl();
 
     /** Destroy a signal implementation. */
     void destroy_impl(win_signal_impl& impl);

--- a/src/corosio/src/detail/iocp/signals.hpp
+++ b/src/corosio/src/detail/iocp/signals.hpp
@@ -122,8 +122,6 @@ class win_signal_impl
 public:
     explicit win_signal_impl(win_signals& svc) noexcept;
 
-    void release() override;
-
     std::coroutine_handle<> wait(
         std::coroutine_handle<>,
         capy::executor_ref,
@@ -163,8 +161,6 @@ public:
 
     io_object::io_object_impl* construct() override;
     void destroy(io_object::io_object_impl*) override;
-    void open(io_object::handle&) override {}
-    void close(io_object::handle&) override {}
 
     /** Construct the signal service.
 

--- a/src/corosio/src/detail/iocp/sockets.cpp
+++ b/src/corosio/src/detail/iocp/sockets.cpp
@@ -195,7 +195,7 @@ accept_op::do_complete(
 
         if (op->peer_wrapper)
         {
-            op->peer_wrapper->release();
+            op->acceptor_ptr->socket_service().destroy(op->peer_wrapper);
             op->peer_wrapper = nullptr;
         }
 
@@ -304,13 +304,6 @@ win_socket_impl_internal::
 ~win_socket_impl_internal()
 {
     svc_.unregister_impl(*this);
-}
-
-void
-win_socket_impl_internal::
-release_internal()
-{
-    close_socket();
 }
 
 std::coroutine_handle<>
@@ -592,14 +585,12 @@ close_socket() noexcept
 
 void
 win_socket_impl::
-release()
+close_internal() noexcept
 {
     if (internal_)
     {
-        auto& svc = internal_->svc_;
-        internal_->release_internal();
+        internal_->close_socket();
         internal_.reset();
-        svc.destroy_impl(*this);
     }
 }
 
@@ -910,22 +901,6 @@ win_acceptor_impl_internal::
     svc_.unregister_acceptor_impl(*this);
 }
 
-void
-win_acceptor_impl_internal::
-release_internal()
-{
-    // Cancel pending I/O before closing to ensure operations
-    // complete with ERROR_OPERATION_ABORTED via IOCP
-    if (socket_ != INVALID_SOCKET)
-    {
-        ::CancelIoEx(
-            reinterpret_cast<HANDLE>(socket_),
-            nullptr);
-    }
-    close_socket();
-    // Destruction happens automatically when all shared_ptrs are released
-}
-
 std::coroutine_handle<>
 win_acceptor_impl_internal::
 accept(
@@ -960,7 +935,7 @@ accept(
 
     if (accepted == INVALID_SOCKET)
     {
-        peer_wrapper.release();
+        svc_.destroy(&peer_wrapper);
         op.dwError = ::WSAGetLastError();
         svc_.post(&op);
         // completion is always posted to scheduler queue, never inline.
@@ -977,7 +952,7 @@ accept(
     {
         DWORD err = ::GetLastError();
         ::closesocket(accepted);
-        peer_wrapper.release();
+        svc_.destroy(&peer_wrapper);
         op.dwError = err;
         svc_.post(&op);
         // completion is always posted to scheduler queue, never inline.
@@ -993,7 +968,7 @@ accept(
     if (!accept_ex)
     {
         ::closesocket(accepted);
-        peer_wrapper.release();
+        svc_.destroy(&peer_wrapper);
         op.peer_wrapper = nullptr;
         op.accepted_socket = INVALID_SOCKET;
         op.dwError = WSAEOPNOTSUPP;
@@ -1022,7 +997,7 @@ accept(
         {
             svc_.work_finished();
             ::closesocket(accepted);
-            peer_wrapper.release();
+            svc_.destroy(&peer_wrapper);
             op.peer_wrapper = nullptr;
             op.accepted_socket = INVALID_SOCKET;
             op.dwError = err;
@@ -1069,14 +1044,12 @@ close_socket() noexcept
 
 void
 win_acceptor_impl::
-release()
+close_internal() noexcept
 {
     if (internal_)
     {
-        auto& svc = internal_->svc_;
-        internal_->release_internal();
+        internal_->close_socket();
         internal_.reset();
-        svc.destroy_acceptor_impl(*this);
     }
 }
 

--- a/src/corosio/src/detail/iocp/sockets.cpp
+++ b/src/corosio/src/detail/iocp/sockets.cpp
@@ -656,9 +656,9 @@ shutdown()
     }
 }
 
-win_socket_impl&
+io_object::io_object_impl*
 win_sockets::
-create_impl()
+construct()
 {
     auto internal = std::make_shared<win_socket_impl_internal>(*this);
 
@@ -674,7 +674,7 @@ create_impl()
         socket_wrapper_list_.push_back(wrapper);
     }
 
-    return *wrapper;
+    return wrapper;
 }
 
 void
@@ -795,25 +795,25 @@ load_extension_functions()
     ::closesocket(sock);
 }
 
-win_acceptor_impl&
-win_sockets::
-create_acceptor_impl()
+io_object::io_object_impl*
+win_acceptor_service::
+construct()
 {
-    auto internal = std::make_shared<win_acceptor_impl_internal>(*this);
+    auto internal = std::make_shared<win_acceptor_impl_internal>(svc_);
 
     {
-        std::lock_guard<win_mutex> lock(mutex_);
-        acceptor_list_.push_back(internal.get());
+        std::lock_guard<win_mutex> lock(svc_.mutex_);
+        svc_.acceptor_list_.push_back(internal.get());
     }
 
     auto* wrapper = new win_acceptor_impl(std::move(internal));
 
     {
-        std::lock_guard<win_mutex> lock(mutex_);
-        acceptor_wrapper_list_.push_back(wrapper);
+        std::lock_guard<win_mutex> lock(svc_.mutex_);
+        svc_.acceptor_wrapper_list_.push_back(wrapper);
     }
 
-    return *wrapper;
+    return wrapper;
 }
 
 void
@@ -952,7 +952,7 @@ accept(
     op.start(token);
 
     // Create wrapper for the peer socket (service owns it)
-    auto& peer_wrapper = svc_.create_impl();
+    auto& peer_wrapper = static_cast<win_socket_impl&>(*svc_.construct());
 
     // Create the accepted socket
     SOCKET accepted = ::WSASocketW(

--- a/src/corosio/src/detail/iocp/sockets.cpp
+++ b/src/corosio/src/detail/iocp/sockets.cpp
@@ -642,7 +642,7 @@ shutdown()
     }
 }
 
-io_object::io_object_impl*
+io_object::implementation*
 win_sockets::
 construct()
 {
@@ -781,7 +781,7 @@ load_extension_functions()
     ::closesocket(sock);
 }
 
-io_object::io_object_impl*
+io_object::implementation*
 win_acceptor_service::
 construct()
 {
@@ -908,7 +908,7 @@ accept(
     capy::executor_ref d,
     std::stop_token token,
     std::error_code* ec,
-    io_object::io_object_impl** impl_out)
+    io_object::implementation** impl_out)
 {
     // Keep acceptor internal alive during I/O
     acc_.acceptor_ptr = shared_from_this();

--- a/src/corosio/src/detail/iocp/sockets.cpp
+++ b/src/corosio/src/detail/iocp/sockets.cpp
@@ -310,14 +310,6 @@ void
 win_socket_impl_internal::
 release_internal()
 {
-    // Cancel pending I/O before closing to ensure operations
-    // complete with ERROR_OPERATION_ABORTED via IOCP
-    if (socket_ != INVALID_SOCKET)
-    {
-        ::CancelIoEx(
-            reinterpret_cast<HANDLE>(socket_),
-            nullptr);
-    }
     close_socket();
 }
 
@@ -586,6 +578,9 @@ close_socket() noexcept
 {
     if (socket_ != INVALID_SOCKET)
     {
+        ::CancelIoEx(
+            reinterpret_cast<HANDLE>(socket_),
+            nullptr);
         ::closesocket(socket_);
         socket_ = INVALID_SOCKET;
     }
@@ -1061,6 +1056,9 @@ close_socket() noexcept
 {
     if (socket_ != INVALID_SOCKET)
     {
+        ::CancelIoEx(
+            reinterpret_cast<HANDLE>(socket_),
+            nullptr);
         ::closesocket(socket_);
         socket_ = INVALID_SOCKET;
     }

--- a/src/corosio/src/detail/iocp/sockets.cpp
+++ b/src/corosio/src/detail/iocp/sockets.cpp
@@ -132,7 +132,7 @@ accept_op::do_complete(
 
         if (op->peer_wrapper)
         {
-            op->peer_wrapper->release();
+            op->peer_wrapper->close_internal();
             op->peer_wrapper = nullptr;
         }
 

--- a/src/corosio/src/detail/iocp/sockets.hpp
+++ b/src/corosio/src/detail/iocp/sockets.hpp
@@ -15,6 +15,7 @@
 #if BOOST_COROSIO_HAS_IOCP
 
 #include <boost/corosio/detail/config.hpp>
+#include <boost/corosio/detail/except.hpp>
 #include <boost/corosio/tcp_acceptor.hpp>
 #include <boost/corosio/tcp_socket.hpp>
 #include <boost/capy/ex/executor_ref.hpp>
@@ -485,6 +486,11 @@ public:
         return internal_->local_endpoint();
     }
 
+    bool is_open() const noexcept override
+    {
+        return internal_ && internal_->is_open();
+    }
+
     void cancel() noexcept override
     {
         internal_->cancel();
@@ -518,10 +524,27 @@ class win_sockets
 public:
     using key_type = win_sockets;
 
-    void open(io_object::handle&) override {}
-    void close(io_object::handle&) override {}
-    void destroy(io_object::implementation*) override {}
-    io_object::implementation* construct() override { return nullptr; }
+    io_object::io_object_impl* construct() override;
+
+    void destroy(io_object::io_object_impl* p) override
+    {
+        if (p)
+            p->release();
+    }
+
+    void open(io_object::handle& h) override
+    {
+        auto& wrapper = static_cast<win_socket_impl&>(*h.get());
+        std::error_code ec = open_socket(*wrapper.get_internal());
+        if (ec)
+            detail::throw_system_error(ec, "tcp_socket::open");
+    }
+
+    void close(io_object::handle& h) override
+    {
+        auto& wrapper = static_cast<win_socket_impl&>(*h.get());
+        wrapper.get_internal()->close_socket();
+    }
 
     /** Construct the socket service.
 
@@ -541,11 +564,6 @@ public:
     /** Shut down the service. */
     void shutdown() override;
 
-    /** Create a new socket implementation wrapper.
-        The service owns the returned object.
-    */
-    win_socket_impl& create_impl();
-
     /** Destroy a socket implementation wrapper.
         Removes from tracking list and deletes.
     */
@@ -562,11 +580,6 @@ public:
         @return Error code, or success.
     */
     std::error_code open_socket(win_socket_impl_internal& impl);
-
-    /** Create a new acceptor implementation wrapper.
-        The service owns the returned object.
-    */
-    win_acceptor_impl& create_acceptor_impl();
 
     /** Destroy an acceptor implementation wrapper.
         Removes from tracking list and deletes.
@@ -609,6 +622,8 @@ public:
     void work_finished() noexcept;
 
 private:
+    friend class win_acceptor_service;
+
     void load_extension_functions();
 
     win_scheduler& sched_;
@@ -620,6 +635,57 @@ private:
     void* iocp_;
     LPFN_CONNECTEX connect_ex_ = nullptr;
     LPFN_ACCEPTEX accept_ex_ = nullptr;
+};
+
+//------------------------------------------------------------------------------
+
+/** IOCP acceptor service wrapping win_sockets for acceptor lifecycle.
+
+    Provides io_service + acceptor_service interface for tcp_acceptor
+    on Windows. Delegates to win_sockets for actual socket operations.
+*/
+class win_acceptor_service
+    : public capy::execution_context::service
+    , public io_object::io_service
+{
+public:
+    using key_type = win_acceptor_service;
+
+    win_acceptor_service(capy::execution_context& ctx, win_sockets& svc)
+        : svc_(svc)
+    {
+        (void)ctx;
+    }
+
+    io_object::io_object_impl* construct() override;
+
+    void destroy(io_object::io_object_impl* p) override
+    {
+        if (p)
+            p->release();
+    }
+
+    void open(io_object::handle&) override {}
+    void close(io_object::handle& h) override
+    {
+        auto& wrapper = static_cast<win_acceptor_impl&>(*h.get());
+        wrapper.get_internal()->close_socket();
+    }
+
+    /** Open, bind, and listen on an acceptor socket. */
+    std::error_code open_acceptor(
+        tcp_acceptor::acceptor_impl& impl,
+        endpoint ep,
+        int backlog)
+    {
+        auto& wrapper = static_cast<win_acceptor_impl&>(impl);
+        return svc_.open_acceptor(*wrapper.get_internal(), ep, backlog);
+    }
+
+    void shutdown() override {}
+
+private:
+    win_sockets& svc_;
 };
 
 } // namespace boost::corosio::detail

--- a/src/corosio/src/detail/iocp/sockets.hpp
+++ b/src/corosio/src/detail/iocp/sockets.hpp
@@ -143,8 +143,6 @@ public:
     explicit win_socket_impl_internal(win_sockets& svc) noexcept;
     ~win_socket_impl_internal();
 
-    void release_internal();
-
     std::coroutine_handle<> connect(
         std::coroutine_handle<>,
         capy::executor_ref,
@@ -213,7 +211,7 @@ public:
     {
     }
 
-    void release() override;
+    void close_internal() noexcept;
 
     std::coroutine_handle<> connect(
         std::coroutine_handle<> h,
@@ -424,7 +422,8 @@ public:
     explicit win_acceptor_impl_internal(win_sockets& svc) noexcept;
     ~win_acceptor_impl_internal();
 
-    void release_internal();
+    /// Return the owning socket service.
+    win_sockets& socket_service() noexcept { return svc_; }
 
     std::coroutine_handle<> accept(
         std::coroutine_handle<>,
@@ -469,7 +468,7 @@ public:
     {
     }
 
-    void release() override;
+    void close_internal() noexcept;
 
     std::coroutine_handle<> accept(
         std::coroutine_handle<> h,
@@ -529,15 +528,11 @@ public:
     void destroy(io_object::io_object_impl* p) override
     {
         if (p)
-            p->release();
-    }
-
-    void open(io_object::handle& h) override
-    {
-        auto& wrapper = static_cast<win_socket_impl&>(*h.get());
-        std::error_code ec = open_socket(*wrapper.get_internal());
-        if (ec)
-            detail::throw_system_error(ec, "tcp_socket::open");
+        {
+            auto& wrapper = static_cast<win_socket_impl&>(*p);
+            wrapper.close_internal();
+            destroy_impl(wrapper);
+        }
     }
 
     void close(io_object::handle& h) override
@@ -662,10 +657,13 @@ public:
     void destroy(io_object::io_object_impl* p) override
     {
         if (p)
-            p->release();
+        {
+            auto& wrapper = static_cast<win_acceptor_impl&>(*p);
+            wrapper.close_internal();
+            svc_.destroy_acceptor_impl(wrapper);
+        }
     }
 
-    void open(io_object::handle&) override {}
     void close(io_object::handle& h) override
     {
         auto& wrapper = static_cast<win_acceptor_impl&>(*h.get());

--- a/src/corosio/src/detail/iocp/sockets.hpp
+++ b/src/corosio/src/detail/iocp/sockets.hpp
@@ -100,7 +100,7 @@ struct accept_op : overlapped_op
     win_socket_impl* peer_wrapper = nullptr;
     std::shared_ptr<win_acceptor_impl_internal> acceptor_ptr;
     SOCKET listen_socket = INVALID_SOCKET;
-    io_object::io_object_impl** impl_out = nullptr;
+    io_object::implementation** impl_out = nullptr;
     char addr_buf[2 * (sizeof(sockaddr_in6) + 16)];
 
     static void do_complete(void* owner, scheduler_op* base,
@@ -194,13 +194,13 @@ private:
 
 /** Socket implementation wrapper for IOCP-based I/O.
 
-    This class is the public-facing socket_impl that holds a shared_ptr
+    This class is the public-facing implementation that holds a shared_ptr
     to the internal state. The shared_ptr is hidden from the public interface.
 
     @note Internal implementation detail. Users interact with socket class.
 */
 class win_socket_impl
-    : public tcp_socket::socket_impl
+    : public tcp_socket::implementation
     , public intrusive_list<win_socket_impl>::node
 {
     std::shared_ptr<win_socket_impl_internal> internal_;
@@ -430,7 +430,7 @@ public:
         capy::executor_ref,
         std::stop_token,
         std::error_code*,
-        io_object::io_object_impl**);
+        io_object::implementation**);
 
     SOCKET native_handle() const noexcept { return socket_; }
     endpoint local_endpoint() const noexcept { return local_endpoint_; }
@@ -451,13 +451,13 @@ private:
 
 /** Acceptor implementation wrapper for IOCP-based I/O.
 
-    This class is the public-facing acceptor_impl that holds a shared_ptr
+    This class is the public-facing implementation that holds a shared_ptr
     to the internal state. The shared_ptr is hidden from the public interface.
 
     @note Internal implementation detail. Users interact with acceptor class.
 */
 class win_acceptor_impl
-    : public tcp_acceptor::acceptor_impl
+    : public tcp_acceptor::implementation
     , public intrusive_list<win_acceptor_impl>::node
 {
     std::shared_ptr<win_acceptor_impl_internal> internal_;
@@ -475,7 +475,7 @@ public:
         capy::executor_ref d,
         std::stop_token token,
         std::error_code* ec,
-        io_object::io_object_impl** impl_out) override
+        io_object::implementation** impl_out) override
     {
         return internal_->accept(h, d, token, ec, impl_out);
     }
@@ -523,9 +523,9 @@ class win_sockets
 public:
     using key_type = win_sockets;
 
-    io_object::io_object_impl* construct() override;
+    io_object::implementation* construct() override;
 
-    void destroy(io_object::io_object_impl* p) override
+    void destroy(io_object::implementation* p) override
     {
         if (p)
         {
@@ -652,9 +652,9 @@ public:
         (void)ctx;
     }
 
-    io_object::io_object_impl* construct() override;
+    io_object::implementation* construct() override;
 
-    void destroy(io_object::io_object_impl* p) override
+    void destroy(io_object::implementation* p) override
     {
         if (p)
         {
@@ -672,7 +672,7 @@ public:
 
     /** Open, bind, and listen on an acceptor socket. */
     std::error_code open_acceptor(
-        tcp_acceptor::acceptor_impl& impl,
+        tcp_acceptor::implementation& impl,
         endpoint ep,
         int backlog)
     {

--- a/src/corosio/src/detail/kqueue/acceptors.cpp
+++ b/src/corosio/src/detail/kqueue/acceptors.cpp
@@ -215,7 +215,7 @@ accept(
     capy::executor_ref ex,
     std::stop_token token,
     std::error_code* ec,
-    io_object::io_object_impl** impl_out)
+    io_object::implementation** impl_out)
 {
     auto& op = acc_;
     op.reset();
@@ -438,7 +438,7 @@ shutdown()
     // after scheduler shutdown has drained all queued ops.
 }
 
-io_object::io_object_impl*
+io_object::implementation*
 kqueue_acceptor_service::
 construct()
 {
@@ -454,7 +454,7 @@ construct()
 
 void
 kqueue_acceptor_service::
-destroy(io_object::io_object_impl* impl)
+destroy(io_object::implementation* impl)
 {
     auto* kq_impl = static_cast<kqueue_acceptor_impl*>(impl);
     kq_impl->close_socket();
@@ -473,7 +473,7 @@ close(io_object::handle& h)
 std::error_code
 kqueue_acceptor_service::
 open_acceptor(
-    tcp_acceptor::acceptor_impl& impl,
+    tcp_acceptor::implementation& impl,
     endpoint ep,
     int backlog)
 {

--- a/src/corosio/src/detail/kqueue/acceptors.cpp
+++ b/src/corosio/src/detail/kqueue/acceptors.cpp
@@ -465,12 +465,6 @@ destroy(io_object::io_object_impl* impl)
 
 void
 kqueue_acceptor_service::
-open(io_object::handle&)
-{
-}
-
-void
-kqueue_acceptor_service::
 close(io_object::handle& h)
 {
     static_cast<kqueue_acceptor_impl*>(h.get())->close_socket();

--- a/src/corosio/src/detail/kqueue/acceptors.cpp
+++ b/src/corosio/src/detail/kqueue/acceptors.cpp
@@ -109,7 +109,7 @@ operator()()
                 ->service().socket_service();
             if (socket_svc)
             {
-                auto& impl = static_cast<kqueue_socket_impl&>(socket_svc->create_impl());
+                auto& impl = static_cast<kqueue_socket_impl&>(*socket_svc->construct());
                 impl.set_socket(accepted_fd);
 
                 // Register accepted socket with kqueue (edge-triggered via EV_CLEAR)
@@ -130,7 +130,7 @@ operator()()
                         *ec_out = make_err(errno);
                     ::close(accepted_fd);
                     accepted_fd = -1;
-                    socket_svc->destroy_impl(impl);
+                    socket_svc->destroy(&impl);
                     if (impl_out)
                         *impl_out = nullptr;
                 }
@@ -184,7 +184,10 @@ operator()()
 
         if (peer_impl)
         {
-            peer_impl->release();
+            auto* socket_svc_cleanup = static_cast<kqueue_acceptor_impl*>(acceptor_impl_)
+                ->service().socket_service();
+            if (socket_svc_cleanup)
+                socket_svc_cleanup->destroy(peer_impl);
             peer_impl = nullptr;
         }
 
@@ -203,14 +206,6 @@ kqueue_acceptor_impl::
 kqueue_acceptor_impl(kqueue_acceptor_service& svc) noexcept
     : svc_(svc)
 {
-}
-
-void
-kqueue_acceptor_impl::
-release()
-{
-    close_socket();
-    svc_.destroy_acceptor_impl(*this);
 }
 
 std::coroutine_handle<>
@@ -443,9 +438,9 @@ shutdown()
     // after scheduler shutdown has drained all queued ops.
 }
 
-tcp_acceptor::acceptor_impl&
+io_object::io_object_impl*
 kqueue_acceptor_service::
-create_acceptor_impl()
+construct()
 {
     auto impl = std::make_shared<kqueue_acceptor_impl>(*this);
     auto* raw = impl.get();
@@ -454,17 +449,31 @@ create_acceptor_impl()
     state_->acceptor_list_.push_back(raw);
     state_->acceptor_ptrs_.emplace(raw, std::move(impl));
 
-    return *raw;
+    return raw;
 }
 
 void
 kqueue_acceptor_service::
-destroy_acceptor_impl(tcp_acceptor::acceptor_impl& impl)
+destroy(io_object::io_object_impl* impl)
 {
-    auto* kq_impl = static_cast<kqueue_acceptor_impl*>(&impl);
+    auto* kq_impl = static_cast<kqueue_acceptor_impl*>(impl);
+    kq_impl->close_socket();
     std::lock_guard lock(state_->mutex_);
     state_->acceptor_list_.remove(kq_impl);
     state_->acceptor_ptrs_.erase(kq_impl);
+}
+
+void
+kqueue_acceptor_service::
+open(io_object::handle&)
+{
+}
+
+void
+kqueue_acceptor_service::
+close(io_object::handle& h)
+{
+    static_cast<kqueue_acceptor_impl*>(h.get())->close_socket();
 }
 
 std::error_code

--- a/src/corosio/src/detail/kqueue/acceptors.hpp
+++ b/src/corosio/src/detail/kqueue/acceptors.hpp
@@ -209,9 +209,6 @@ public:
     /// Destroy an impl previously returned by construct().
     void destroy(io_object::io_object_impl*) override;
 
-    /// Open the acceptor (no-op; opening is done by open_acceptor).
-    void open(io_object::handle&) override;
-
     /// Close the acceptor's listening socket.
     void close(io_object::handle&) override;
 

--- a/src/corosio/src/detail/kqueue/acceptors.hpp
+++ b/src/corosio/src/detail/kqueue/acceptors.hpp
@@ -56,7 +56,7 @@ class kqueue_socket_service;
 
 /// Acceptor implementation for kqueue backend.
 class kqueue_acceptor_impl
-    : public tcp_acceptor::acceptor_impl
+    : public tcp_acceptor::implementation
     , public std::enable_shared_from_this<kqueue_acceptor_impl>
     , public intrusive_list<kqueue_acceptor_impl>::node
 {
@@ -100,8 +100,8 @@ public:
         @par Example
         @code
         std::error_code ec;
-        io_object::io_object_impl* peer = nullptr;
-        co_await acceptor_impl.accept(
+        io_object::implementation* peer = nullptr;
+        co_await implementation.accept(
             my_handle, ex, stop_source.get_token(), &ec, &peer);
         if (!ec)
             // peer is a valid kqueue_socket_impl
@@ -112,7 +112,7 @@ public:
         capy::executor_ref ex,
         std::stop_token token,
         std::error_code* ec,
-        io_object::io_object_impl** out_impl) override;
+        io_object::implementation** out_impl) override;
 
     int native_handle() const noexcept { return fd_; }
     endpoint local_endpoint() const noexcept override { return local_endpoint_; }
@@ -204,10 +204,10 @@ public:
     void shutdown() override;
 
     /// Construct a new acceptor impl owned by this service.
-    io_object::io_object_impl* construct() override;
+    io_object::implementation* construct() override;
 
     /// Destroy an impl previously returned by construct().
-    void destroy(io_object::io_object_impl*) override;
+    void destroy(io_object::implementation*) override;
 
     /// Close the acceptor's listening socket.
     void close(io_object::handle&) override;
@@ -218,7 +218,7 @@ public:
         any syscall failure (socket, bind, listen, fcntl).
     */
     std::error_code open_acceptor(
-        tcp_acceptor::acceptor_impl& impl,
+        tcp_acceptor::implementation& impl,
         endpoint ep,
         int backlog) override;
 

--- a/src/corosio/src/detail/kqueue/acceptors.hpp
+++ b/src/corosio/src/detail/kqueue/acceptors.hpp
@@ -65,8 +65,6 @@ class kqueue_acceptor_impl
 public:
     explicit kqueue_acceptor_impl(kqueue_acceptor_service& svc) noexcept;
 
-    void release() override;
-
     /** Initiate an asynchronous accept on the listening socket.
 
         Attempts a synchronous accept first. If the socket would block
@@ -118,7 +116,7 @@ public:
 
     int native_handle() const noexcept { return fd_; }
     endpoint local_endpoint() const noexcept override { return local_endpoint_; }
-    bool is_open() const noexcept { return fd_ >= 0; }
+    bool is_open() const noexcept override { return fd_ >= 0; }
 
     /** Cancel any pending accept operation.
 
@@ -205,16 +203,17 @@ public:
     */
     void shutdown() override;
 
-    /** Create a new acceptor impl owned by this service.
-        The returned tcp_acceptor::acceptor_impl must be destroyed
-        via destroy_acceptor_impl() or by shutdown().
-    */
-    tcp_acceptor::acceptor_impl& create_acceptor_impl() override;
+    /// Construct a new acceptor impl owned by this service.
+    io_object::io_object_impl* construct() override;
 
-    /** Remove and destroy an impl previously returned by
-        create_acceptor_impl(). Closes the socket if still open.
-    */
-    void destroy_acceptor_impl(tcp_acceptor::acceptor_impl& impl) override;
+    /// Destroy an impl previously returned by construct().
+    void destroy(io_object::io_object_impl*) override;
+
+    /// Open the acceptor (no-op; opening is done by open_acceptor).
+    void open(io_object::handle&) override;
+
+    /// Close the acceptor's listening socket.
+    void close(io_object::handle&) override;
 
     /** Bind and listen on @p ep with the given @p backlog.
         Registers the fd with kqueue on success and caches the

--- a/src/corosio/src/detail/kqueue/op.hpp
+++ b/src/corosio/src/detail/kqueue/op.hpp
@@ -348,8 +348,8 @@ struct kqueue_write_op : kqueue_op
 struct kqueue_accept_op : kqueue_op
 {
     int accepted_fd = -1;
-    io_object::io_object_impl* peer_impl = nullptr;
-    io_object::io_object_impl** impl_out = nullptr;
+    io_object::implementation* peer_impl = nullptr;
+    io_object::implementation** impl_out = nullptr;
 
     void reset() noexcept
     {

--- a/src/corosio/src/detail/kqueue/sockets.cpp
+++ b/src/corosio/src/detail/kqueue/sockets.cpp
@@ -769,7 +769,7 @@ shutdown()
     // shutdown) keeps every impl alive until all ops have been drained.
 }
 
-io_object::io_object_impl*
+io_object::implementation*
 kqueue_socket_service::
 construct()
 {
@@ -787,7 +787,7 @@ construct()
 
 void
 kqueue_socket_service::
-destroy(io_object::io_object_impl* impl)
+destroy(io_object::implementation* impl)
 {
     auto* kq_impl = static_cast<kqueue_socket_impl*>(impl);
     kq_impl->close_socket();
@@ -798,7 +798,7 @@ destroy(io_object::io_object_impl* impl)
 
 std::error_code
 kqueue_socket_service::
-open_socket(tcp_socket::socket_impl& impl)
+open_socket(tcp_socket::implementation& impl)
 {
     auto* kq_impl = static_cast<kqueue_socket_impl*>(&impl);
     kq_impl->close_socket();

--- a/src/corosio/src/detail/kqueue/sockets.cpp
+++ b/src/corosio/src/detail/kqueue/sockets.cpp
@@ -858,16 +858,6 @@ open_socket(tcp_socket::socket_impl& impl)
 
 void
 kqueue_socket_service::
-open(io_object::handle& h)
-{
-    auto ec = open_socket(
-        *static_cast<tcp_socket::socket_impl*>(h.get()));
-    if (ec)
-        detail::throw_system_error(ec, "open");
-}
-
-void
-kqueue_socket_service::
 close(io_object::handle& h)
 {
     static_cast<kqueue_socket_impl*>(h.get())->close_socket();

--- a/src/corosio/src/detail/kqueue/sockets.cpp
+++ b/src/corosio/src/detail/kqueue/sockets.cpp
@@ -187,14 +187,6 @@ kqueue_socket_impl(kqueue_socket_service& svc) noexcept
 kqueue_socket_impl::
 ~kqueue_socket_impl() = default;
 
-void
-kqueue_socket_impl::
-release()
-{
-    close_socket();
-    svc_.destroy_impl(*this);
-}
-
 std::coroutine_handle<>
 kqueue_socket_impl::
 connect(
@@ -777,9 +769,9 @@ shutdown()
     // shutdown) keeps every impl alive until all ops have been drained.
 }
 
-tcp_socket::socket_impl&
+io_object::io_object_impl*
 kqueue_socket_service::
-create_impl()
+construct()
 {
     auto impl = std::make_shared<kqueue_socket_impl>(*this);
     auto* raw = impl.get();
@@ -790,14 +782,15 @@ create_impl()
         state_->socket_ptrs_.emplace(raw, std::move(impl));
     }
 
-    return *raw;
+    return raw;
 }
 
 void
 kqueue_socket_service::
-destroy_impl(tcp_socket::socket_impl& impl)
+destroy(io_object::io_object_impl* impl)
 {
-    auto* kq_impl = static_cast<kqueue_socket_impl*>(&impl);
+    auto* kq_impl = static_cast<kqueue_socket_impl*>(impl);
+    kq_impl->close_socket();
     std::lock_guard lock(state_->mutex_);
     state_->socket_list_.remove(kq_impl);
     state_->socket_ptrs_.erase(kq_impl);
@@ -861,6 +854,23 @@ open_socket(tcp_socket::socket_impl& impl)
     scheduler().register_descriptor(fd, &kq_impl->desc_state_);
 
     return {};
+}
+
+void
+kqueue_socket_service::
+open(io_object::handle& h)
+{
+    auto ec = open_socket(
+        *static_cast<tcp_socket::socket_impl*>(h.get()));
+    if (ec)
+        detail::throw_system_error(ec, "open");
+}
+
+void
+kqueue_socket_service::
+close(io_object::handle& h)
+{
+    static_cast<kqueue_socket_impl*>(h.get())->close_socket();
 }
 
 void

--- a/src/corosio/src/detail/kqueue/sockets.hpp
+++ b/src/corosio/src/detail/kqueue/sockets.hpp
@@ -78,7 +78,7 @@ class kqueue_socket_impl;
 
 /// Socket implementation for kqueue backend.
 class kqueue_socket_impl
-    : public tcp_socket::socket_impl
+    : public tcp_socket::implementation
     , public std::enable_shared_from_this<kqueue_socket_impl>
     , public intrusive_list<kqueue_socket_impl>::node
 {
@@ -198,10 +198,10 @@ public:
 
     void shutdown() override;
 
-    io_object::io_object_impl* construct() override;
-    void destroy(io_object::io_object_impl*) override;
+    io_object::implementation* construct() override;
+    void destroy(io_object::implementation*) override;
     void close(io_object::handle&) override;
-    std::error_code open_socket(tcp_socket::socket_impl& impl) override;
+    std::error_code open_socket(tcp_socket::implementation& impl) override;
 
     kqueue_scheduler& scheduler() const noexcept { return state_->sched_; }
     void post(kqueue_op* op);

--- a/src/corosio/src/detail/kqueue/sockets.hpp
+++ b/src/corosio/src/detail/kqueue/sockets.hpp
@@ -200,7 +200,6 @@ public:
 
     io_object::io_object_impl* construct() override;
     void destroy(io_object::io_object_impl*) override;
-    void open(io_object::handle&) override;
     void close(io_object::handle&) override;
     std::error_code open_socket(tcp_socket::socket_impl& impl) override;
 

--- a/src/corosio/src/detail/kqueue/sockets.hpp
+++ b/src/corosio/src/detail/kqueue/sockets.hpp
@@ -88,8 +88,6 @@ public:
     explicit kqueue_socket_impl(kqueue_socket_service& svc) noexcept;
     ~kqueue_socket_impl();
 
-    void release() override;
-
     std::coroutine_handle<> connect(
         std::coroutine_handle<>,
         capy::executor_ref,
@@ -200,8 +198,10 @@ public:
 
     void shutdown() override;
 
-    tcp_socket::socket_impl& create_impl() override;
-    void destroy_impl(tcp_socket::socket_impl& impl) override;
+    io_object::io_object_impl* construct() override;
+    void destroy(io_object::io_object_impl*) override;
+    void open(io_object::handle&) override;
+    void close(io_object::handle&) override;
     std::error_code open_socket(tcp_socket::socket_impl& impl) override;
 
     kqueue_scheduler& scheduler() const noexcept { return state_->sched_; }

--- a/src/corosio/src/detail/posix/resolver_service.cpp
+++ b/src/corosio/src/detail/posix/resolver_service.cpp
@@ -434,8 +434,14 @@ public:
     posix_resolver_service_impl(posix_resolver_service_impl const&) = delete;
     posix_resolver_service_impl& operator=(posix_resolver_service_impl const&) = delete;
 
+    io_object::io_object_impl* construct() override;
+
+    void destroy(io_object::io_object_impl* p) override
+    {
+        static_cast<posix_resolver_impl*>(p)->release();
+    }
+
     void shutdown() override;
-    resolver::resolver_impl& create_impl() override;
     void destroy_impl(posix_resolver_impl& impl);
 
     void post(scheduler_op* op);
@@ -828,9 +834,9 @@ shutdown()
     }
 }
 
-resolver::resolver_impl&
+io_object::io_object_impl*
 posix_resolver_service_impl::
-create_impl()
+construct()
 {
     auto ptr = std::make_shared<posix_resolver_impl>(*this);
     auto* impl = ptr.get();
@@ -841,7 +847,7 @@ create_impl()
         resolver_ptrs_[impl] = std::move(ptr);
     }
 
-    return *impl;
+    return impl;
 }
 
 void

--- a/src/corosio/src/detail/posix/resolver_service.cpp
+++ b/src/corosio/src/detail/posix/resolver_service.cpp
@@ -283,7 +283,7 @@ class posix_resolver_service_impl;
     Shared objects: Unsafe. See single-inflight contract above.
 */
 class posix_resolver_impl
-    : public resolver::resolver_impl
+    : public resolver::implementation
     , public std::enable_shared_from_this<posix_resolver_impl>
     , public intrusive_list<posix_resolver_impl>::node
 {
@@ -432,9 +432,9 @@ public:
     posix_resolver_service_impl(posix_resolver_service_impl const&) = delete;
     posix_resolver_service_impl& operator=(posix_resolver_service_impl const&) = delete;
 
-    io_object::io_object_impl* construct() override;
+    io_object::implementation* construct() override;
 
-    void destroy(io_object::io_object_impl* p) override
+    void destroy(io_object::implementation* p) override
     {
         auto& impl = static_cast<posix_resolver_impl&>(*p);
         impl.cancel();
@@ -826,7 +826,7 @@ shutdown()
     }
 }
 
-io_object::io_object_impl*
+io_object::implementation*
 posix_resolver_service_impl::
 construct()
 {

--- a/src/corosio/src/detail/posix/resolver_service.cpp
+++ b/src/corosio/src/detail/posix/resolver_service.cpp
@@ -381,8 +381,6 @@ public:
     {
     }
 
-    void release() override;
-
     std::coroutine_handle<> resolve(
         std::coroutine_handle<>,
         capy::executor_ref,
@@ -438,7 +436,9 @@ public:
 
     void destroy(io_object::io_object_impl* p) override
     {
-        static_cast<posix_resolver_impl*>(p)->release();
+        auto& impl = static_cast<posix_resolver_impl&>(*p);
+        impl.cancel();
+        destroy_impl(impl);
     }
 
     void shutdown() override;
@@ -608,14 +608,6 @@ start(std::stop_token token)
 //------------------------------------------------------------------------------
 // posix_resolver_impl implementation
 //------------------------------------------------------------------------------
-
-void
-posix_resolver_impl::
-release()
-{
-    cancel();
-    svc_.destroy_impl(*this);
-}
 
 std::coroutine_handle<>
 posix_resolver_impl::

--- a/src/corosio/src/detail/posix/resolver_service.hpp
+++ b/src/corosio/src/detail/posix/resolver_service.hpp
@@ -62,10 +62,6 @@ class posix_resolver_service
     , public io_object::io_service
 {
 public:
-    // io_service no-ops for resolvers (no kernel resource to open/close)
-    void open(io_object::handle&) override {}
-    void close(io_object::handle&) override {}
-
 protected:
     posix_resolver_service() = default;
 };

--- a/src/corosio/src/detail/posix/resolver_service.hpp
+++ b/src/corosio/src/detail/posix/resolver_service.hpp
@@ -57,11 +57,14 @@ struct scheduler;
     implementation (posix_resolver_service_impl) is created via
     get_resolver_service() which passes the scheduler reference.
 */
-class posix_resolver_service : public capy::execution_context::service
+class posix_resolver_service
+    : public capy::execution_context::service
+    , public io_object::io_service
 {
 public:
-    /** Create a new resolver implementation. */
-    virtual resolver::resolver_impl& create_impl() = 0;
+    // io_service no-ops for resolvers (no kernel resource to open/close)
+    void open(io_object::handle&) override {}
+    void close(io_object::handle&) override {}
 
 protected:
     posix_resolver_service() = default;

--- a/src/corosio/src/detail/posix/signals.cpp
+++ b/src/corosio/src/detail/posix/signals.cpp
@@ -161,7 +161,7 @@ struct signal_registration
 {
     int signal_number = 0;
     signal_set::flags_t flags = signal_set::none;
-    signal_set::signal_set_impl* owner = nullptr;
+    signal_set::implementation* owner = nullptr;
     std::size_t undelivered = 0;
     signal_registration* next_in_table = nullptr;
     signal_registration* prev_in_table = nullptr;
@@ -173,7 +173,7 @@ struct signal_registration
 //------------------------------------------------------------------------------
 
 class posix_signal_impl
-    : public signal_set::signal_set_impl
+    : public signal_set::implementation
     , public intrusive_list<posix_signal_impl>::node
 {
     friend class posix_signals_impl;
@@ -214,9 +214,9 @@ public:
     posix_signals_impl(posix_signals_impl const&) = delete;
     posix_signals_impl& operator=(posix_signals_impl const&) = delete;
 
-    io_object::io_object_impl* construct() override;
+    io_object::implementation* construct() override;
 
-    void destroy(io_object::io_object_impl* p) override
+    void destroy(io_object::implementation* p) override
     {
         auto& impl = static_cast<posix_signal_impl&>(*p);
         impl.clear();
@@ -483,7 +483,7 @@ shutdown()
     }
 }
 
-io_object::io_object_impl*
+io_object::implementation*
 posix_signals_impl::
 construct()
 {

--- a/src/corosio/src/detail/posix/signals.cpp
+++ b/src/corosio/src/detail/posix/signals.cpp
@@ -216,8 +216,14 @@ public:
     posix_signals_impl(posix_signals_impl const&) = delete;
     posix_signals_impl& operator=(posix_signals_impl const&) = delete;
 
+    io_object::io_object_impl* construct() override;
+
+    void destroy(io_object::io_object_impl* p) override
+    {
+        static_cast<posix_signal_impl*>(p)->release();
+    }
+
     void shutdown() override;
-    signal_set::signal_set_impl& create_impl() override;
 
     void destroy_impl(posix_signal_impl& impl);
 
@@ -485,9 +491,9 @@ shutdown()
     }
 }
 
-signal_set::signal_set_impl&
+io_object::io_object_impl*
 posix_signals_impl::
-create_impl()
+construct()
 {
     auto* impl = new posix_signal_impl(*this);
 
@@ -496,7 +502,7 @@ create_impl()
         impl_list_.push_back(impl);
     }
 
-    return *impl;
+    return impl;
 }
 
 void
@@ -867,28 +873,18 @@ get_signal_service(capy::execution_context& ctx, scheduler& sched)
 //------------------------------------------------------------------------------
 
 signal_set::
-~signal_set()
-{
-    if (impl_)
-        impl_->release();
-}
+~signal_set() = default;
 
 signal_set::
 signal_set(capy::execution_context& ctx)
-    : io_object(ctx)
+    : io_object(create_handle<detail::posix_signals>(ctx))
 {
-    auto* svc = ctx.find_service<detail::posix_signals>();
-    if (!svc)
-        detail::throw_logic_error("signal_set: signal service not initialized");
-    impl_ = &svc->create_impl();
 }
 
 signal_set::
 signal_set(signal_set&& other) noexcept
     : io_object(std::move(other))
 {
-    impl_ = other.impl_;
-    other.impl_ = nullptr;
 }
 
 signal_set&
@@ -897,14 +893,9 @@ operator=(signal_set&& other)
 {
     if (this != &other)
     {
-        if (ctx_ != other.ctx_)
+        if (&context() != &other.context())
             detail::throw_logic_error("signal_set::operator=: context mismatch");
-
-        if (impl_)
-            impl_->release();
-
-        impl_ = other.impl_;
-        other.impl_ = nullptr;
+        h_ = std::move(other.h_);
     }
     return *this;
 }

--- a/src/corosio/src/detail/posix/signals.cpp
+++ b/src/corosio/src/detail/posix/signals.cpp
@@ -186,8 +186,6 @@ class posix_signal_impl
 public:
     explicit posix_signal_impl(posix_signals_impl& svc) noexcept;
 
-    void release() override;
-
     std::coroutine_handle<> wait(
         std::coroutine_handle<>,
         capy::executor_ref,
@@ -220,7 +218,10 @@ public:
 
     void destroy(io_object::io_object_impl* p) override
     {
-        static_cast<posix_signal_impl*>(p)->release();
+        auto& impl = static_cast<posix_signal_impl&>(*p);
+        impl.clear();
+        impl.cancel();
+        destroy_impl(impl);
     }
 
     void shutdown() override;
@@ -381,15 +382,6 @@ posix_signal_impl::
 posix_signal_impl(posix_signals_impl& svc) noexcept
     : svc_(svc)
 {
-}
-
-void
-posix_signal_impl::
-release()
-{
-    clear();
-    cancel();
-    svc_.destroy_impl(*this);
 }
 
 std::coroutine_handle<>

--- a/src/corosio/src/detail/posix/signals.hpp
+++ b/src/corosio/src/detail/posix/signals.hpp
@@ -45,11 +45,14 @@ struct scheduler;
     implementation (posix_signals_impl) is created via get_signal_service()
     which passes the scheduler reference.
 */
-class posix_signals : public capy::execution_context::service
+class posix_signals
+    : public capy::execution_context::service
+    , public io_object::io_service
 {
 public:
-    /** Create a new signal set implementation. */
-    virtual signal_set::signal_set_impl& create_impl() = 0;
+    // io_service no-ops for signal sets (no kernel resource to open/close)
+    void open(io_object::handle&) override {}
+    void close(io_object::handle&) override {}
 
 protected:
     posix_signals() = default;

--- a/src/corosio/src/detail/posix/signals.hpp
+++ b/src/corosio/src/detail/posix/signals.hpp
@@ -50,10 +50,6 @@ class posix_signals
     , public io_object::io_service
 {
 public:
-    // io_service no-ops for signal sets (no kernel resource to open/close)
-    void open(io_object::handle&) override {}
-    void close(io_object::handle&) override {}
-
 protected:
     posix_signals() = default;
 };

--- a/src/corosio/src/detail/select/acceptors.cpp
+++ b/src/corosio/src/detail/select/acceptors.cpp
@@ -141,7 +141,7 @@ accept(
     capy::executor_ref ex,
     std::stop_token token,
     std::error_code* ec,
-    io_object::io_object_impl** impl_out)
+    io_object::implementation** impl_out)
 {
     auto& op = acc_;
     op.reset();
@@ -359,7 +359,7 @@ shutdown()
     // after scheduler shutdown has drained all queued ops.
 }
 
-io_object::io_object_impl*
+io_object::implementation*
 select_acceptor_service::
 construct()
 {
@@ -375,7 +375,7 @@ construct()
 
 void
 select_acceptor_service::
-destroy(io_object::io_object_impl* impl)
+destroy(io_object::implementation* impl)
 {
     auto* select_impl = static_cast<select_acceptor_impl*>(impl);
     select_impl->close_socket();
@@ -394,7 +394,7 @@ close(io_object::handle& h)
 std::error_code
 select_acceptor_service::
 open_acceptor(
-    tcp_acceptor::acceptor_impl& impl,
+    tcp_acceptor::implementation& impl,
     endpoint ep,
     int backlog)
 {

--- a/src/corosio/src/detail/select/acceptors.cpp
+++ b/src/corosio/src/detail/select/acceptors.cpp
@@ -61,7 +61,7 @@ operator()()
                 ->service().socket_service();
             if (socket_svc)
             {
-                auto& impl = static_cast<select_socket_impl&>(socket_svc->create_impl());
+                auto& impl = static_cast<select_socket_impl&>(*socket_svc->construct());
                 impl.set_socket(accepted_fd);
 
                 sockaddr_in local_addr{};
@@ -110,7 +110,10 @@ operator()()
 
         if (peer_impl)
         {
-            peer_impl->release();
+            auto* socket_svc_cleanup = static_cast<select_acceptor_impl*>(acceptor_impl_)
+                ->service().socket_service();
+            if (socket_svc_cleanup)
+                socket_svc_cleanup->destroy(peer_impl);
             peer_impl = nullptr;
         }
 
@@ -129,14 +132,6 @@ select_acceptor_impl::
 select_acceptor_impl(select_acceptor_service& svc) noexcept
     : svc_(svc)
 {
-}
-
-void
-select_acceptor_impl::
-release()
-{
-    close_socket();
-    svc_.destroy_acceptor_impl(*this);
 }
 
 std::coroutine_handle<>
@@ -364,9 +359,9 @@ shutdown()
     // after scheduler shutdown has drained all queued ops.
 }
 
-tcp_acceptor::acceptor_impl&
+io_object::io_object_impl*
 select_acceptor_service::
-create_acceptor_impl()
+construct()
 {
     auto impl = std::make_shared<select_acceptor_impl>(*this);
     auto* raw = impl.get();
@@ -375,17 +370,31 @@ create_acceptor_impl()
     state_->acceptor_list_.push_back(raw);
     state_->acceptor_ptrs_.emplace(raw, std::move(impl));
 
-    return *raw;
+    return raw;
 }
 
 void
 select_acceptor_service::
-destroy_acceptor_impl(tcp_acceptor::acceptor_impl& impl)
+destroy(io_object::io_object_impl* impl)
 {
-    auto* select_impl = static_cast<select_acceptor_impl*>(&impl);
+    auto* select_impl = static_cast<select_acceptor_impl*>(impl);
+    select_impl->close_socket();
     std::lock_guard lock(state_->mutex_);
     state_->acceptor_list_.remove(select_impl);
     state_->acceptor_ptrs_.erase(select_impl);
+}
+
+void
+select_acceptor_service::
+open(io_object::handle&)
+{
+}
+
+void
+select_acceptor_service::
+close(io_object::handle& h)
+{
+    static_cast<select_acceptor_impl*>(h.get())->close_socket();
 }
 
 std::error_code

--- a/src/corosio/src/detail/select/acceptors.cpp
+++ b/src/corosio/src/detail/select/acceptors.cpp
@@ -386,12 +386,6 @@ destroy(io_object::io_object_impl* impl)
 
 void
 select_acceptor_service::
-open(io_object::handle&)
-{
-}
-
-void
-select_acceptor_service::
 close(io_object::handle& h)
 {
     static_cast<select_acceptor_impl*>(h.get())->close_socket();

--- a/src/corosio/src/detail/select/acceptors.hpp
+++ b/src/corosio/src/detail/select/acceptors.hpp
@@ -36,7 +36,7 @@ class select_socket_service;
 
 /// Acceptor implementation for select backend.
 class select_acceptor_impl
-    : public tcp_acceptor::acceptor_impl
+    : public tcp_acceptor::implementation
     , public std::enable_shared_from_this<select_acceptor_impl>
     , public intrusive_list<select_acceptor_impl>::node
 {
@@ -50,7 +50,7 @@ public:
         capy::executor_ref,
         std::stop_token,
         std::error_code*,
-        io_object::io_object_impl**) override;
+        io_object::implementation**) override;
 
     int native_handle() const noexcept { return fd_; }
     endpoint local_endpoint() const noexcept override { return local_endpoint_; }
@@ -101,11 +101,11 @@ public:
 
     void shutdown() override;
 
-    io_object::io_object_impl* construct() override;
-    void destroy(io_object::io_object_impl*) override;
+    io_object::implementation* construct() override;
+    void destroy(io_object::implementation*) override;
     void close(io_object::handle&) override;
     std::error_code open_acceptor(
-        tcp_acceptor::acceptor_impl& impl,
+        tcp_acceptor::implementation& impl,
         endpoint ep,
         int backlog) override;
 

--- a/src/corosio/src/detail/select/acceptors.hpp
+++ b/src/corosio/src/detail/select/acceptors.hpp
@@ -45,8 +45,6 @@ class select_acceptor_impl
 public:
     explicit select_acceptor_impl(select_acceptor_service& svc) noexcept;
 
-    void release() override;
-
     std::coroutine_handle<> accept(
         std::coroutine_handle<>,
         capy::executor_ref,
@@ -56,7 +54,7 @@ public:
 
     int native_handle() const noexcept { return fd_; }
     endpoint local_endpoint() const noexcept override { return local_endpoint_; }
-    bool is_open() const noexcept { return fd_ >= 0; }
+    bool is_open() const noexcept override { return fd_ >= 0; }
     void cancel() noexcept override;
     void cancel_single_op(select_op& op) noexcept;
     void close_socket() noexcept;
@@ -103,8 +101,10 @@ public:
 
     void shutdown() override;
 
-    tcp_acceptor::acceptor_impl& create_acceptor_impl() override;
-    void destroy_acceptor_impl(tcp_acceptor::acceptor_impl& impl) override;
+    io_object::io_object_impl* construct() override;
+    void destroy(io_object::io_object_impl*) override;
+    void open(io_object::handle&) override;
+    void close(io_object::handle&) override;
     std::error_code open_acceptor(
         tcp_acceptor::acceptor_impl& impl,
         endpoint ep,

--- a/src/corosio/src/detail/select/acceptors.hpp
+++ b/src/corosio/src/detail/select/acceptors.hpp
@@ -103,7 +103,6 @@ public:
 
     io_object::io_object_impl* construct() override;
     void destroy(io_object::io_object_impl*) override;
-    void open(io_object::handle&) override;
     void close(io_object::handle&) override;
     std::error_code open_acceptor(
         tcp_acceptor::acceptor_impl& impl,

--- a/src/corosio/src/detail/select/op.hpp
+++ b/src/corosio/src/detail/select/op.hpp
@@ -322,8 +322,8 @@ struct select_write_op : select_op
 struct select_accept_op : select_op
 {
     int accepted_fd = -1;
-    io_object::io_object_impl* peer_impl = nullptr;
-    io_object::io_object_impl** impl_out = nullptr;
+    io_object::implementation* peer_impl = nullptr;
+    io_object::implementation** impl_out = nullptr;
 
     void reset() noexcept
     {

--- a/src/corosio/src/detail/select/sockets.cpp
+++ b/src/corosio/src/detail/select/sockets.cpp
@@ -645,7 +645,7 @@ shutdown()
     // shutdown) keeps every impl alive until all ops have been drained.
 }
 
-io_object::io_object_impl*
+io_object::implementation*
 select_socket_service::
 construct()
 {
@@ -663,7 +663,7 @@ construct()
 
 void
 select_socket_service::
-destroy(io_object::io_object_impl* impl)
+destroy(io_object::implementation* impl)
 {
     auto* select_impl = static_cast<select_socket_impl*>(impl);
     select_impl->close_socket();
@@ -674,7 +674,7 @@ destroy(io_object::io_object_impl* impl)
 
 std::error_code
 select_socket_service::
-open_socket(tcp_socket::socket_impl& impl)
+open_socket(tcp_socket::implementation& impl)
 {
     auto* select_impl = static_cast<select_socket_impl*>(&impl);
     select_impl->close_socket();

--- a/src/corosio/src/detail/select/sockets.cpp
+++ b/src/corosio/src/detail/select/sockets.cpp
@@ -717,16 +717,6 @@ open_socket(tcp_socket::socket_impl& impl)
 
 void
 select_socket_service::
-open(io_object::handle& h)
-{
-    auto ec = open_socket(
-        *static_cast<tcp_socket::socket_impl*>(h.get()));
-    if (ec)
-        detail::throw_system_error(ec, "open");
-}
-
-void
-select_socket_service::
 close(io_object::handle& h)
 {
     static_cast<select_socket_impl*>(h.get())->close_socket();

--- a/src/corosio/src/detail/select/sockets.cpp
+++ b/src/corosio/src/detail/select/sockets.cpp
@@ -16,6 +16,8 @@
 #include "src/detail/dispatch_coro.hpp"
 #include "src/detail/make_err.hpp"
 
+#include <boost/corosio/detail/except.hpp>
+
 #include <boost/capy/buffers.hpp>
 
 #include <errno.h>
@@ -109,14 +111,6 @@ select_socket_impl::
 select_socket_impl(select_socket_service& svc) noexcept
     : svc_(svc)
 {
-}
-
-void
-select_socket_impl::
-release()
-{
-    close_socket();
-    svc_.destroy_impl(*this);
 }
 
 std::coroutine_handle<>
@@ -651,9 +645,9 @@ shutdown()
     // shutdown) keeps every impl alive until all ops have been drained.
 }
 
-tcp_socket::socket_impl&
+io_object::io_object_impl*
 select_socket_service::
-create_impl()
+construct()
 {
     auto impl = std::make_shared<select_socket_impl>(*this);
     auto* raw = impl.get();
@@ -664,14 +658,15 @@ create_impl()
         state_->socket_ptrs_.emplace(raw, std::move(impl));
     }
 
-    return *raw;
+    return raw;
 }
 
 void
 select_socket_service::
-destroy_impl(tcp_socket::socket_impl& impl)
+destroy(io_object::io_object_impl* impl)
 {
-    auto* select_impl = static_cast<select_socket_impl*>(&impl);
+    auto* select_impl = static_cast<select_socket_impl*>(impl);
+    select_impl->close_socket();
     std::lock_guard lock(state_->mutex_);
     state_->socket_list_.remove(select_impl);
     state_->socket_ptrs_.erase(select_impl);
@@ -718,6 +713,23 @@ open_socket(tcp_socket::socket_impl& impl)
 
     select_impl->fd_ = fd;
     return {};
+}
+
+void
+select_socket_service::
+open(io_object::handle& h)
+{
+    auto ec = open_socket(
+        *static_cast<tcp_socket::socket_impl*>(h.get()));
+    if (ec)
+        detail::throw_system_error(ec, "open");
+}
+
+void
+select_socket_service::
+close(io_object::handle& h)
+{
+    static_cast<select_socket_impl*>(h.get())->close_socket();
 }
 
 void

--- a/src/corosio/src/detail/select/sockets.hpp
+++ b/src/corosio/src/detail/select/sockets.hpp
@@ -182,7 +182,6 @@ public:
 
     io_object::io_object_impl* construct() override;
     void destroy(io_object::io_object_impl*) override;
-    void open(io_object::handle&) override;
     void close(io_object::handle&) override;
     std::error_code open_socket(tcp_socket::socket_impl& impl) override;
 

--- a/src/corosio/src/detail/select/sockets.hpp
+++ b/src/corosio/src/detail/select/sockets.hpp
@@ -60,7 +60,7 @@
 
     Service Ownership
     -----------------
-    select_socket_service owns all socket impls. destroy_impl() removes the
+    select_socket_service owns all socket impls. destroy() removes the
     shared_ptr from the map, but the impl may survive if ops still hold
     impl_ptr refs. shutdown() closes all sockets and clears the map; any
     in-flight ops will complete and release their refs.
@@ -81,8 +81,6 @@ class select_socket_impl
 
 public:
     explicit select_socket_impl(select_socket_service& svc) noexcept;
-
-    void release() override;
 
     std::coroutine_handle<> connect(
         std::coroutine_handle<>,
@@ -182,8 +180,10 @@ public:
 
     void shutdown() override;
 
-    tcp_socket::socket_impl& create_impl() override;
-    void destroy_impl(tcp_socket::socket_impl& impl) override;
+    io_object::io_object_impl* construct() override;
+    void destroy(io_object::io_object_impl*) override;
+    void open(io_object::handle&) override;
+    void close(io_object::handle&) override;
     std::error_code open_socket(tcp_socket::socket_impl& impl) override;
 
     select_scheduler& scheduler() const noexcept { return state_->sched_; }

--- a/src/corosio/src/detail/select/sockets.hpp
+++ b/src/corosio/src/detail/select/sockets.hpp
@@ -73,7 +73,7 @@ class select_socket_impl;
 
 /// Socket implementation for select backend.
 class select_socket_impl
-    : public tcp_socket::socket_impl
+    : public tcp_socket::implementation
     , public std::enable_shared_from_this<select_socket_impl>
     , public intrusive_list<select_socket_impl>::node
 {
@@ -180,10 +180,10 @@ public:
 
     void shutdown() override;
 
-    io_object::io_object_impl* construct() override;
-    void destroy(io_object::io_object_impl*) override;
+    io_object::implementation* construct() override;
+    void destroy(io_object::implementation*) override;
     void close(io_object::handle&) override;
-    std::error_code open_socket(tcp_socket::socket_impl& impl) override;
+    std::error_code open_socket(tcp_socket::implementation& impl) override;
 
     select_scheduler& scheduler() const noexcept { return state_->sched_; }
     void post(select_op* op);

--- a/src/corosio/src/detail/socket_service.hpp
+++ b/src/corosio/src/detail/socket_service.hpp
@@ -61,23 +61,6 @@ class socket_service
 public:
     using key_type = socket_service;
 
-    void open(io_object::handle&) override {}
-    void close(io_object::handle&) override {}
-    void destroy(io_object::implementation*) override {}
-    io_object::implementation* construct() override { return nullptr; }
-
-    /** Create a new socket implementation.
-
-        @return Reference to the newly created socket implementation.
-    */
-    virtual tcp_socket::socket_impl& create_impl() = 0;
-
-    /** Destroy a socket implementation.
-
-        @param impl The socket implementation to destroy.
-    */
-    virtual void destroy_impl(tcp_socket::socket_impl& impl) = 0;
-
     /** Open a socket.
 
         Creates an IPv4 TCP socket and associates it with the platform reactor.
@@ -102,22 +85,12 @@ protected:
 
     The key_type is acceptor_service itself, which enables runtime polymorphism.
 */
-class acceptor_service : public capy::execution_context::service
+class acceptor_service
+    : public capy::execution_context::service
+    , public io_object::io_service
 {
 public:
     using key_type = acceptor_service;
-
-    /** Create a new acceptor implementation.
-
-        @return Reference to the newly created acceptor implementation.
-    */
-    virtual tcp_acceptor::acceptor_impl& create_acceptor_impl() = 0;
-
-    /** Destroy an acceptor implementation.
-
-        @param impl The acceptor implementation to destroy.
-    */
-    virtual void destroy_acceptor_impl(tcp_acceptor::acceptor_impl& impl) = 0;
 
     /** Open an acceptor.
 

--- a/src/corosio/src/detail/socket_service.hpp
+++ b/src/corosio/src/detail/socket_service.hpp
@@ -68,7 +68,7 @@ public:
         @param impl The socket implementation to open.
         @return Error code on failure, empty on success.
     */
-    virtual std::error_code open_socket(tcp_socket::socket_impl& impl) = 0;
+    virtual std::error_code open_socket(tcp_socket::implementation& impl) = 0;
 
 protected:
     socket_service() = default;
@@ -103,7 +103,7 @@ public:
         @return Error code on failure, empty on success.
     */
     virtual std::error_code open_acceptor(
-        tcp_acceptor::acceptor_impl& impl,
+        tcp_acceptor::implementation& impl,
         endpoint ep,
         int backlog) = 0;
 

--- a/src/corosio/src/detail/timer_service.cpp
+++ b/src/corosio/src/detail/timer_service.cpp
@@ -179,9 +179,6 @@ struct timer_impl
 
     explicit timer_impl(timer_service_impl& svc) noexcept;
 
-
-    void release() override;
-
     std::coroutine_handle<> wait(
         std::coroutine_handle<>,
         capy::executor_ref,
@@ -307,7 +304,7 @@ public:
 
     void destroy(io_object::io_object_impl* p) override
     {
-        static_cast<timer_impl*>(p)->release();
+        destroy_impl(static_cast<timer_impl&>(*p));
     }
 
     void destroy_impl(timer_impl& impl)
@@ -681,13 +678,6 @@ operator()()
 
     d.post(h);
     sched.on_work_finished();
-}
-
-void
-timer_impl::
-release()
-{
-    svc_->destroy_impl(*this);
 }
 
 std::coroutine_handle<>

--- a/src/corosio/src/detail/timer_service.cpp
+++ b/src/corosio/src/detail/timer_service.cpp
@@ -277,7 +277,7 @@ public:
         }
     }
 
-    timer::timer_impl* create_impl() override
+    io_object::io_object_impl* construct() override
     {
         timer_impl* impl = try_pop_tl_cache(this);
         if (impl)
@@ -303,6 +303,11 @@ public:
             impl = new timer_impl(*this);
         }
         return impl;
+    }
+
+    void destroy(io_object::io_object_impl* p) override
+    {
+        static_cast<timer_impl*>(p)->release();
     }
 
     void destroy_impl(timer_impl& impl)
@@ -809,25 +814,6 @@ struct timer_service_access
         return static_cast<scheduler_impl&>(*ctx.sched_);
     }
 };
-
-timer::timer_impl*
-timer_service_create(capy::execution_context& ctx)
-{
-    if (!ctx.target<basic_io_context>())
-        detail::throw_logic_error();
-    auto& ioctx = static_cast<basic_io_context&>(ctx);
-    auto* svc = static_cast<timer_service_impl*>(
-        timer_service_access::get_scheduler(ioctx).timer_svc_);
-    if (!svc)
-        detail::throw_logic_error();
-    return svc->create_impl();
-}
-
-void
-timer_service_destroy(timer::timer_impl& base) noexcept
-{
-    static_cast<timer_impl&>(base).release();
-}
 
 std::size_t
 timer_service_update_expiry(timer::timer_impl& base)

--- a/src/corosio/src/detail/timer_service.cpp
+++ b/src/corosio/src/detail/timer_service.cpp
@@ -30,7 +30,7 @@
     Timer Service
     =============
 
-    The public timer class holds an opaque timer_impl* and forwards
+    The public timer class holds an opaque implementation* and forwards
     all operations through extern free functions defined at the bottom
     of this file.
 
@@ -40,7 +40,7 @@
     error output, stop_token, embedded completion_op. Each concurrent
     co_await t.wait() allocates one waiter_node.
 
-    timer_impl holds per-timer state: expiry, heap index, and an
+    implementation holds per-timer state: expiry, heap index, and an
     intrusive_list of waiter_nodes. Multiple coroutines can wait on
     the same timer simultaneously.
 
@@ -67,7 +67,7 @@
        order.
 
     2. Thread-local impl cache — A single-slot per-thread cache of
-       timer_impl avoids the mutex on create/destroy for the common
+       implementation avoids the mutex on create/destroy for the common
        create-then-destroy-on-same-thread pattern. On pop, if the
        cached impl's svc_ doesn't match the current service, the
        stale impl is deleted eagerly rather than reused.
@@ -110,7 +110,7 @@
 namespace boost::corosio::detail {
 
 class timer_service_impl;
-struct timer_impl;
+struct implementation;
 struct waiter_node;
 
 void timer_service_invalidate_cache() noexcept;
@@ -147,7 +147,7 @@ struct waiter_node
     };
 
     // nullptr once removed from timer's waiter list (concurrency marker)
-    timer_impl* impl_ = nullptr;
+    implementation* impl_ = nullptr;
     timer_service_impl* svc_ = nullptr;
     std::coroutine_handle<> h_;
     capy::executor_ref d_;
@@ -164,8 +164,8 @@ struct waiter_node
     }
 };
 
-struct timer_impl
-    : timer::timer_impl
+struct implementation
+    : timer::implementation
 {
     using clock_type = std::chrono::steady_clock;
     using time_point = clock_type::time_point;
@@ -175,9 +175,9 @@ struct timer_impl
     intrusive_list<waiter_node> waiters_;
 
     // Free list linkage (reused when impl is on free_list)
-    timer_impl* next_free_ = nullptr;
+    implementation* next_free_ = nullptr;
 
-    explicit timer_impl(timer_service_impl& svc) noexcept;
+    explicit implementation(timer_service_impl& svc) noexcept;
 
     std::coroutine_handle<> wait(
         std::coroutine_handle<>,
@@ -186,8 +186,8 @@ struct timer_impl
         std::error_code*) override;
 };
 
-timer_impl* try_pop_tl_cache(timer_service_impl*) noexcept;
-bool try_push_tl_cache(timer_impl*) noexcept;
+implementation* try_pop_tl_cache(timer_service_impl*) noexcept;
+bool try_push_tl_cache(implementation*) noexcept;
 waiter_node* try_pop_waiter_tl_cache() noexcept;
 bool try_push_waiter_tl_cache(waiter_node*) noexcept;
 
@@ -202,13 +202,13 @@ private:
     struct heap_entry
     {
         time_point time_;
-        timer_impl* timer_;
+        implementation* timer_;
     };
 
     scheduler* sched_ = nullptr;
     mutable std::mutex mutex_;
     std::vector<heap_entry> heap_;
-    timer_impl* free_list_ = nullptr;
+    implementation* free_list_ = nullptr;
     waiter_node* waiter_free_list_ = nullptr;
     callback on_earliest_changed_;
     // Avoids mutex in nearest_expiry() and empty()
@@ -274,9 +274,9 @@ public:
         }
     }
 
-    io_object::io_object_impl* construct() override
+    io_object::implementation* construct() override
     {
-        timer_impl* impl = try_pop_tl_cache(this);
+        implementation* impl = try_pop_tl_cache(this);
         if (impl)
         {
             impl->svc_ = this;
@@ -297,17 +297,17 @@ public:
         }
         else
         {
-            impl = new timer_impl(*this);
+            impl = new implementation(*this);
         }
         return impl;
     }
 
-    void destroy(io_object::io_object_impl* p) override
+    void destroy(io_object::implementation* p) override
     {
-        destroy_impl(static_cast<timer_impl&>(*p));
+        destroy_impl(static_cast<implementation&>(*p));
     }
 
-    void destroy_impl(timer_impl& impl)
+    void destroy_impl(implementation& impl)
     {
         cancel_timer(impl);
 
@@ -354,7 +354,7 @@ public:
     }
 
     // Heap insertion deferred to wait() — avoids lock when timer is idle
-    std::size_t update_timer(timer_impl& impl, time_point new_time)
+    std::size_t update_timer(implementation& impl, time_point new_time)
     {
         bool in_heap =
             (impl.heap_index_ != (std::numeric_limits<std::size_t>::max)());
@@ -405,7 +405,7 @@ public:
 
     // Inserts timer into heap if needed and pushes waiter, all under
     // one lock to prevent races with cancel_waiter/process_expired
-    void insert_waiter(timer_impl& impl, waiter_node* w)
+    void insert_waiter(implementation& impl, waiter_node* w)
     {
         bool notify = false;
         {
@@ -424,7 +424,7 @@ public:
             on_earliest_changed_();
     }
 
-    std::size_t cancel_timer(timer_impl& impl)
+    std::size_t cancel_timer(implementation& impl)
     {
         if (!impl.might_have_pending_waits_)
             return 0;
@@ -487,7 +487,7 @@ public:
     }
 
     // Cancel front waiter only (FIFO), return 0 or 1
-    std::size_t cancel_one_waiter(timer_impl& impl)
+    std::size_t cancel_one_waiter(implementation& impl)
     {
         if (!impl.might_have_pending_waits_)
             return 0;
@@ -535,7 +535,7 @@ public:
 
             while (!heap_.empty() && heap_[0].time_ <= now)
             {
-                timer_impl* t = heap_[0].timer_;
+                implementation* t = heap_[0].timer_;
                 remove_timer_impl(*t);
                 while (auto* w = t->waiters_.pop_front())
                 {
@@ -568,7 +568,7 @@ private:
         cached_nearest_ns_.store(ns, std::memory_order_release);
     }
 
-    void remove_timer_impl(timer_impl& impl)
+    void remove_timer_impl(implementation& impl)
     {
         std::size_t index = impl.heap_index_;
         if (index >= heap_.size())
@@ -634,8 +634,8 @@ private:
     }
 };
 
-timer_impl::
-timer_impl(timer_service_impl& svc) noexcept
+implementation::
+implementation(timer_service_impl& svc) noexcept
     : svc_(&svc)
 {
 }
@@ -681,7 +681,7 @@ operator()()
 }
 
 std::coroutine_handle<>
-timer_impl::
+implementation::
 wait(
     std::coroutine_handle<> h,
     capy::executor_ref d,
@@ -735,10 +735,10 @@ wait(
 // All caches are cleared by timer_service_invalidate_cache()
 // during shutdown.
 
-thread_local_ptr<timer_impl> tl_cached_impl;
+thread_local_ptr<implementation> tl_cached_impl;
 thread_local_ptr<waiter_node> tl_cached_waiter;
 
-timer_impl*
+implementation*
 try_pop_tl_cache(timer_service_impl* svc) noexcept
 {
     auto* impl = tl_cached_impl.get();
@@ -754,7 +754,7 @@ try_pop_tl_cache(timer_service_impl* svc) noexcept
 }
 
 bool
-try_push_tl_cache(timer_impl* impl) noexcept
+try_push_tl_cache(implementation* impl) noexcept
 {
     if (!tl_cached_impl.get())
     {
@@ -806,23 +806,23 @@ struct timer_service_access
 };
 
 std::size_t
-timer_service_update_expiry(timer::timer_impl& base)
+timer_service_update_expiry(timer::implementation& base)
 {
-    auto& impl = static_cast<timer_impl&>(base);
+    auto& impl = static_cast<implementation&>(base);
     return impl.svc_->update_timer(impl, impl.expiry_);
 }
 
 std::size_t
-timer_service_cancel(timer::timer_impl& base) noexcept
+timer_service_cancel(timer::implementation& base) noexcept
 {
-    auto& impl = static_cast<timer_impl&>(base);
+    auto& impl = static_cast<implementation&>(base);
     return impl.svc_->cancel_timer(impl);
 }
 
 std::size_t
-timer_service_cancel_one(timer::timer_impl& base) noexcept
+timer_service_cancel_one(timer::implementation& base) noexcept
 {
-    auto& impl = static_cast<timer_impl&>(base);
+    auto& impl = static_cast<implementation&>(base);
     return impl.svc_->cancel_one_waiter(impl);
 }
 

--- a/src/corosio/src/detail/timer_service.hpp
+++ b/src/corosio/src/detail/timer_service.hpp
@@ -43,10 +43,6 @@ public:
         void operator()() const { if (fn_) fn_(ctx_); }
     };
 
-    // io_service no-ops for timers (no kernel resource to open/close)
-    void open(io_object::handle&) override {}
-    void close(io_object::handle&) override {}
-
     // Query methods for scheduler
     virtual bool empty() const noexcept = 0;
     virtual time_point nearest_expiry() const noexcept = 0;

--- a/src/corosio/src/detail/timer_service.hpp
+++ b/src/corosio/src/detail/timer_service.hpp
@@ -20,7 +20,9 @@ namespace boost::corosio::detail {
 
 struct scheduler;
 
-class timer_service : public capy::execution_context::service
+class timer_service
+    : public capy::execution_context::service
+    , public io_object::io_service
 {
 public:
     using clock_type = std::chrono::steady_clock;
@@ -41,8 +43,9 @@ public:
         void operator()() const { if (fn_) fn_(ctx_); }
     };
 
-    // Create timer implementation
-    virtual timer::timer_impl* create_impl() = 0;
+    // io_service no-ops for timers (no kernel resource to open/close)
+    void open(io_object::handle&) override {}
+    void close(io_object::handle&) override {}
 
     // Query methods for scheduler
     virtual bool empty() const noexcept = 0;

--- a/src/corosio/src/epoll_context.cpp
+++ b/src/corosio/src/epoll_context.cpp
@@ -32,9 +32,6 @@ epoll_context(
     sched_ = &make_service<detail::epoll_scheduler>(
         static_cast<int>(concurrency_hint));
 
-    // Install socket/acceptor services.
-    // These use socket_service and acceptor_service as key_type,
-    // enabling runtime polymorphism.
     make_service<detail::epoll_socket_service>();
     make_service<detail::epoll_acceptor_service>();
 }

--- a/src/corosio/src/iocp_context.cpp
+++ b/src/corosio/src/iocp_context.cpp
@@ -12,6 +12,8 @@
 #if BOOST_COROSIO_HAS_IOCP
 
 #include "src/detail/iocp/scheduler.hpp"
+#include "src/detail/iocp/sockets.hpp"
+#include "src/detail/iocp/signals.hpp"
 
 #include <thread>
 
@@ -29,6 +31,10 @@ iocp_context(
 {
     sched_ = &make_service<detail::win_scheduler>(
         static_cast<int>(concurrency_hint));
+
+    auto& sockets = make_service<detail::win_sockets>();
+    make_service<detail::win_acceptor_service>(sockets);
+    make_service<detail::win_signals>();
 }
 
 iocp_context::

--- a/src/corosio/src/kqueue_context.cpp
+++ b/src/corosio/src/kqueue_context.cpp
@@ -44,9 +44,6 @@ kqueue_context(
     sched_ = &make_service<detail::kqueue_scheduler>(
         static_cast<int>(concurrency_hint));
 
-    // Install socket/acceptor services.
-    // These use socket_service and acceptor_service as key_type,
-    // enabling runtime polymorphism.
     make_service<detail::kqueue_socket_service>();
     make_service<detail::kqueue_acceptor_service>();
 }

--- a/src/corosio/src/resolver.cpp
+++ b/src/corosio/src/resolver.cpp
@@ -47,34 +47,20 @@ using resolver_service = detail::posix_resolver_service;
 } // namespace
 
 resolver::
-~resolver()
-{
-    if (impl_)
-        impl_->release();
-}
+~resolver() = default;
 
 resolver::
 resolver(
     capy::execution_context& ctx)
-    : io_object(ctx)
+    : io_object(create_handle<resolver_service>(ctx))
 {
-    auto* svc = ctx_->find_service<resolver_service>();
-    if (!svc)
-    {
-        // Resolver service not yet created - this happens if io_context
-        // hasn't been constructed yet, or if the scheduler didn't
-        // initialize the resolver service
-        throw std::runtime_error("resolver_service not found");
-    }
-    auto& impl = svc->create_impl();
-    impl_ = &impl;
 }
 
 void
 resolver::
 cancel()
 {
-    if (impl_)
+    if (h_)
         get().cancel();
 }
 

--- a/src/corosio/src/select_context.cpp
+++ b/src/corosio/src/select_context.cpp
@@ -32,9 +32,6 @@ select_context(
     sched_ = &make_service<detail::select_scheduler>(
         static_cast<int>(concurrency_hint));
 
-    // Install socket/acceptor services.
-    // These use socket_service and acceptor_service as key_type,
-    // enabling runtime polymorphism.
     make_service<detail::select_socket_service>();
     make_service<detail::select_acceptor_service>();
 }

--- a/src/corosio/src/tcp_acceptor.cpp
+++ b/src/corosio/src/tcp_acceptor.cpp
@@ -13,7 +13,6 @@
 #if BOOST_COROSIO_HAS_IOCP
 #include "src/detail/iocp/sockets.hpp"
 #else
-// POSIX backends use the abstract acceptor_service interface
 #include "src/detail/socket_service.hpp"
 #endif
 
@@ -30,7 +29,11 @@ tcp_acceptor::
 tcp_acceptor::
 tcp_acceptor(
     capy::execution_context& ctx)
-    : io_object(ctx)
+#if BOOST_COROSIO_HAS_IOCP
+    : io_object(create_handle<detail::win_acceptor_service>(ctx))
+#else
+    : io_object(create_handle<detail::acceptor_service>(ctx))
+#endif
 {
 }
 
@@ -38,70 +41,41 @@ std::error_code
 tcp_acceptor::
 listen(endpoint ep, int backlog)
 {
-    if (impl_)
+    if (is_open())
         close();
 
-    std::error_code ec;
-
 #if BOOST_COROSIO_HAS_IOCP
-    auto& svc = ctx_->use_service<detail::win_sockets>();
-    auto& wrapper = svc.create_acceptor_impl();
-    impl_ = &wrapper;
-    ec = svc.open_acceptor(*wrapper.get_internal(), ep, backlog);
+    auto& svc = static_cast<detail::win_acceptor_service&>(h_.service());
 #else
-    // POSIX backends use abstract acceptor_service for runtime polymorphism.
-    // The concrete service (epoll_sockets or select_sockets) must be installed
-    // by the context constructor before any acceptor operations.
-    auto* svc = ctx_->find_service<detail::acceptor_service>();
-    if (!svc)
-    {
-        // Should not happen with properly constructed io_context
-        return make_error_code(std::errc::operation_not_supported);
-    }
-    auto& wrapper = svc->create_acceptor_impl();
-    impl_ = &wrapper;
-    ec = svc->open_acceptor(wrapper, ep, backlog);
+    auto& svc = static_cast<detail::acceptor_service&>(h_.service());
 #endif
-    // Both branches above define 'wrapper' as a reference to the impl
-    if (ec)
-    {
-        wrapper.release();
-        impl_ = nullptr;
-    }
-    return ec;
+    return svc.open_acceptor(
+        *static_cast<tcp_acceptor::acceptor_impl*>(h_.get()), ep, backlog);
 }
 
 void
 tcp_acceptor::
 close()
 {
-    if (!impl_)
+    if (!is_open())
         return;
-
-    // acceptor_impl has virtual release() method
-    impl_->release();
-    impl_ = nullptr;
+    h_.service().close(h_);
 }
 
 void
 tcp_acceptor::
 cancel()
 {
-    if (!impl_)
+    if (!is_open())
         return;
-#if BOOST_COROSIO_HAS_IOCP
-    static_cast<detail::win_acceptor_impl*>(impl_)->get_internal()->cancel();
-#else
-    // acceptor_impl has virtual cancel() method
     get().cancel();
-#endif
 }
 
 endpoint
 tcp_acceptor::
 local_endpoint() const noexcept
 {
-    if (!impl_)
+    if (!is_open())
         return endpoint{};
     return get().local_endpoint();
 }

--- a/src/corosio/src/tcp_acceptor.cpp
+++ b/src/corosio/src/tcp_acceptor.cpp
@@ -50,7 +50,7 @@ listen(endpoint ep, int backlog)
     auto& svc = static_cast<detail::acceptor_service&>(h_.service());
 #endif
     return svc.open_acceptor(
-        *static_cast<tcp_acceptor::acceptor_impl*>(h_.get()), ep, backlog);
+        *static_cast<tcp_acceptor::implementation*>(h_.get()), ep, backlog);
 }
 
 void

--- a/src/corosio/src/tcp_socket.cpp
+++ b/src/corosio/src/tcp_socket.cpp
@@ -44,13 +44,13 @@ open()
         return;
 #if BOOST_COROSIO_HAS_IOCP
     auto& svc = static_cast<detail::win_sockets&>(h_.service());
-    auto& wrapper = static_cast<tcp_socket::socket_impl&>(*h_.get());
+    auto& wrapper = static_cast<tcp_socket::implementation&>(*h_.get());
     std::error_code ec = svc.open_socket(
         *static_cast<detail::win_socket_impl&>(wrapper).get_internal());
 #else
     auto& svc = static_cast<detail::socket_service&>(h_.service());
     std::error_code ec = svc.open_socket(
-        static_cast<tcp_socket::socket_impl&>(*h_.get()));
+        static_cast<tcp_socket::implementation&>(*h_.get()));
 #endif
     if (ec)
         detail::throw_system_error(ec, "tcp_socket::open");

--- a/src/corosio/src/tcp_socket.cpp
+++ b/src/corosio/src/tcp_socket.cpp
@@ -14,7 +14,6 @@
 #if BOOST_COROSIO_HAS_IOCP
 #include "src/detail/iocp/sockets.hpp"
 #else
-// POSIX backends use the abstract socket_service interface
 #include "src/detail/socket_service.hpp"
 #endif
 
@@ -29,7 +28,11 @@ tcp_socket::
 tcp_socket::
 tcp_socket(
     capy::execution_context& ctx)
-    : io_stream(ctx)
+#if BOOST_COROSIO_HAS_IOCP
+    : io_stream(create_handle<detail::win_sockets>(ctx))
+#else
+    : io_stream(create_handle<detail::socket_service>(ctx))
+#endif
 {
 }
 
@@ -37,64 +40,34 @@ void
 tcp_socket::
 open()
 {
-    if (impl_)
+    if (is_open())
         return;
-
-#if BOOST_COROSIO_HAS_IOCP
-    auto& svc = ctx_->use_service<detail::win_sockets>();
-    auto& wrapper = svc.create_impl();
-    impl_ = &wrapper;
-    std::error_code ec = svc.open_socket(*wrapper.get_internal());
-#else
-    // POSIX backends use abstract socket_service for runtime polymorphism.
-    // The concrete service (epoll_sockets or select_sockets) must be installed
-    // by the context constructor before any socket operations.
-    auto* svc = ctx_->find_service<detail::socket_service>();
-    if (!svc)
-        detail::throw_logic_error("tcp_socket::open: no socket service installed");
-    auto& wrapper = svc->create_impl();
-    impl_ = &wrapper;
-    std::error_code ec = svc->open_socket(wrapper);
-#endif
-    if (ec)
-    {
-        wrapper.release();
-        impl_ = nullptr;
-        detail::throw_system_error(ec, "tcp_socket::open");
-    }
+    h_.service().open(h_);
 }
 
 void
 tcp_socket::
 close()
 {
-    if (!impl_)
+    if (!is_open())
         return;
-
-    // socket_impl has virtual release() method
-    impl_->release();
-    impl_ = nullptr;
+    h_.service().close(h_);
 }
 
 void
 tcp_socket::
 cancel()
 {
-    if (!impl_)
+    if (!is_open())
         return;
-#if BOOST_COROSIO_HAS_IOCP
-    static_cast<detail::win_socket_impl*>(impl_)->get_internal()->cancel();
-#else
-    // socket_impl has virtual cancel() method
     get().cancel();
-#endif
 }
 
 void
 tcp_socket::
 shutdown(shutdown_type what)
 {
-    if (impl_)
+    if (is_open())
         get().shutdown(what);
 }
 
@@ -102,7 +75,7 @@ native_handle_type
 tcp_socket::
 native_handle() const noexcept
 {
-    if (!impl_)
+    if (!is_open())
     {
 #if BOOST_COROSIO_HAS_IOCP
         return static_cast<native_handle_type>(~0ull);  // INVALID_SOCKET
@@ -113,15 +86,11 @@ native_handle() const noexcept
     return get().native_handle();
 }
 
-//------------------------------------------------------------------------------
-// Socket Options
-//------------------------------------------------------------------------------
-
 void
 tcp_socket::
 set_no_delay(bool value)
 {
-    if (!impl_)
+    if (!is_open())
         detail::throw_logic_error("set_no_delay: socket not open");
     std::error_code ec = get().set_no_delay(value);
     if (ec)
@@ -132,7 +101,7 @@ bool
 tcp_socket::
 no_delay() const
 {
-    if (!impl_)
+    if (!is_open())
         detail::throw_logic_error("no_delay: socket not open");
     std::error_code ec;
     bool result = get().no_delay(ec);
@@ -145,7 +114,7 @@ void
 tcp_socket::
 set_keep_alive(bool value)
 {
-    if (!impl_)
+    if (!is_open())
         detail::throw_logic_error("set_keep_alive: socket not open");
     std::error_code ec = get().set_keep_alive(value);
     if (ec)
@@ -156,7 +125,7 @@ bool
 tcp_socket::
 keep_alive() const
 {
-    if (!impl_)
+    if (!is_open())
         detail::throw_logic_error("keep_alive: socket not open");
     std::error_code ec;
     bool result = get().keep_alive(ec);
@@ -169,7 +138,7 @@ void
 tcp_socket::
 set_receive_buffer_size(int size)
 {
-    if (!impl_)
+    if (!is_open())
         detail::throw_logic_error("set_receive_buffer_size: socket not open");
     std::error_code ec = get().set_receive_buffer_size(size);
     if (ec)
@@ -180,7 +149,7 @@ int
 tcp_socket::
 receive_buffer_size() const
 {
-    if (!impl_)
+    if (!is_open())
         detail::throw_logic_error("receive_buffer_size: socket not open");
     std::error_code ec;
     int result = get().receive_buffer_size(ec);
@@ -193,7 +162,7 @@ void
 tcp_socket::
 set_send_buffer_size(int size)
 {
-    if (!impl_)
+    if (!is_open())
         detail::throw_logic_error("set_send_buffer_size: socket not open");
     std::error_code ec = get().set_send_buffer_size(size);
     if (ec)
@@ -204,7 +173,7 @@ int
 tcp_socket::
 send_buffer_size() const
 {
-    if (!impl_)
+    if (!is_open())
         detail::throw_logic_error("send_buffer_size: socket not open");
     std::error_code ec;
     int result = get().send_buffer_size(ec);
@@ -217,7 +186,7 @@ void
 tcp_socket::
 set_linger(bool enabled, int timeout)
 {
-    if (!impl_)
+    if (!is_open())
         detail::throw_logic_error("set_linger: socket not open");
     std::error_code ec = get().set_linger(enabled, timeout);
     if (ec)
@@ -228,7 +197,7 @@ tcp_socket::linger_options
 tcp_socket::
 linger() const
 {
-    if (!impl_)
+    if (!is_open())
         detail::throw_logic_error("linger: socket not open");
     std::error_code ec;
     linger_options result = get().linger(ec);
@@ -241,7 +210,7 @@ endpoint
 tcp_socket::
 local_endpoint() const noexcept
 {
-    if (!impl_)
+    if (!is_open())
         return endpoint{};
     return get().local_endpoint();
 }
@@ -250,7 +219,7 @@ endpoint
 tcp_socket::
 remote_endpoint() const noexcept
 {
-    if (!impl_)
+    if (!is_open())
         return endpoint{};
     return get().remote_endpoint();
 }

--- a/src/corosio/src/tcp_socket.cpp
+++ b/src/corosio/src/tcp_socket.cpp
@@ -42,7 +42,18 @@ open()
 {
     if (is_open())
         return;
-    h_.service().open(h_);
+#if BOOST_COROSIO_HAS_IOCP
+    auto& svc = static_cast<detail::win_sockets&>(h_.service());
+    auto& wrapper = static_cast<tcp_socket::socket_impl&>(*h_.get());
+    std::error_code ec = svc.open_socket(
+        *static_cast<detail::win_socket_impl&>(wrapper).get_internal());
+#else
+    auto& svc = static_cast<detail::socket_service&>(h_.service());
+    std::error_code ec = svc.open_socket(
+        static_cast<tcp_socket::socket_impl&>(*h_.get()));
+#endif
+    if (ec)
+        detail::throw_system_error(ec, "tcp_socket::open");
 }
 
 void

--- a/src/corosio/src/test/socket_pair.cpp
+++ b/src/corosio/src/test/socket_pair.cpp
@@ -11,7 +11,6 @@
 #include <boost/corosio/tcp_acceptor.hpp>
 #include <system_error>
 #include <boost/corosio/basic_io_context.hpp>
-#include <boost/corosio/detail/platform.hpp>
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/task.hpp>
 

--- a/src/corosio/src/timer.cpp
+++ b/src/corosio/src/timer.cpp
@@ -11,14 +11,13 @@
 #include <boost/corosio/timer.hpp>
 
 #include <boost/corosio/detail/except.hpp>
+#include "src/detail/timer_service.hpp"
 
 namespace boost::corosio {
 
 namespace detail {
 
 // Defined in timer_service.cpp
-extern timer::timer_impl* timer_service_create(capy::execution_context&);
-extern void timer_service_destroy(timer::timer_impl&) noexcept;
 extern std::size_t timer_service_update_expiry(timer::timer_impl&);
 extern std::size_t timer_service_cancel(timer::timer_impl&) noexcept;
 extern std::size_t timer_service_cancel_one(timer::timer_impl&) noexcept;
@@ -26,17 +25,12 @@ extern std::size_t timer_service_cancel_one(timer::timer_impl&) noexcept;
 } // namespace detail
 
 timer::
-~timer()
-{
-    if (impl_)
-        detail::timer_service_destroy(get());
-}
+~timer() = default;
 
 timer::
 timer(capy::execution_context& ctx)
-    : io_object(ctx)
+    : io_object(create_handle<detail::timer_service>(ctx))
 {
-    impl_ = detail::timer_service_create(ctx);
 }
 
 timer::
@@ -48,10 +42,8 @@ timer(capy::execution_context& ctx, time_point t)
 
 timer::
 timer(timer&& other) noexcept
-    : io_object(other.context())
+    : io_object(std::move(other))
 {
-    impl_ = other.impl_;
-    other.impl_ = nullptr;
 }
 
 timer&
@@ -60,13 +52,10 @@ operator=(timer&& other)
 {
     if (this != &other)
     {
-        if (ctx_ != other.ctx_)
+        if (&context() != &other.context())
             detail::throw_logic_error(
                 "cannot move timer across execution contexts");
-        if (impl_)
-            detail::timer_service_destroy(get());
-        impl_ = other.impl_;
-        other.impl_ = nullptr;
+        h_ = std::move(other.h_);
     }
     return *this;
 }

--- a/src/corosio/src/timer.cpp
+++ b/src/corosio/src/timer.cpp
@@ -18,9 +18,9 @@ namespace boost::corosio {
 namespace detail {
 
 // Defined in timer_service.cpp
-extern std::size_t timer_service_update_expiry(timer::timer_impl&);
-extern std::size_t timer_service_cancel(timer::timer_impl&) noexcept;
-extern std::size_t timer_service_cancel_one(timer::timer_impl&) noexcept;
+extern std::size_t timer_service_update_expiry(timer::implementation&);
+extern std::size_t timer_service_cancel(timer::implementation&) noexcept;
+extern std::size_t timer_service_cancel_one(timer::implementation&) noexcept;
 
 } // namespace detail
 

--- a/test/unit/cross_ssl_stream.cpp
+++ b/test/unit/cross_ssl_stream.cpp
@@ -75,13 +75,13 @@ struct cross_ssl_stream_test
     static auto
     make_openssl( io_stream& s, tls_context ctx )
     {
-        return openssl_stream( s, ctx );
+        return openssl_stream( &s, ctx );
     }
 
     static auto
     make_wolfssl( io_stream& s, tls_context ctx )
     {
-        return wolfssl_stream( s, ctx );
+        return wolfssl_stream( &s, ctx );
     }
 
     void

--- a/test/unit/tls_stream_stress.cpp
+++ b/test/unit/tls_stream_stress.cpp
@@ -18,8 +18,6 @@
 //
 // Tests run for a configurable duration (default 1 second).
 
-#include <boost/corosio/detail/platform.hpp>
-
 #include <boost/corosio/io_context.hpp>
 #include <boost/corosio/tls_stream.hpp>
 #include <boost/corosio/timer.hpp>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * I/O objects are now move-only and expose a handle-based ownership model for safer lifetime management across platforms.

* **Refactor**
  * Service lifecycle rewritten from per-object release to construct/destroy/close semantics with unified implementation types.
  * Public APIs simplified: implementations and services use consistent handle-based access and clearer open/close semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->