### PR TITLE
Fix coroutine frame leaks during io_context shutdown (#159)

### DIFF
--- a/include/boost/corosio/detail/timer_service.hpp
+++ b/include/boost/corosio/detail/timer_service.hpp
@@ -30,6 +30,7 @@
 #include <mutex>
 #include <optional>
 #include <stop_token>
+#include <utility>
 #include <vector>
 
 namespace boost::corosio::detail {
@@ -198,8 +199,7 @@ struct BOOST_COROSIO_SYMBOL_VISIBLE waiter_node
         completion_op() noexcept : scheduler_op(&do_complete) {}
 
         void operator()() override;
-        // No-op — lifetime owned by waiter_node, not the scheduler queue
-        void destroy() override {}
+        void destroy() override;
     };
 
     // Per-waiter stop_token cancellation
@@ -328,15 +328,22 @@ timer_service::shutdown()
 {
     timer_service_invalidate_cache();
 
-    // Cancel waiting timers still in the heap
+    // Cancel waiting timers still in the heap.
+    // Each waiter called work_started() in implementation::wait().
+    // On IOCP the scheduler shutdown loop exits when outstanding_work_
+    // reaches zero, so we must call work_finished() here to balance it.
+    // On other backends this is harmless (their drain loops exit when
+    // the queue is empty, not based on outstanding_work_).
     for (auto& entry : heap_)
     {
         auto* impl = entry.timer_;
         while (auto* w = impl->waiters_.pop_front())
         {
             w->stop_cb_.reset();
-            w->h_ = {};
+            auto h = std::exchange(w->h_, {});
             sched_->work_finished();
+            if (h)
+                h.destroy();
             delete w;
         }
         impl->heap_index_ = (std::numeric_limits<std::size_t>::max)();
@@ -722,10 +729,12 @@ waiter_node::canceller::operator()() const
 
 inline void
 waiter_node::completion_op::do_complete(
-    void* owner, scheduler_op* base, std::uint32_t, std::uint32_t)
+    [[maybe_unused]] void* owner, scheduler_op* base, std::uint32_t, std::uint32_t)
 {
-    if (!owner)
-        return;
+    // owner is always non-null here. The destroy path (owner == nullptr)
+    // is unreachable because completion_op overrides destroy() directly,
+    // bypassing scheduler_op::destroy() which would call func_(nullptr, ...).
+    BOOST_COROSIO_ASSERT(owner);
     static_cast<completion_op*>(base)->operator()();
 }
 
@@ -746,6 +755,30 @@ waiter_node::completion_op::operator()()
 
     d.post(h);
     sched.work_finished();
+}
+
+inline void
+waiter_node::completion_op::destroy()
+{
+    // Called during scheduler shutdown drain when this completion_op is
+    // in the scheduler's ready queue (posted by cancel_timer() or
+    // process_expired()). Balances the work_started() from
+    // implementation::wait(). The scheduler drain loop separately
+    // balances the work_started() from post(). On IOCP both decrements
+    // are required for outstanding_work_ to reach zero; on other
+    // backends this is harmless.
+    //
+    // This override also prevents scheduler_op::destroy() from calling
+    // do_complete(nullptr, ...). See also: timer_service::shutdown()
+    // which drains waiters still in the timer heap (the other path).
+    auto* w = waiter_;
+    w->stop_cb_.reset();
+    auto h = std::exchange(w->h_, {});
+    auto& sched = w->svc_->get_scheduler();
+    delete w;
+    sched.work_finished();
+    if (h)
+        h.destroy();
 }
 
 inline std::coroutine_handle<>

--- a/include/boost/corosio/native/detail/epoll/epoll_scheduler.hpp
+++ b/include/boost/corosio/native/detail/epoll/epoll_scheduler.hpp
@@ -288,7 +288,6 @@ private:
     mutable op_queue completed_ops_;
     mutable std::atomic<long> outstanding_work_;
     bool stopped_;
-    bool shutdown_;
 
     // True while a thread is blocked in epoll_wait. Used by
     // wake_one_thread_and_unlock and work_finished to know when
@@ -612,7 +611,6 @@ inline epoll_scheduler::epoll_scheduler(capy::execution_context& ctx, int)
     , timer_fd_(-1)
     , outstanding_work_(0)
     , stopped_(false)
-    , shutdown_(false)
     , task_running_{false}
     , task_interrupted_(false)
     , state_(0)
@@ -696,7 +694,6 @@ epoll_scheduler::shutdown()
 {
     {
         std::unique_lock lock(mutex_);
-        shutdown_ = true;
 
         while (auto* h = completed_ops_.pop())
         {
@@ -709,8 +706,6 @@ epoll_scheduler::shutdown()
 
         signal_all(lock);
     }
-
-    outstanding_work_.store(0, std::memory_order_release);
 
     if (event_fd_ >= 0)
         interrupt_reactor();
@@ -736,7 +731,9 @@ epoll_scheduler::post(std::coroutine_handle<> h) const
 
         void destroy() override
         {
+            auto h = h_;
             delete this;
+            h.destroy();
         }
     };
 

--- a/include/boost/corosio/native/detail/iocp/win_scheduler.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_scheduler.hpp
@@ -100,7 +100,6 @@ private:
     void* iocp_;
     mutable long outstanding_work_;
     mutable long stopped_;
-    long shutdown_;
     long stop_event_posted_;
     mutable long dispatch_required_;
 
@@ -162,7 +161,6 @@ inline win_scheduler::win_scheduler(
     : iocp_(nullptr)
     , outstanding_work_(0)
     , stopped_(0)
-    , shutdown_(0)
     , stop_event_posted_(0)
     , dispatch_required_(0)
 {
@@ -194,12 +192,19 @@ inline win_scheduler::~win_scheduler()
 inline void
 win_scheduler::shutdown()
 {
-    ::InterlockedExchange(&shutdown_, 1);
-
     if (timers_)
         timers_->stop();
 
-    for (;;)
+    // Drain timer heap before the work-counting loop. The timer_service
+    // was registered after this scheduler (nested make_service from our
+    // constructor), so execution_context::shutdown() calls us first.
+    // Asio avoids this by owning timer queues directly inside the
+    // scheduler; we bridge the gap by shutting down the timer service
+    // early. The subsequent call from execution_context is a no-op.
+    if (timer_svc_)
+        timer_svc_->shutdown();
+
+    while (::InterlockedExchangeAdd(&outstanding_work_, 0) > 0)
     {
         op_queue ops;
         {
@@ -207,38 +212,39 @@ win_scheduler::shutdown()
             ops.splice(completed_ops_);
         }
 
-        bool drained_any = false;
-
-        while (auto* h = ops.pop())
+        if (!ops.empty())
         {
-            h->destroy();
-            drained_any = true;
+            while (auto* h = ops.pop())
+            {
+                ::InterlockedDecrement(&outstanding_work_);
+                h->destroy();
+            }
         }
-
-        DWORD bytes;
-        ULONG_PTR key;
-        LPOVERLAPPED overlapped;
-        ::GetQueuedCompletionStatus(iocp_, &bytes, &key, &overlapped, 0);
-        if (overlapped)
+        else
         {
-            if (key == key_posted)
+            DWORD bytes;
+            ULONG_PTR key;
+            LPOVERLAPPED overlapped;
+            ::GetQueuedCompletionStatus(
+                iocp_, &bytes, &key, &overlapped,
+                iocp::max_gqcs_timeout);
+            if (overlapped)
             {
-                auto* op = reinterpret_cast<scheduler_op*>(overlapped);
-                op->destroy();
+                ::InterlockedDecrement(&outstanding_work_);
+                if (key == key_posted)
+                {
+                    auto* op =
+                        reinterpret_cast<scheduler_op*>(overlapped);
+                    op->destroy();
+                }
+                else
+                {
+                    auto* op = overlapped_to_op(overlapped);
+                    op->destroy();
+                }
             }
-            else
-            {
-                auto* op = overlapped_to_op(overlapped);
-                op->destroy();
-            }
-            drained_any = true;
         }
-
-        if (!drained_any)
-            break;
     }
-
-    ::InterlockedExchange(&outstanding_work_, 0);
 }
 
 inline void
@@ -254,7 +260,28 @@ win_scheduler::post(std::coroutine_handle<> h) const
             auto* self = static_cast<post_handler*>(base);
             if (!owner)
             {
+                // Shutdown path: destroy the coroutine frame synchronously.
+                //
+                // Bounded destruction invariant: the chain triggered by
+                // coro.destroy() is at most two levels deep:
+                //   1. task frame destroyed → ~io_awaitable_promise_base()
+                //      destroys stored continuation (if != noop_coroutine)
+                //   2. continuation (trampoline) destroyed → final_suspend
+                //      returns suspend_never, no further continuation
+                //
+                // If a future refactor adds deeper continuation chains,
+                // this would reintroduce re-entrant stack overflow risk.
+#ifndef NDEBUG
+                static thread_local int destroy_depth = 0;
+                ++destroy_depth;
+                BOOST_COROSIO_ASSERT(destroy_depth <= 2);
+#endif
+                auto coro = self->h_;
                 delete self;
+                coro.destroy();
+#ifndef NDEBUG
+                --destroy_depth;
+#endif
                 return;
             }
             auto coro = self->h_;

--- a/include/boost/corosio/native/detail/kqueue/kqueue_scheduler.hpp
+++ b/include/boost/corosio/native/detail/kqueue/kqueue_scheduler.hpp
@@ -363,7 +363,6 @@ private:
     mutable op_queue completed_ops_;
     mutable std::atomic<std::int64_t> outstanding_work_{0};
     std::atomic<bool> stopped_{false};
-    bool shutdown_ = false;
 
     // True while a thread is blocked in kevent(). Used by
     // wake_one_thread_and_unlock and work_finished to know when
@@ -709,7 +708,6 @@ inline kqueue_scheduler::kqueue_scheduler(capy::execution_context& ctx, int)
     : kq_fd_(-1)
     , outstanding_work_(0)
     , stopped_(false)
-    , shutdown_(false)
     , task_running_(false)
     , task_interrupted_(false)
     , state_(0)
@@ -764,7 +762,6 @@ kqueue_scheduler::shutdown()
 {
     {
         std::unique_lock lock(mutex_);
-        shutdown_ = true;
 
         while (auto* h = completed_ops_.pop())
         {
@@ -777,8 +774,6 @@ kqueue_scheduler::shutdown()
 
         signal_all(lock);
     }
-
-    outstanding_work_.store(0, std::memory_order_release);
 
     if (kq_fd_ >= 0)
         interrupt_reactor();
@@ -808,7 +803,9 @@ kqueue_scheduler::post(std::coroutine_handle<> h) const
 
         void destroy() override
         {
+            auto h = h_;
             delete this;
+            h.destroy();
         }
     };
 

--- a/include/boost/corosio/native/detail/select/select_scheduler.hpp
+++ b/include/boost/corosio/native/detail/select/select_scheduler.hpp
@@ -156,7 +156,6 @@ private:
     mutable op_queue completed_ops_;
     mutable std::atomic<long> outstanding_work_;
     std::atomic<bool> stopped_;
-    bool shutdown_;
 
     // Per-fd state for tracking registered operations
     struct fd_state
@@ -259,7 +258,6 @@ inline select_scheduler::select_scheduler(capy::execution_context& ctx, int)
     : pipe_fds_{-1, -1}
     , outstanding_work_(0)
     , stopped_(false)
-    , shutdown_(false)
     , max_fd_(-1)
     , reactor_running_(false)
     , reactor_interrupted_(false)
@@ -325,7 +323,6 @@ select_scheduler::shutdown()
 {
     {
         std::unique_lock lock(mutex_);
-        shutdown_ = true;
 
         while (auto* h = completed_ops_.pop())
         {
@@ -336,8 +333,6 @@ select_scheduler::shutdown()
             lock.lock();
         }
     }
-
-    outstanding_work_.store(0, std::memory_order_release);
 
     if (pipe_fds_[1] >= 0)
         interrupt_reactor();
@@ -365,7 +360,9 @@ select_scheduler::post(std::coroutine_handle<> h) const
 
         void destroy() override
         {
+            auto h = h_;
             delete this;
+            h.destroy();
         }
     };
 

--- a/test/unit/io_context.cpp
+++ b/test/unit/io_context.cpp
@@ -22,6 +22,7 @@
 #include <thread>
 #include <vector>
 
+#include "context.hpp"
 #include "test_suite.hpp"
 
 namespace boost::corosio {
@@ -120,6 +121,45 @@ inline atomic_counter_coro
 make_atomic_coro(std::atomic<int>& counter)
 {
     auto c                 = []() -> atomic_counter_coro { co_return; }();
+    c.h.promise().counter_ = &counter;
+    return c;
+}
+
+// Coroutine whose promise destructor increments a counter.
+// Both initial_suspend and final_suspend return suspend_always so the
+// frame is only freed by an explicit .destroy() call.
+struct destroy_counter_coro
+{
+    struct promise_type
+    {
+        int* counter_ = nullptr;
+
+        destroy_counter_coro get_return_object()
+        {
+            return {std::coroutine_handle<promise_type>::from_promise(*this)};
+        }
+
+        std::suspend_always initial_suspend() noexcept { return {}; }
+        std::suspend_always final_suspend() noexcept { return {}; }
+        void return_void() {}
+        void unhandled_exception() { std::terminate(); }
+
+        ~promise_type()
+        {
+            if (counter_)
+                ++(*counter_);
+        }
+    };
+
+    std::coroutine_handle<promise_type> h;
+
+    operator std::coroutine_handle<>() const { return h; }
+};
+
+inline destroy_counter_coro
+make_destroy_coro(int& counter)
+{
+    auto c                 = []() -> destroy_counter_coro { co_return; }();
     c.h.promise().counter_ = &counter;
     return c;
 }
@@ -513,6 +553,24 @@ struct io_context_test
         BOOST_TEST(finished);
     }
 
+    void testShutdownDestroysPostedCoroutineFrames()
+    {
+        int destroyed = 0;
+
+        {
+            io_context ioc;
+            auto ex = ioc.get_executor();
+
+            ex.post(make_destroy_coro(destroyed));
+            ex.post(make_destroy_coro(destroyed));
+            ex.post(make_destroy_coro(destroyed));
+
+            // io_context destructor triggers shutdown
+        }
+
+        BOOST_TEST_EQ(destroyed, 3);
+    }
+
     void run()
     {
         testConstruction();
@@ -529,9 +587,38 @@ struct io_context_test
         testMultithreaded();
         testMultithreadedStress();
         testWhenAllSetEvent();
+        testShutdownDestroysPostedCoroutineFrames();
     }
 };
 
 TEST_SUITE(io_context_test, "boost.corosio.io_context");
+
+// Backend-parameterized tests for shutdown paths that differ per backend
+template<auto Backend>
+struct io_context_shutdown_test
+{
+    void testShutdownDestroysPostedCoroutineFrames()
+    {
+        int destroyed = 0;
+
+        {
+            io_context ioc(Backend);
+            auto ex = ioc.get_executor();
+
+            ex.post(make_destroy_coro(destroyed));
+            ex.post(make_destroy_coro(destroyed));
+            ex.post(make_destroy_coro(destroyed));
+        }
+
+        BOOST_TEST_EQ(destroyed, 3);
+    }
+
+    void run()
+    {
+        testShutdownDestroysPostedCoroutineFrames();
+    }
+};
+
+COROSIO_BACKEND_TESTS(io_context_shutdown_test, "boost.corosio.io_context_shutdown")
 
 } // namespace boost::corosio

--- a/test/unit/native/iocp/iocp_shutdown.cpp
+++ b/test/unit/native/iocp/iocp_shutdown.cpp
@@ -1,0 +1,157 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#include <boost/corosio/detail/platform.hpp>
+
+#if BOOST_COROSIO_HAS_IOCP
+
+#include <boost/corosio/native/native_io_context.hpp>
+#include <boost/corosio/native/detail/iocp/win_overlapped_op.hpp>
+#include <boost/corosio/native/detail/iocp/win_completion_key.hpp>
+#include <boost/corosio/native/detail/iocp/win_windows.hpp>
+
+#include "test_suite.hpp"
+
+namespace boost::corosio {
+
+// Test helper: exposes IOCP handle for direct posting.
+struct iocp_test_context : native_io_context<iocp>
+{
+    void* iocp_handle()
+    {
+        return static_cast<detail::win_scheduler*>(sched_)->native_handle();
+    }
+};
+
+// Overlapped op that increments a counter when destroyed during shutdown.
+struct test_overlapped_op : detail::overlapped_op
+{
+    int* destroyed_;
+
+    static void do_complete(
+        void* owner,
+        detail::scheduler_op* base,
+        std::uint32_t,
+        std::uint32_t)
+    {
+        auto* self = static_cast<test_overlapped_op*>(base);
+        if (!owner)
+        {
+            ++(*self->destroyed_);
+            delete self;
+            return;
+        }
+        delete self;
+    }
+
+    explicit test_overlapped_op(int& destroyed)
+        : detail::overlapped_op(&do_complete)
+        , destroyed_(&destroyed)
+    {
+    }
+};
+
+struct iocp_shutdown_test
+{
+    // Shutdown drains I/O completions (key_io) from the IOCP.
+    // Covers the else branch of `if (key == key_posted)` in shutdown().
+    void testShutdownDrainsIOCompletion()
+    {
+        int destroyed = 0;
+
+        {
+            iocp_test_context ctx;
+            auto ex   = ctx.get_executor();
+            void* ioc = ctx.iocp_handle();
+
+            auto* op = new test_overlapped_op(destroyed);
+
+            ex.on_work_started();
+
+            BOOL ok = ::PostQueuedCompletionStatus(
+                ioc, 0, detail::key_io, static_cast<LPOVERLAPPED>(op));
+            BOOST_TEST(ok != 0);
+        }
+
+        BOOST_TEST_EQ(destroyed, 1);
+    }
+
+    // Shutdown drains key_result_stored completions from the IOCP.
+    void testShutdownDrainsResultStoredCompletion()
+    {
+        int destroyed = 0;
+
+        {
+            iocp_test_context ctx;
+            auto ex   = ctx.get_executor();
+            void* ioc = ctx.iocp_handle();
+
+            auto* op              = new test_overlapped_op(destroyed);
+            op->ready_            = 1;
+            op->dwError           = 0;
+            op->bytes_transferred = 42;
+
+            ex.on_work_started();
+
+            BOOL ok = ::PostQueuedCompletionStatus(
+                ioc,
+                0,
+                detail::key_result_stored,
+                static_cast<LPOVERLAPPED>(op));
+            BOOST_TEST(ok != 0);
+        }
+
+        BOOST_TEST_EQ(destroyed, 1);
+    }
+
+    // Shutdown drains multiple I/O completions with different keys.
+    void testShutdownDrainsMixedCompletions()
+    {
+        int io_destroyed     = 0;
+        int stored_destroyed = 0;
+
+        {
+            iocp_test_context ctx;
+            auto ex   = ctx.get_executor();
+            void* ioc = ctx.iocp_handle();
+
+            auto* io_op = new test_overlapped_op(io_destroyed);
+            ex.on_work_started();
+            ::PostQueuedCompletionStatus(
+                ioc, 0, detail::key_io, static_cast<LPOVERLAPPED>(io_op));
+
+            auto* stored_op              = new test_overlapped_op(stored_destroyed);
+            stored_op->ready_            = 1;
+            stored_op->dwError           = 0;
+            stored_op->bytes_transferred = 0;
+            ex.on_work_started();
+            ::PostQueuedCompletionStatus(
+                ioc,
+                0,
+                detail::key_result_stored,
+                static_cast<LPOVERLAPPED>(stored_op));
+        }
+
+        BOOST_TEST_EQ(io_destroyed, 1);
+        BOOST_TEST_EQ(stored_destroyed, 1);
+    }
+
+    void run()
+    {
+        testShutdownDrainsIOCompletion();
+        testShutdownDrainsResultStoredCompletion();
+        testShutdownDrainsMixedCompletions();
+    }
+};
+
+TEST_SUITE(iocp_shutdown_test, "boost.corosio.native.iocp_shutdown");
+
+} // namespace boost::corosio
+
+#endif // BOOST_COROSIO_HAS_IOCP

--- a/test/unit/timer.cpp
+++ b/test/unit/timer.cpp
@@ -17,6 +17,7 @@
 
 #include <chrono>
 #include <memory>
+#include <new>
 #include <stop_token>
 
 #include "context.hpp"
@@ -345,7 +346,7 @@ struct timer_test
         std::error_code result_ec;
 
         t.expires_after(std::chrono::seconds(60));
-        delay_timer.expires_after(std::chrono::milliseconds(10));
+        delay_timer.expires_after(std::chrono::milliseconds(50));
 
         auto wait_task = [](timer& t_ref, std::error_code& ec_out,
                             bool& done_out) -> capy::task<> {
@@ -361,7 +362,7 @@ struct timer_test
         };
         capy::run_async(ioc.get_executor())(delay_task(delay_timer, t));
 
-        ioc.run_for(std::chrono::milliseconds(100));
+        ioc.run_for(std::chrono::milliseconds(500));
         BOOST_TEST(completed);
         BOOST_TEST(result_ec == capy::cond::canceled);
     }
@@ -918,6 +919,119 @@ struct timer_test
         BOOST_TEST(!captured_ec);
     }
 
+    // Shutdown cleanup
+
+    void testShutdownDestroysTimerWaiters()
+    {
+        bool started   = false;
+        bool destroyed = false;
+
+        {
+            io_context ioc(Backend);
+            timer t(ioc);
+            t.expires_after(std::chrono::seconds(3600));
+
+            auto task = [](timer& t_ref, bool& started_flag,
+                           bool& destroyed_flag) -> capy::task<> {
+                struct guard
+                {
+                    bool& flag_;
+                    ~guard() { flag_ = true; }
+                };
+                guard g{destroyed_flag};
+                started_flag = true;
+                auto [ec]    = co_await t_ref.wait();
+                (void)ec;
+            };
+
+            capy::run_async(ioc.get_executor())(task(t, started, destroyed));
+            ioc.poll();
+
+            BOOST_TEST(started);
+            // io_context destructor triggers shutdown
+        }
+
+        BOOST_TEST(destroyed);
+    }
+
+    void testShutdownDrainsHeapWaiters()
+    {
+        // Exercises timer_service::shutdown()'s waiter drain loop.
+        // Normally the timer destructs before io_context, cancelling
+        // waiters via cancel_timer(). Here we use placement-new so the
+        // timer outlives io_context — its destructor is skipped, leaving
+        // waiters in the heap for shutdown() to drain.
+        int destroyed = 0;
+
+        {
+            io_context ioc(Backend);
+
+            alignas(timer) unsigned char buf[sizeof(timer)];
+            auto* t = new (buf) timer(ioc);
+            t->expires_after(std::chrono::seconds(3600));
+
+            auto task = [](timer& t_ref, int& counter) -> capy::task<> {
+                struct guard
+                {
+                    int& c_;
+                    ~guard() { ++c_; }
+                };
+                guard g{counter};
+                auto [ec] = co_await t_ref.wait();
+                (void)ec;
+            };
+
+            capy::run_async(ioc.get_executor())(task(*t, destroyed));
+            ioc.poll();
+
+            // io_context destructs. Timer t is still alive in buf.
+            // timer_service::shutdown() finds the waiter in the heap
+            // and drains it, destroying the coroutine frame.
+            // Timer destructor is intentionally skipped (placement-new).
+        }
+
+        BOOST_TEST_EQ(destroyed, 1);
+    }
+
+    void testAbruptStopWithPendingTimerOps()
+    {
+        bool waiter_started = false;
+
+        {
+            io_context ioc(Backend);
+            timer t1(ioc);
+            timer t2(ioc);
+            timer t3(ioc);
+
+            t1.expires_after(std::chrono::hours(1));
+            t2.expires_after(std::chrono::hours(1));
+            t3.expires_after(std::chrono::hours(1));
+
+            auto waiter = [](timer& t, bool& started) -> capy::task<> {
+                started   = true;
+                auto [ec] = co_await t.wait();
+                (void)ec;
+            };
+
+            auto stopper = [](io_context& ctx) -> capy::task<> {
+                ctx.stop();
+                co_return;
+            };
+
+            capy::run_async(ioc.get_executor())(waiter(t1, waiter_started));
+            capy::run_async(ioc.get_executor())(waiter(t2, waiter_started));
+            capy::run_async(ioc.get_executor())(waiter(t3, waiter_started));
+            capy::run_async(ioc.get_executor())(stopper(ioc));
+
+            ioc.run();
+
+            BOOST_TEST(waiter_started);
+            // io_context destructs with 3 pending timer waiters
+        }
+        // Shutdown completes without hanging
+        BOOST_TEST_PASS();
+    }
+
     // Edge cases
 
     void testLongDuration()
@@ -1031,6 +1145,11 @@ struct timer_test
         testIoResultSuccess();
         testIoResultCanceled();
         testIoResultStructuredBinding();
+
+        // Shutdown cleanup
+        testShutdownDestroysTimerWaiters();
+        testShutdownDrainsHeapWaiters();
+        testAbruptStopWithPendingTimerOps();
 
         // Edge cases
         testLongDuration();


### PR DESCRIPTION
Closes #159

Restore coroutine handle destruction in shutdown paths that was previously removed (3a29bea, 57c6600) to work around a stack overflow from re-entrant destruction. The destruction chain is now bounded (task → trampoline → noop_coroutine, at most 2 levels deep per run_async invocation), so the overflow no longer applies.

Three shutdown paths now properly destroy coroutine frames:

- post_handler::destroy() in all four backends (epoll, kqueue, select, IOCP) saves the handle before delete, then destroys it
- timer_service::shutdown() destroys handles instead of abandoning them with h_ = {}
- completion_op::destroy() (timer cancel path) destroys the waiter and its coroutine handle instead of being a no-op

Includes regression tests that fail under ASan without the fix:
- testShutdownDestroysPostedCoroutineFrames: posts coroutines then destructs io_context, verifies frames are destroyed
- testShutdownDestroysTimerWaiters: suspends on a timer then destructs io_context, verifies the coroutine frame is destroyed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coroutine resource cleanup: coroutine frames are now destroyed at the correct time during post and shutdown paths, preventing use-after-free and reentrancy issues.
  * More reliable shutdown: removed per-scheduler shutdown flags and now rely on outstanding-work tracking and explicit draining for safer teardown.

* **Refactor**
  * Unified completion and destruction behavior so waiting operations and post handlers consistently balance work tracking and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->