### PR TITLE
Fix kqueue close: clear SO_LINGER instead of calling shutdown

### DIFF
--- a/include/boost/corosio/native/detail/kqueue/kqueue_acceptor_service.hpp
+++ b/include/boost/corosio/native/detail/kqueue/kqueue_acceptor_service.hpp
@@ -443,8 +443,6 @@ kqueue_acceptor::close_socket() noexcept
 
     if (fd_ >= 0)
     {
-        if (desc_state_.registered_events != 0)
-            svc_.scheduler().deregister_descriptor(fd_);
         ::close(fd_);
         fd_ = -1;
     }

--- a/include/boost/corosio/native/detail/kqueue/kqueue_socket.hpp
+++ b/include/boost/corosio/native/detail/kqueue/kqueue_socket.hpp
@@ -130,6 +130,7 @@ public:
 private:
     kqueue_socket_service& svc_;
     int fd_ = -1;
+    bool user_set_linger_ = false;
     endpoint local_endpoint_;
     endpoint remote_endpoint_;
 };

--- a/include/boost/corosio/native/detail/kqueue/kqueue_socket_service.hpp
+++ b/include/boost/corosio/native/detail/kqueue/kqueue_socket_service.hpp
@@ -691,6 +691,7 @@ kqueue_socket::set_linger(bool enabled, int timeout) noexcept
     lg.l_linger = timeout;
     if (::setsockopt(fd_, SOL_SOCKET, SO_LINGER, &lg, sizeof(lg)) != 0)
         return make_err(errno);
+    user_set_linger_ = true;
     return {};
 }
 
@@ -848,18 +849,13 @@ kqueue_socket::close_socket() noexcept
 
     if (fd_ >= 0)
     {
-        // Send FIN so the peer gets a reliable kqueue notification
-        // before we deregister and close the descriptor.
-        ::shutdown(fd_, SHUT_WR);
-
-        if (desc_state_.registered_events != 0)
-            svc_.scheduler().deregister_descriptor(fd_);
         ::close(fd_);
         fd_ = -1;
     }
 
     desc_state_.fd                = -1;
     desc_state_.registered_events = 0;
+    user_set_linger_              = false;
 
     local_endpoint_  = endpoint{};
     remote_endpoint_ = endpoint{};
@@ -881,7 +877,16 @@ kqueue_socket_service::shutdown()
     std::lock_guard lock(state_->mutex_);
 
     while (auto* impl = state_->socket_list_.pop_front())
+    {
+        if (impl->user_set_linger_ && impl->fd_ >= 0)
+        {
+            struct ::linger lg;
+            lg.l_onoff  = 0;
+            lg.l_linger = 0;
+            ::setsockopt(impl->fd_, SOL_SOCKET, SO_LINGER, &lg, sizeof(lg));
+        }
         impl->close_socket();
+    }
 
     // Don't clear socket_ptrs_ here. The scheduler shuts down after us and
     // drains completed_ops_, calling destroy() on each queued op. If we
@@ -911,6 +916,18 @@ inline void
 kqueue_socket_service::destroy(io_object::implementation* impl)
 {
     auto* kq_impl = static_cast<kqueue_socket*>(impl);
+
+    // Match asio: if the user set SO_LINGER, clear it before close so
+    // the destructor doesn't block and close() sends FIN instead of RST.
+    // RST doesn't reliably trigger EV_EOF on macOS kqueue.
+    if (kq_impl->user_set_linger_ && kq_impl->fd_ >= 0)
+    {
+        struct ::linger lg;
+        lg.l_onoff  = 0;
+        lg.l_linger = 0;
+        ::setsockopt(kq_impl->fd_, SOL_SOCKET, SO_LINGER, &lg, sizeof(lg));
+    }
+
     kq_impl->close_socket();
     std::lock_guard lock(state_->mutex_);
     state_->socket_list_.remove(kq_impl);

--- a/perf/bench/corosio/socket_throughput_bench.cpp
+++ b/perf/bench/corosio/socket_throughput_bench.cpp
@@ -87,6 +87,7 @@ bench_throughput(std::size_t chunk_size, double duration_s)
                 break;
             total_written += n;
         }
+        writer.shutdown( corosio::tcp_socket::shutdown_send );
         writer.close();
     };
 
@@ -163,7 +164,7 @@ bench_bidirectional_throughput(std::size_t chunk_size, double duration_s)
                 break;
             written1 += n;
         }
-        sock1.cancel();
+        sock1.shutdown( corosio::tcp_socket::shutdown_send );
     };
 
     auto read1_task = [&]() -> capy::task<> {
@@ -187,7 +188,7 @@ bench_bidirectional_throughput(std::size_t chunk_size, double duration_s)
                 break;
             written2 += n;
         }
-        sock2.cancel();
+        sock2.shutdown( corosio::tcp_socket::shutdown_send );
     };
 
     auto read2_task = [&]() -> capy::task<> {


### PR DESCRIPTION
On macOS, close() with SO_LINGER {1,0} sends RST instead of FIN. RST does not reliably trigger EV_EOF on the peer's kqueue, causing pending reads to hang. The previous workaround called shutdown(SHUT_WR) before close to force a FIN.

Replace this with the approach used by Asio's kqueue reactor: clear SO_LINGER before close so the kernel sends FIN naturally. Also skip the explicit EV_DELETE (deregister_descriptor) on both sockets and acceptors, relying on kqueue's automatic cleanup when the fd is closed — matching Asio's deregister_descriptor(closing=true) path.

Update socket throughput benchmark to match asio.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved socket closure and lifecycle behavior to correctly handle the linger socket option during shutdown and destruction operations. The system now properly tracks and manages user-configured linger settings, ensuring appropriate cleanup of socket states and better resource management across all connection operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->