### PR TITLE
Document move preconditions and awaitable lifetime requirements acros…

### DIFF
--- a/include/boost/corosio/io/io_read_stream.hpp
+++ b/include/boost/corosio/io/io_read_stream.hpp
@@ -112,6 +112,10 @@ public:
         read. The coroutine resumes when at least one byte is read,
         an error occurs, or the operation is cancelled.
 
+        This stream must outlive the returned awaitable. The memory
+        referenced by @p buffers must remain valid until the operation
+        completes.
+
         @param buffers The buffer sequence to read data into.
 
         @return An awaitable yielding `(error_code, std::size_t)`.

--- a/include/boost/corosio/io/io_signal_set.hpp
+++ b/include/boost/corosio/io/io_signal_set.hpp
@@ -100,6 +100,8 @@ public:
         triggered, the operation completes immediately with an error
         that compares equal to `capy::cond::canceled`.
 
+        This signal set must outlive the returned awaitable.
+
         @return An awaitable that completes with `io_result<int>`.
             Returns the signal number when a signal is delivered,
             or an error code on failure.

--- a/include/boost/corosio/io/io_timer.hpp
+++ b/include/boost/corosio/io/io_timer.hpp
@@ -141,6 +141,8 @@ public:
         compares equal to `capy::cond::canceled`; other waiters are
         unaffected.
 
+        This timer must outlive the returned awaitable.
+
         @return An awaitable that completes with `io_result<>`.
     */
     auto wait()

--- a/include/boost/corosio/io/io_write_stream.hpp
+++ b/include/boost/corosio/io/io_write_stream.hpp
@@ -112,6 +112,10 @@ public:
         write. The coroutine resumes when at least one byte is written,
         an error occurs, or the operation is cancelled.
 
+        This stream must outlive the returned awaitable. The memory
+        referenced by @p buffers must remain valid until the operation
+        completes.
+
         @param buffers The buffer sequence containing data to write.
 
         @return An awaitable yielding `(error_code, std::size_t)`.

--- a/include/boost/corosio/native/native_resolver.hpp
+++ b/include/boost/corosio/native/native_resolver.hpp
@@ -157,10 +157,22 @@ public:
     {
     }
 
-    /// Move construct.
+    /** Move construct.
+
+        @pre No awaitables returned by @p other's `resolve` methods
+            exist.
+        @pre The execution context associated with @p other must
+            outlive this resolver.
+    */
     native_resolver(native_resolver&&) noexcept = default;
 
-    /// Move assign.
+    /** Move assign.
+
+        @pre No awaitables returned by either `*this` or the source's
+            `resolve` methods exist.
+        @pre The execution context associated with the source must
+            outlive this resolver.
+    */
     native_resolver& operator=(native_resolver&&) noexcept = default;
 
     native_resolver(native_resolver const&)            = delete;
@@ -170,6 +182,8 @@ public:
 
         Calls the backend implementation directly, bypassing virtual
         dispatch. Otherwise identical to @ref resolver::resolve.
+
+        This resolver must outlive the returned awaitable.
 
         @param host The host name or address string.
         @param service The service name or port string.
@@ -183,6 +197,8 @@ public:
     }
 
     /** Asynchronously resolve a host and service with flags.
+
+        This resolver must outlive the returned awaitable.
 
         @param host The host name or address string.
         @param service The service name or port string.
@@ -202,6 +218,8 @@ public:
         dispatch. Otherwise identical to the endpoint overload of
         @ref resolver::resolve.
 
+        This resolver must outlive the returned awaitable.
+
         @param ep The endpoint to resolve.
 
         @return An awaitable yielding
@@ -213,6 +231,8 @@ public:
     }
 
     /** Asynchronously reverse-resolve an endpoint with flags.
+
+        This resolver must outlive the returned awaitable.
 
         @param ep The endpoint to resolve.
         @param flags Flags controlling resolution behavior.

--- a/include/boost/corosio/native/native_signal_set.hpp
+++ b/include/boost/corosio/native/native_signal_set.hpp
@@ -112,10 +112,25 @@ public:
     {
     }
 
-    /// Move construct.
+    /** Move construct.
+
+        @param other The signal set to move from.
+
+        @pre No awaitables returned by @p other's methods exist.
+        @pre The execution context associated with @p other must
+            outlive this signal set.
+    */
     native_signal_set(native_signal_set&&) noexcept = default;
 
