### PR TITLE
Fix incorrect move semantics docs for I/O objects

### DIFF
--- a/doc/modules/ROOT/pages/4.guide/4d.sockets.adoc
+++ b/doc/modules/ROOT/pages/4.guide/4d.sockets.adoc
@@ -245,7 +245,7 @@ Move assignment closes any existing socket:
 s1 = std::move(s2);  // Closes s1's socket if open, then moves s2
 ----
 
-IMPORTANT: Source and destination must share the same execution context.
+NOTE: After a move, the destination uses the source's execution context.
 
 == The io_stream Interface
 

--- a/doc/modules/ROOT/pages/4.guide/4e.tcp-acceptor.adoc
+++ b/doc/modules/ROOT/pages/4.guide/4e.tcp-acceptor.adoc
@@ -225,7 +225,7 @@ Move assignment closes any existing tcp_acceptor:
 acc1 = std::move(acc2);  // Closes acc1's socket if open, then moves acc2
 ----
 
-IMPORTANT: Source and destination must share the same execution context.
+NOTE: After a move, the destination uses the source's execution context.
 
 == Thread Safety
 

--- a/doc/modules/ROOT/pages/4.guide/4h.timers.adoc
+++ b/doc/modules/ROOT/pages/4.guide/4h.timers.adoc
@@ -266,7 +266,7 @@ corosio::timer t3 = t2;  // Error: deleted copy constructor
 
 Move assignment cancels any pending wait on the destination timer.
 
-IMPORTANT: Source and destination must share the same execution context.
+NOTE: After a move, the destination uses the source's execution context.
 
 == Thread Safety
 

--- a/doc/modules/ROOT/pages/4.guide/4i.signals.adoc
+++ b/doc/modules/ROOT/pages/4.guide/4i.signals.adoc
@@ -350,7 +350,7 @@ corosio::signal_set s2 = std::move(s1);  // OK
 corosio::signal_set s3 = s2;  // Error: deleted copy constructor
 ----
 
-IMPORTANT: Source and destination must share the same execution context.
+NOTE: After a move, the destination uses the source's execution context.
 
 == Thread Safety
 

--- a/doc/modules/ROOT/pages/4.guide/4j.resolver.adoc
+++ b/doc/modules/ROOT/pages/4.guide/4j.resolver.adoc
@@ -257,7 +257,7 @@ corosio::resolver r2 = std::move(r1);  // OK
 corosio::resolver r3 = r2;  // Error: deleted copy constructor
 ----
 
-IMPORTANT: Source and destination must share the same execution context.
+NOTE: After a move, the destination uses the source's execution context.
 
 == Thread Safety
 


### PR DESCRIPTION
The guides stated source and destination must share the same execution context, which is not a precondition. Moves transfer context affinity from source to destination.

Resolves #120.