### PR TITLE
Add Windows and macOS to coverage bot

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,22 +1,22 @@
 # Copyright 2019 - 2021 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
-#
-# Sample codecov configuration file. Edit as required
 
 codecov:
   max_report_age: off
   require_ci_to_pass: yes
   notify:
-    # Increase this if you have multiple coverage collection jobs
-    after_n_builds: 1
+    # Three coverage builds: Linux (GCC), macOS (Apple-Clang), Windows (MinGW)
+    after_n_builds: 3
     wait_for_ci: yes
 
 # Fix paths from CI build to match repository structure
-# Coverage paths look like: /home/runner/work/corosio/corosio/boost-root/libs/corosio/include/...
-# Strip everything up to and including boost-root/libs/corosio/
+# Linux (lcov) paths: /home/runner/.../boost-root/libs/corosio/include/...
+# macOS/Windows (gcovr -r boost-root) paths: libs/corosio/include/...
+# Codecov applies fixes in order, first match wins.
 fixes:
   - "boost-root/libs/corosio/::"
+  - "libs/corosio/::"
 
 # Make coverage checks informational (report but never fail CI)
 coverage:
@@ -31,6 +31,24 @@ coverage:
 # Change how pull request comments look
 comment:
   layout: "reach,diff,flags,files,footer"
+
+# Per-platform coverage flags
+flags:
+  linux:
+    paths:
+      - include/
+      - src/
+    carryforward: true
+  macos:
+    paths:
+      - include/
+      - src/
+    carryforward: true
+  windows:
+    paths:
+      - include/
+      - src/
+    carryforward: true
 
 # Ignore specific files or folders. Glob patterns are supported.
 # See https://docs.codecov.com/docs/ignoring-paths

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,27 @@ jobs:
             build-cmake: true
             vcpkg-triplet: "x64-mingw-static"
 
-          # macOS (3 configurations)
-          # Uses select backend (kqueue support planned for future)
+          - compiler: "mingw"
+            version: "*"
+            cxxstd: "20"
+            latest-cxxstd: "20"
+            cxx: "g++"
+            cc: "gcc"
+            runs-on: "windows-2022"
+            b2-toolset: "gcc"
+            generator: "MinGW Makefiles"
+            name: "MinGW: C++20 (coverage)"
+            windows: true
+            shared: false
+            coverage: true
+            coverage-flag: "windows"
+            build-type: "Debug"
+            cxxflags: "--coverage -fprofile-arcs -ftest-coverage -fprofile-update=atomic"
+            ccflags: "--coverage -fprofile-arcs -ftest-coverage -fprofile-update=atomic"
+            vcpkg-triplet: "x64-mingw-static"
+
+          # macOS (4 configurations)
+          # kqueue is the default backend on macOS
           # Requires -fexperimental-library for std::stop_token support in libc++
 
           - compiler: "apple-clang"
@@ -158,7 +177,24 @@ jobs:
             build-type: "Release"
             cxxflags: "-fexperimental-library"
 
-          # Linux GCC (4 configurations)
+          - compiler: "apple-clang"
+            version: "*"
+            cxxstd: "20"
+            latest-cxxstd: "20"
+            cxx: "clang++"
+            cc: "clang"
+            runs-on: "macos-15"
+            b2-toolset: "clang"
+            name: "Apple-Clang (macOS 15, coverage): C++20"
+            macos: true
+            shared: false
+            coverage: true
+            coverage-flag: "macos"
+            build-type: "Debug"
+            cxxflags: "--coverage -fexperimental-library"
+            ccflags: "--coverage"
+
+          # Linux GCC (5 configurations)
 
           - compiler: "gcc"
             version: "15"
@@ -219,6 +255,7 @@ jobs:
             linux: true
             shared: false
             coverage: true
+            coverage-flag: "linux"
             build-type: "Debug"
             cxxflags: "--coverage -fprofile-arcs -ftest-coverage -fprofile-update=atomic"
             ccflags: "--coverage -fprofile-arcs -ftest-coverage -fprofile-update=atomic"
@@ -903,7 +940,7 @@ jobs:
           ref-source-dir: boost-root
 
       - name: Generate Coverage Report
-        if: ${{ matrix.coverage }}
+        if: ${{ matrix.coverage && matrix.linux }}
         run: |
           set -x
 
@@ -920,11 +957,35 @@ jobs:
             --include "*/boost-root/libs/${{steps.patch.outputs.module}}/src/*" \
             --gcov-tool "$gcov_tool"
 
+      - name: Generate Coverage Report (macOS)
+        if: ${{ matrix.coverage && matrix.macos }}
+        run: |
+          set -x
+          pip3 install --break-system-packages gcovr
+          gcovr \
+            --gcov-executable "xcrun llvm-cov gcov" \
+            -r boost-root \
+            --filter ".*/libs/${{steps.patch.outputs.module}}/include/.*" \
+            --filter ".*/libs/${{steps.patch.outputs.module}}/src/.*" \
+            --lcov -o "boost-root/__build_cmake_test__/coverage.info"
+
+      - name: Generate Coverage Report (Windows)
+        if: ${{ matrix.coverage && matrix.windows }}
+        run: |
+          set -x
+          pip3 install gcovr
+          gcovr \
+            -r boost-root \
+            --filter ".*/libs/${{steps.patch.outputs.module}}/include/.*" \
+            --filter ".*/libs/${{steps.patch.outputs.module}}/src/.*" \
+            --lcov -o "boost-root/__build_cmake_test__/coverage.info"
+
       - name: Upload to Codecov
         if: ${{ matrix.coverage }}
         uses: codecov/codecov-action@v5
         with:
           files: boost-root/__build_cmake_test__/coverage.info
+          flags: ${{ matrix.coverage-flag }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced coverage infrastructure with explicit per-platform support for Windows (MinGW), multiple macOS variants, and Linux (GCC 13), including platform-specific coverage flags.
  * Added platform-specific coverage report generation and improved upload handling to Codecov with propagated flags.
  * Expanded ignored paths to exclude additional build and test directories and clarified per-platform path interpretations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->