-    /// Move assign.
+    /** Move assign.
+
+        @param other The signal set to move from.
+
+        @pre No awaitables returned by either `*this` or @p other's
+            methods exist.
+        @pre The execution context associated with @p other must
+            outlive this signal set.
+    */
     native_signal_set& operator=(native_signal_set&&) noexcept = default;
 
     native_signal_set(native_signal_set const&)            = delete;
@@ -127,6 +142,8 @@ public:
         dispatch. Otherwise identical to @ref signal_set::wait.
 
         @return An awaitable yielding `io_result<int>`.
+
+        This signal set must outlive the returned awaitable.
     */
     auto wait()
     {

--- a/include/boost/corosio/native/native_tcp_acceptor.hpp
+++ b/include/boost/corosio/native/native_tcp_acceptor.hpp
@@ -123,10 +123,25 @@ public:
     {
     }
 
-    /// Move construct.
+    /** Move construct.
+
+        @param other The acceptor to move from.
+
+        @pre No awaitables returned by @p other's methods exist.
+        @pre The execution context associated with @p other must
+            outlive this acceptor.
+    */
     native_tcp_acceptor(native_tcp_acceptor&&) noexcept = default;
 
-    /// Move assign.
+    /** Move assign.
+
+        @param other The acceptor to move from.
+
+        @pre No awaitables returned by either `*this` or @p other's
+            methods exist.
+        @pre The execution context associated with @p other must
+            outlive this acceptor.
+    */
     native_tcp_acceptor& operator=(native_tcp_acceptor&&) noexcept = default;
 
     native_tcp_acceptor(native_tcp_acceptor const&)            = delete;
@@ -142,6 +157,9 @@ public:
         @return An awaitable yielding `io_result<>`.
 
         @throws std::logic_error if the acceptor is not listening.
+
+        Both this acceptor and @p peer must outlive the returned
+        awaitable.
     */
     auto accept(tcp_socket& peer)
     {

--- a/include/boost/corosio/native/native_tcp_socket.hpp
+++ b/include/boost/corosio/native/native_tcp_socket.hpp
@@ -206,10 +206,29 @@ public:
     {
     }
 
-    /// Move construct.
+    /** Move construct.
+
+        @param other The socket to move from.
+
+        @pre No awaitables returned by @p other's methods exist.
+        @pre @p other is not referenced as a peer in any outstanding
+            accept awaitable.
+        @pre The execution context associated with @p other must
+            outlive this socket.
+    */
     native_tcp_socket(native_tcp_socket&&) noexcept = default;
 
-    /// Move assign.
+    /** Move assign.
+
+        @param other The socket to move from.
+
+        @pre No awaitables returned by either `*this` or @p other's
+            methods exist.
+        @pre Neither `*this` nor @p other is referenced as a peer in
+            any outstanding accept awaitable.
+        @pre The execution context associated with @p other must
+            outlive this socket.
+    */
     native_tcp_socket& operator=(native_tcp_socket&&) noexcept = default;
 
     native_tcp_socket(native_tcp_socket const&)            = delete;
@@ -223,6 +242,10 @@ public:
         @param buffers The buffer sequence to read into.
 
         @return An awaitable yielding `(error_code, std::size_t)`.
+
+        This socket must outlive the returned awaitable. The memory
+        referenced by @p buffers must remain valid until the operation
+        completes.
     */
     template<capy::MutableBufferSequence MB>
     auto read_some(MB const& buffers)
@@ -238,6 +261,10 @@ public:
         @param buffers The buffer sequence to write from.
 
         @return An awaitable yielding `(error_code, std::size_t)`.
+
+        This socket must outlive the returned awaitable. The memory
+        referenced by @p buffers must remain valid until the operation
+        completes.
     */
     template<capy::ConstBufferSequence CB>
     auto write_some(CB const& buffers)
@@ -255,6 +282,8 @@ public:
         @return An awaitable yielding `io_result<>`.
 
         @throws std::logic_error if the socket is not open.
+
+        This socket must outlive the returned awaitable.
     */
     auto connect(endpoint ep)
     {

--- a/include/boost/corosio/native/native_timer.hpp
+++ b/include/boost/corosio/native/native_timer.hpp
@@ -116,10 +116,25 @@ public:
     {
     }
 
-    /// Move construct.
+    /** Move construct.
+
+        @param other The timer to move from.
+
+        @pre No awaitables returned by @p other's methods exist.
+        @pre The execution context associated with @p other must
+            outlive this timer.
+    */
     native_timer(native_timer&&) noexcept = default;
 
-    /// Move assign.
+    /** Move assign.
+
+        @param other The timer to move from.
+
+        @pre No awaitables returned by either `*this` or @p other's
+            methods exist.
+        @pre The execution context associated with @p other must
+            outlive this timer.
+    */
     native_timer& operator=(native_timer&&) noexcept = default;
 
     native_timer(native_timer const&)            = delete;
@@ -131,6 +146,8 @@ public:
         dispatch. Otherwise identical to @ref timer::wait.
 
         @return An awaitable yielding `io_result<>`.
+
+        This timer must outlive the returned awaitable.
     */
     auto wait()
     {

--- a/include/boost/corosio/resolver.hpp
+++ b/include/boost/corosio/resolver.hpp
@@ -298,18 +298,31 @@ public:
 
     /** Move constructor.
 
-        Transfers ownership of the resolver resources.
+        Transfers ownership of the resolver resources. After the move,
+        @p other is in a moved-from state and may only be destroyed or
+        assigned to.
 
         @param other The resolver to move from.
+
+        @pre No awaitables returned by @p other's `resolve` methods
+            exist.
+        @pre The execution context associated with @p other must
+            outlive this resolver.
     */
     resolver(resolver&& other) noexcept : io_object(std::move(other)) {}
 
     /** Move assignment operator.
 
-        Cancels any existing operations and transfers ownership.
-        The source and destination must share the same execution context.
+        Destroys the current implementation and transfers ownership
+        from @p other. After the move, @p other is in a moved-from
+        state and may only be destroyed or assigned to.
 
         @param other The resolver to move from.
+
+        @pre No awaitables returned by either `*this` or @p other's
+            `resolve` methods exist.
+        @pre The execution context associated with @p other must
+            outlive this resolver.
 
         @return Reference to this resolver.
     */
@@ -326,6 +339,8 @@ public:
     /** Initiate an asynchronous resolve operation.
 
         Resolves the host and service names into a list of endpoints.
+
+        This resolver must outlive the returned awaitable.
 
         @param host A string identifying a location. May be a descriptive
             name or a numeric address string.
@@ -350,6 +365,8 @@ public:
 
         Resolves the host and service names into a list of endpoints.
 
+        This resolver must outlive the returned awaitable.
+
         @param host A string identifying a location.
 
         @param service A string identifying the requested service.
@@ -368,6 +385,8 @@ public:
 
         Resolves an endpoint into a hostname and service name using
         reverse DNS lookup (PTR record query).
+
+        This resolver must outlive the returned awaitable.
 
         @param ep The endpoint to resolve.
 
@@ -391,6 +410,8 @@ public:
 
         Resolves an endpoint into a hostname and service name using
         reverse DNS lookup (PTR record query).
+
+        This resolver must outlive the returned awaitable.
 
         @param ep The endpoint to resolve.
 

--- a/include/boost/corosio/signal_set.hpp
+++ b/include/boost/corosio/signal_set.hpp
@@ -204,13 +204,23 @@ public:
         Transfers ownership of the signal set resources.
 
         @param other The signal set to move from.
+
+        @pre No awaitables returned by @p other's methods exist.
+        @pre The execution context associated with @p other must
+            outlive this signal set.
     */
     signal_set(signal_set&& other) noexcept;
 
     /** Move assignment operator.
 
         Closes any existing signal set and transfers ownership.
+
         @param other The signal set to move from.
+
+        @pre No awaitables returned by either `*this` or @p other's
+            methods exist.
+        @pre The execution context associated with @p other must
+            outlive this signal set.
 
         @return Reference to this signal set.
     */

--- a/include/boost/corosio/tcp_acceptor.hpp
+++ b/include/boost/corosio/tcp_acceptor.hpp
@@ -137,13 +137,23 @@ public:
         Transfers ownership of the acceptor resources.
 
         @param other The acceptor to move from.
+
+        @pre No awaitables returned by @p other's methods exist.
+        @pre The execution context associated with @p other must
+            outlive this acceptor.
     */
     tcp_acceptor(tcp_acceptor&& other) noexcept : io_object(std::move(other)) {}
 
     /** Move assignment operator.
 
         Closes any existing acceptor and transfers ownership.
+
         @param other The acceptor to move from.
+
+        @pre No awaitables returned by either `*this` or @p other's
+            methods exist.
+        @pre The execution context associated with @p other must
+            outlive this acceptor.
 
         @return Reference to this acceptor.
     */
@@ -227,6 +237,9 @@ public:
         @par Preconditions
         The acceptor must be listening (`is_open() == true`).
         The peer socket must be associated with the same execution context.
+
+        Both this acceptor and @p peer must outlive the returned
+        awaitable.
 
         @par Example
         @code

--- a/include/boost/corosio/tcp_socket.hpp
+++ b/include/boost/corosio/tcp_socket.hpp
@@ -204,13 +204,27 @@ public:
         Transfers ownership of the socket resources.
 
         @param other The socket to move from.
+
+        @pre No awaitables returned by @p other's methods exist.
+        @pre @p other is not referenced as a peer in any outstanding
+            accept awaitable.
+        @pre The execution context associated with @p other must
+            outlive this socket.
     */
     tcp_socket(tcp_socket&& other) noexcept : io_object(std::move(other)) {}
 
     /** Move assignment operator.
 
         Closes any existing socket and transfers ownership.
+
         @param other The socket to move from.
+
+        @pre No awaitables returned by either `*this` or @p other's
+            methods exist.
+        @pre Neither `*this` nor @p other is referenced as a peer in
+            any outstanding accept awaitable.
+        @pre The execution context associated with @p other must
+            outlive this socket.
 
         @return Reference to this socket.
     */
@@ -282,6 +296,8 @@ public:
 
         @par Preconditions
         The socket must be open (`is_open() == true`).
+
+        This socket must outlive the returned awaitable.
 
         @par Example
         @code

--- a/include/boost/corosio/timer.hpp
+++ b/include/boost/corosio/timer.hpp
@@ -86,6 +86,10 @@ public:
         Transfers ownership of the timer resources.
 
         @param other The timer to move from.
+
+        @pre No awaitables returned by @p other's methods exist.
+        @pre The execution context associated with @p other must
+            outlive this timer.
     */
     timer(timer&& other) noexcept;
 
@@ -94,6 +98,11 @@ public:
         Closes any existing timer and transfers ownership.
 
         @param other The timer to move from.
+
+        @pre No awaitables returned by either `*this` or @p other's
+            methods exist.
+        @pre The execution context associated with @p other must
+            outlive this timer.
 
         @return Reference to this timer.
     */


### PR DESCRIPTION
…s public API

Add @pre conditions to move constructors and move assignment operators for all public I/O types: tcp_socket, tcp_acceptor, timer, signal_set, resolver, and their native variants. Document awaitable lifetime requirements and buffer validity for read_some/write_some.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for async operation awaitables with lifetime requirements across I/O stream, resolver, signal set, TCP acceptor, TCP socket, and timer components.
  * Added precondition notes to move constructors and move assignment operators.
  * Clarified buffer validity requirements and object lifetime constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->