### PR TITLE
Add IPv6 socket support with dual-stack, lazy fd creation, and generi…

### DIFF
--- a/doc/design/physical-structure.md
+++ b/doc/design/physical-structure.md
@@ -206,9 +206,13 @@ public:
         virtual native_handle_type native_handle() const noexcept = 0;
         virtual void cancel() noexcept = 0;
 
-        // Protocol-specific socket options
-        virtual std::error_code set_no_delay( bool ) noexcept = 0;
-        // ...
+        // Generic socket options (level/name passed through from option type)
+        virtual std::error_code set_option(
+            int level, int optname,
+            void const* data, std::size_t size ) noexcept = 0;
+        virtual std::error_code get_option(
+            int level, int optname,
+            void* data, std::size_t* size ) const noexcept = 0;
     };
 
 private:

--- a/include/boost/corosio/detail/acceptor_service.hpp
+++ b/include/boost/corosio/detail/acceptor_service.hpp
@@ -34,18 +34,41 @@ public:
     /// Identifies this service for `execution_context` lookup.
     using key_type = acceptor_service;
 
-    /** Open an acceptor.
+    /** Create the acceptor socket without binding or listening.
 
-        Creates an IPv4 TCP socket, binds it to the specified endpoint,
-        and begins listening for incoming connections.
+        Creates a socket with dual-stack enabled for IPv6 but does
+        not bind or listen. Does not set SO_REUSEADDR.
 
         @param impl The acceptor implementation to open.
-        @param ep The local endpoint to bind to.
-        @param backlog The maximum length of the queue of pending connections.
+        @param family Address family (e.g. `AF_INET`, `AF_INET6`).
+        @param type Socket type (e.g. `SOCK_STREAM`).
+        @param protocol Protocol number (e.g. `IPPROTO_TCP`).
         @return Error code on failure, empty on success.
     */
-    virtual std::error_code open_acceptor(
-        tcp_acceptor::implementation& impl, endpoint ep, int backlog) = 0;
+    virtual std::error_code open_acceptor_socket(
+        tcp_acceptor::implementation& impl,
+        int family, int type, int protocol) = 0;
+
+    /** Bind an open acceptor to a local endpoint.
+
+        @param impl The acceptor implementation to bind.
+        @param ep The local endpoint to bind to.
+        @return Error code on failure, empty on success.
+    */
+    virtual std::error_code bind_acceptor(
+        tcp_acceptor::implementation& impl, endpoint ep) = 0;
+
+    /** Start listening for incoming connections.
+
+        Registers the acceptor with the platform reactor after
+        calling `::listen()`.
+
+        @param impl The acceptor implementation to listen on.
+        @param backlog The maximum length of the pending connection queue.
+        @return Error code on failure, empty on success.
+    */
+    virtual std::error_code listen_acceptor(
+        tcp_acceptor::implementation& impl, int backlog) = 0;
 
 protected:
     /// Construct the acceptor service.

--- a/include/boost/corosio/detail/endpoint_convert.hpp
+++ b/include/boost/corosio/detail/endpoint_convert.hpp
@@ -90,6 +90,145 @@ from_sockaddr_in6(sockaddr_in6 const& sa) noexcept
     return endpoint(ipv6_address(bytes), ntohs(sa.sin6_port));
 }
 
+/** Convert an IPv4 endpoint to an IPv4-mapped IPv6 sockaddr_in6.
+
+    Produces a `sockaddr_in6` with the `::ffff:` prefix, suitable
+    for passing an IPv4 destination to a dual-stack IPv6 socket.
+
+    @param ep The endpoint to convert. Must be IPv4 (is_v4() == true).
+    @return A sockaddr_in6 with the IPv4-mapped address.
+*/
+inline sockaddr_in6
+to_v4_mapped_sockaddr_in6(endpoint const& ep) noexcept
+{
+    sockaddr_in6 sa{};
+    sa.sin6_family = AF_INET6;
+    sa.sin6_port   = htons(ep.port());
+    // ::ffff:0:0/96 prefix
+    sa.sin6_addr.s6_addr[10] = 0xff;
+    sa.sin6_addr.s6_addr[11] = 0xff;
+    auto bytes = ep.v4_address().to_bytes();
+    std::memcpy(&sa.sin6_addr.s6_addr[12], bytes.data(), 4);
+    return sa;
+}
+
+/** Convert endpoint to sockaddr_storage.
+
+    Dispatches to @ref to_sockaddr_in or @ref to_sockaddr_in6
+    based on the endpoint's address family.
+
+    @param ep The endpoint to convert.
+    @param storage Output parameter filled with the sockaddr.
+    @return The length of the filled sockaddr structure.
+*/
+inline socklen_t
+to_sockaddr( endpoint const& ep, sockaddr_storage& storage ) noexcept
+{
+    std::memset( &storage, 0, sizeof( storage ) );
+    if( ep.is_v4() )
+    {
+        auto sa = to_sockaddr_in( ep );
+        std::memcpy( &storage, &sa, sizeof( sa ) );
+        return sizeof( sa );
+    }
+    auto sa6 = to_sockaddr_in6( ep );
+    std::memcpy( &storage, &sa6, sizeof( sa6 ) );
+    return sizeof( sa6 );
+}
+
+/** Convert endpoint to sockaddr_storage for a specific socket family.
+
+    When the socket is AF_INET6 and the endpoint is IPv4, the address
+    is converted to an IPv4-mapped IPv6 address (`::ffff:x.x.x.x`) so
+    dual-stack sockets can connect to IPv4 destinations.
+
+    @param ep The endpoint to convert.
+    @param socket_family The address family of the socket (AF_INET or
+        AF_INET6).
+    @param storage Output parameter filled with the sockaddr.
+    @return The length of the filled sockaddr structure.
+*/
+inline socklen_t
+to_sockaddr(
+    endpoint const& ep,
+    int socket_family,
+    sockaddr_storage& storage) noexcept
+{
+    // IPv4 endpoint on IPv6 socket: use IPv4-mapped address
+    if (ep.is_v4() && socket_family == AF_INET6)
+    {
+        std::memset(&storage, 0, sizeof(storage));
+        auto sa6 = to_v4_mapped_sockaddr_in6(ep);
+        std::memcpy(&storage, &sa6, sizeof(sa6));
+        return sizeof(sa6);
+    }
+    return to_sockaddr(ep, storage);
+}
+
+/** Create endpoint from sockaddr_storage.
+
+    Dispatches on `ss_family` to reconstruct the appropriate
+    IPv4 or IPv6 endpoint.
+
+    @param storage The sockaddr_storage with fields in network byte order.
+    @return An endpoint with address and port extracted from storage.
+*/
+inline endpoint
+from_sockaddr( sockaddr_storage const& storage ) noexcept
+{
+    if( storage.ss_family == AF_INET )
+    {
+        sockaddr_in sa;
+        std::memcpy( &sa, &storage, sizeof( sa ) );
+        return from_sockaddr_in( sa );
+    }
+    if( storage.ss_family == AF_INET6 )
+    {
+        sockaddr_in6 sa6;
+        std::memcpy( &sa6, &storage, sizeof( sa6 ) );
+        return from_sockaddr_in6( sa6 );
+    }
+    return endpoint{};
+}
+
+/** Return the native address family for an endpoint.
+
+    @param ep The endpoint to query.
+    @return `AF_INET` for IPv4, `AF_INET6` for IPv6.
+*/
+inline int
+endpoint_family( endpoint const& ep ) noexcept
+{
+    return ep.is_v6() ? AF_INET6 : AF_INET;
+}
+
+/** Return the address family of a socket descriptor.
+
+    @param fd The socket file descriptor.
+    @return AF_INET, AF_INET6, or AF_UNSPEC on failure.
+*/
+inline int
+socket_family(
+#if BOOST_COROSIO_POSIX
+    int fd
+#else
+    std::uintptr_t fd
+#endif
+    ) noexcept
+{
+    sockaddr_storage storage{};
+    socklen_t len = sizeof(storage);
+    if (getsockname(
+#if BOOST_COROSIO_POSIX
+            fd,
+#else
+            static_cast<SOCKET>(fd),
+#endif
+            reinterpret_cast<sockaddr*>(&storage), &len) != 0)
+        return AF_UNSPEC;
+    return storage.ss_family;
+}
+
 } // namespace boost::corosio::detail
 
 #endif

--- a/include/boost/corosio/detail/socket_service.hpp
+++ b/include/boost/corosio/detail/socket_service.hpp
@@ -35,12 +35,17 @@ public:
 
     /** Open a socket.
 
-        Creates an IPv4 TCP socket and associates it with the platform reactor.
+        Creates a socket and associates it with the platform reactor.
 
         @param impl The socket implementation to open.
+        @param family Address family (e.g. `AF_INET`, `AF_INET6`).
+        @param type Socket type (e.g. `SOCK_STREAM`).
+        @param protocol Protocol number (e.g. `IPPROTO_TCP`).
         @return Error code on failure, empty on success.
     */
-    virtual std::error_code open_socket(tcp_socket::implementation& impl) = 0;
+    virtual std::error_code
+    open_socket( tcp_socket::implementation& impl,
+                 int family, int type, int protocol ) = 0;
 
 protected:
     /// Construct the socket service.

--- a/include/boost/corosio/io/io_read_stream.hpp
+++ b/include/boost/corosio/io/io_read_stream.hpp
@@ -105,6 +105,11 @@ protected:
     /// Construct from a handle.
     explicit io_read_stream(handle h) noexcept : io_object(std::move(h)) {}
 
+    io_read_stream(io_read_stream&&) noexcept            = default;
+    io_read_stream& operator=(io_read_stream&&) noexcept = delete;
+    io_read_stream(io_read_stream const&)                = delete;
+    io_read_stream& operator=(io_read_stream const&)     = delete;
+
 public:
     /** Asynchronously read data from the stream.
 

--- a/include/boost/corosio/io/io_write_stream.hpp
+++ b/include/boost/corosio/io/io_write_stream.hpp
@@ -105,6 +105,11 @@ protected:
     /// Construct from a handle.
     explicit io_write_stream(handle h) noexcept : io_object(std::move(h)) {}
 
+    io_write_stream(io_write_stream&&) noexcept            = default;
+    io_write_stream& operator=(io_write_stream&&) noexcept = delete;
+    io_write_stream(io_write_stream const&)                = delete;
+    io_write_stream& operator=(io_write_stream const&)     = delete;
+
 public:
     /** Asynchronously write data to the stream.
 

--- a/include/boost/corosio/ipv6_address.hpp
+++ b/include/boost/corosio/ipv6_address.hpp
@@ -261,6 +261,18 @@ public:
         return a1.addr_ != a2.addr_;
     }
 
+    /** Return an address object that represents the unspecified address.
+
+        The address 0:0:0:0:0:0:0:0 (::) may be used to bind a socket
+        to all available interfaces.
+
+        @return The unspecified address (::).
+    */
+    static ipv6_address any() noexcept
+    {
+        return ipv6_address();
+    }
+
     /** Return an address object that represents the loopback address.
 
         The unicast address 0:0:0:0:0:0:0:1 is called

--- a/include/boost/corosio/native/detail/epoll/epoll_acceptor.hpp
+++ b/include/boost/corosio/native/detail/epoll/epoll_acceptor.hpp
@@ -57,6 +57,13 @@ public:
         return fd_ >= 0;
     }
     void cancel() noexcept override;
+
+    std::error_code set_option(
+        int level, int optname,
+        void const* data, std::size_t size) noexcept override;
+    std::error_code get_option(
+        int level, int optname,
+        void* data, std::size_t* size) const noexcept override;
     void cancel_single_op(epoll_op& op) noexcept;
     void close_socket() noexcept;
     void set_local_endpoint(endpoint ep) noexcept

--- a/include/boost/corosio/native/detail/epoll/epoll_acceptor_service.hpp
+++ b/include/boost/corosio/native/detail/epoll/epoll_acceptor_service.hpp
@@ -74,8 +74,13 @@ public:
     io_object::implementation* construct() override;
     void destroy(io_object::implementation*) override;
     void close(io_object::handle&) override;
-    std::error_code open_acceptor(
-        tcp_acceptor::implementation& impl, endpoint ep, int backlog) override;
+    std::error_code open_acceptor_socket(
+        tcp_acceptor::implementation& impl,
+        int family, int type, int protocol) override;
+    std::error_code bind_acceptor(
+        tcp_acceptor::implementation& impl, endpoint ep) override;
+    std::error_code listen_acceptor(
+        tcp_acceptor::implementation& impl, int backlog) override;
 
     epoll_scheduler& scheduler() const noexcept
     {
@@ -150,7 +155,7 @@ epoll_accept_op::operator()()
 
             impl.set_endpoints(
                 static_cast<epoll_acceptor*>(acceptor_impl_)->local_endpoint(),
-                from_sockaddr_in(peer_addr));
+                from_sockaddr(peer_storage));
 
             if (impl_out)
                 *impl_out = &impl;
@@ -204,13 +209,13 @@ epoll_acceptor::accept(
     op.fd       = fd_;
     op.start(token, this);
 
-    sockaddr_in addr{};
-    socklen_t addrlen = sizeof(addr);
+    sockaddr_storage peer_storage{};
+    socklen_t addrlen = sizeof(peer_storage);
     int accepted;
     do
     {
         accepted = ::accept4(
-            fd_, reinterpret_cast<sockaddr*>(&addr), &addrlen,
+            fd_, reinterpret_cast<sockaddr*>(&peer_storage), &addrlen,
             SOCK_NONBLOCK | SOCK_CLOEXEC);
     }
     while (accepted < 0 && errno == EINTR);
@@ -241,7 +246,8 @@ epoll_acceptor::accept(
                 socket_svc->scheduler().register_descriptor(
                     accepted, &impl.desc_state_);
 
-                impl.set_endpoints(local_endpoint_, from_sockaddr_in(addr));
+                impl.set_endpoints(
+                    local_endpoint_, from_sockaddr(peer_storage));
 
                 *ec = {};
                 if (impl_out)
@@ -257,8 +263,8 @@ epoll_acceptor::accept(
             return dispatch_coro(ex, h);
         }
 
-        op.accepted_fd = accepted;
-        op.peer_addr   = addr;
+        op.accepted_fd   = accepted;
+        op.peer_storage  = peer_storage;
         op.complete(0, 0);
         op.impl_ptr = shared_from_this();
         svc_.post(&op);
@@ -424,50 +430,91 @@ epoll_acceptor_service::close(io_object::handle& h)
 }
 
 inline std::error_code
-epoll_acceptor_service::open_acceptor(
-    tcp_acceptor::implementation& impl, endpoint ep, int backlog)
+epoll_acceptor::set_option(
+    int level, int optname,
+    void const* data, std::size_t size) noexcept
+{
+    if (::setsockopt(fd_, level, optname, data,
+            static_cast<socklen_t>(size)) != 0)
+        return make_err(errno);
+    return {};
+}
+
+inline std::error_code
+epoll_acceptor::get_option(
+    int level, int optname,
+    void* data, std::size_t* size) const noexcept
+{
+    socklen_t len = static_cast<socklen_t>(*size);
+    if (::getsockopt(fd_, level, optname, data, &len) != 0)
+        return make_err(errno);
+    *size = static_cast<std::size_t>(len);
+    return {};
+}
+
+inline std::error_code
+epoll_acceptor_service::open_acceptor_socket(
+    tcp_acceptor::implementation& impl,
+    int family, int type, int protocol)
 {
     auto* epoll_impl = static_cast<epoll_acceptor*>(&impl);
     epoll_impl->close_socket();
 
-    int fd = ::socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    int fd = ::socket(family, type | SOCK_NONBLOCK | SOCK_CLOEXEC, protocol);
     if (fd < 0)
         return make_err(errno);
 
-    int reuse = 1;
-    ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
-
-    sockaddr_in addr = detail::to_sockaddr_in(ep);
-    if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0)
+    if (family == AF_INET6)
     {
-        int errn = errno;
-        ::close(fd);
-        return make_err(errn);
-    }
-
-    if (::listen(fd, backlog) < 0)
-    {
-        int errn = errno;
-        ::close(fd);
-        return make_err(errn);
+        int val = 0; // dual-stack default
+        ::setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &val, sizeof(val));
     }
 
     epoll_impl->fd_ = fd;
 
-    // Register fd with epoll (edge-triggered mode)
+    // Set up descriptor state but do NOT register with epoll yet
     epoll_impl->desc_state_.fd = fd;
     {
         std::lock_guard lock(epoll_impl->desc_state_.mutex);
         epoll_impl->desc_state_.read_op = nullptr;
     }
-    scheduler().register_descriptor(fd, &epoll_impl->desc_state_);
 
-    // Cache the local endpoint (queries OS for ephemeral port if port was 0)
-    sockaddr_in local_addr{};
-    socklen_t local_len = sizeof(local_addr);
-    if (::getsockname(
-            fd, reinterpret_cast<sockaddr*>(&local_addr), &local_len) == 0)
-        epoll_impl->set_local_endpoint(detail::from_sockaddr_in(local_addr));
+    return {};
+}
+
+inline std::error_code
+epoll_acceptor_service::bind_acceptor(
+    tcp_acceptor::implementation& impl, endpoint ep)
+{
+    auto* epoll_impl = static_cast<epoll_acceptor*>(&impl);
+    int fd = epoll_impl->fd_;
+
+    sockaddr_storage storage{};
+    socklen_t addrlen = detail::to_sockaddr(ep, storage);
+    if (::bind(fd, reinterpret_cast<sockaddr*>(&storage), addrlen) < 0)
+        return make_err(errno);
+
+    // Cache local endpoint (resolves ephemeral port)
+    sockaddr_storage local{};
+    socklen_t local_len = sizeof(local);
+    if (::getsockname(fd, reinterpret_cast<sockaddr*>(&local), &local_len) == 0)
+        epoll_impl->set_local_endpoint(detail::from_sockaddr(local));
+
+    return {};
+}
+
+inline std::error_code
+epoll_acceptor_service::listen_acceptor(
+    tcp_acceptor::implementation& impl, int backlog)
+{
+    auto* epoll_impl = static_cast<epoll_acceptor*>(&impl);
+    int fd = epoll_impl->fd_;
+
+    if (::listen(fd, backlog) < 0)
+        return make_err(errno);
+
+    // Register fd with epoll (edge-triggered mode)
+    scheduler().register_descriptor(fd, &epoll_impl->desc_state_);
 
     return {};
 }

--- a/include/boost/corosio/native/detail/epoll/epoll_op.hpp
+++ b/include/boost/corosio/native/detail/epoll/epoll_op.hpp
@@ -355,24 +355,24 @@ struct epoll_accept_op final : epoll_op
 {
     int accepted_fd                      = -1;
     io_object::implementation** impl_out = nullptr;
-    sockaddr_in peer_addr{};
+    sockaddr_storage peer_storage{};
 
     void reset() noexcept
     {
         epoll_op::reset();
-        accepted_fd = -1;
-        impl_out    = nullptr;
-        peer_addr   = {};
+        accepted_fd  = -1;
+        impl_out     = nullptr;
+        peer_storage = {};
     }
 
     void perform_io() noexcept override
     {
-        socklen_t addrlen = sizeof(peer_addr);
+        socklen_t addrlen = sizeof(peer_storage);
         int new_fd;
         do
         {
             new_fd = ::accept4(
-                fd, reinterpret_cast<sockaddr*>(&peer_addr), &addrlen,
+                fd, reinterpret_cast<sockaddr*>(&peer_storage), &addrlen,
                 SOCK_NONBLOCK | SOCK_CLOEXEC);
         }
         while (new_fd < 0 && errno == EINTR);

--- a/include/boost/corosio/native/detail/epoll/epoll_socket.hpp
+++ b/include/boost/corosio/native/detail/epoll/epoll_socket.hpp
@@ -68,22 +68,12 @@ public:
         return fd_;
     }
 
-    // Socket options
-    std::error_code set_no_delay(bool value) noexcept override;
-    bool no_delay(std::error_code& ec) const noexcept override;
-
-    std::error_code set_keep_alive(bool value) noexcept override;
-    bool keep_alive(std::error_code& ec) const noexcept override;
-
-    std::error_code set_receive_buffer_size(int size) noexcept override;
-    int receive_buffer_size(std::error_code& ec) const noexcept override;
-
-    std::error_code set_send_buffer_size(int size) noexcept override;
-    int send_buffer_size(std::error_code& ec) const noexcept override;
-
-    std::error_code set_linger(bool enabled, int timeout) noexcept override;
-    tcp_socket::linger_options
-    linger(std::error_code& ec) const noexcept override;
+    std::error_code set_option(
+        int level, int optname,
+        void const* data, std::size_t size) noexcept override;
+    std::error_code get_option(
+        int level, int optname,
+        void* data, std::size_t* size) const noexcept override;
 
     endpoint local_endpoint() const noexcept override
     {

--- a/include/boost/corosio/native/detail/epoll/epoll_socket_service.hpp
+++ b/include/boost/corosio/native/detail/epoll/epoll_socket_service.hpp
@@ -124,7 +124,9 @@ public:
     io_object::implementation* construct() override;
     void destroy(io_object::implementation*) override;
     void close(io_object::handle&) override;
-    std::error_code open_socket(tcp_socket::implementation& impl) override;
+    std::error_code
+    open_socket(tcp_socket::implementation& impl,
+                int family, int type, int protocol) override;
 
     epoll_scheduler& scheduler() const noexcept
     {
@@ -257,14 +259,13 @@ epoll_connect_op::operator()()
     // Cache endpoints on successful connect
     if (success && socket_impl_)
     {
-        // Query local endpoint via getsockname (may fail, but remote is always known)
         endpoint local_ep;
-        sockaddr_in local_addr{};
-        socklen_t local_len = sizeof(local_addr);
+        sockaddr_storage local_storage{};
+        socklen_t local_len = sizeof(local_storage);
         if (::getsockname(
-                fd, reinterpret_cast<sockaddr*>(&local_addr), &local_len) == 0)
-            local_ep = from_sockaddr_in(local_addr);
-        // Always cache remote endpoint; local may be default if getsockname failed
+                fd, reinterpret_cast<sockaddr*>(&local_storage),
+                &local_len) == 0)
+            local_ep = from_sockaddr(local_storage);
         static_cast<epoll_socket*>(socket_impl_)
             ->set_endpoints(local_ep, target_endpoint);
     }
@@ -300,17 +301,20 @@ epoll_socket::connect(
 {
     auto& op = conn_;
 
-    sockaddr_in addr = detail::to_sockaddr_in(ep);
+    sockaddr_storage storage{};
+    socklen_t addrlen =
+        detail::to_sockaddr(ep, detail::socket_family(fd_), storage);
     int result =
-        ::connect(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+        ::connect(fd_, reinterpret_cast<sockaddr*>(&storage), addrlen);
 
     if (result == 0)
     {
-        sockaddr_in local_addr{};
-        socklen_t local_len = sizeof(local_addr);
+        sockaddr_storage local_storage{};
+        socklen_t local_len = sizeof(local_storage);
         if (::getsockname(
-                fd_, reinterpret_cast<sockaddr*>(&local_addr), &local_len) == 0)
-            local_endpoint_ = detail::from_sockaddr_in(local_addr);
+                fd_, reinterpret_cast<sockaddr*>(&local_storage),
+                &local_len) == 0)
+            local_endpoint_ = detail::from_sockaddr(local_storage);
         remote_endpoint_ = ep;
     }
 
@@ -545,120 +549,26 @@ epoll_socket::shutdown(tcp_socket::shutdown_type what) noexcept
 }
 
 inline std::error_code
-epoll_socket::set_no_delay(bool value) noexcept
+epoll_socket::set_option(
+    int level, int optname,
+    void const* data, std::size_t size) noexcept
 {
-    int flag = value ? 1 : 0;
-    if (::setsockopt(fd_, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag)) != 0)
+    if (::setsockopt(fd_, level, optname, data,
+            static_cast<socklen_t>(size)) != 0)
         return make_err(errno);
     return {};
-}
-
-inline bool
-epoll_socket::no_delay(std::error_code& ec) const noexcept
-{
-    int flag      = 0;
-    socklen_t len = sizeof(flag);
-    if (::getsockopt(fd_, IPPROTO_TCP, TCP_NODELAY, &flag, &len) != 0)
-    {
-        ec = make_err(errno);
-        return false;
-    }
-    ec = {};
-    return flag != 0;
 }
 
 inline std::error_code
-epoll_socket::set_keep_alive(bool value) noexcept
+epoll_socket::get_option(
+    int level, int optname,
+    void* data, std::size_t* size) const noexcept
 {
-    int flag = value ? 1 : 0;
-    if (::setsockopt(fd_, SOL_SOCKET, SO_KEEPALIVE, &flag, sizeof(flag)) != 0)
+    socklen_t len = static_cast<socklen_t>(*size);
+    if (::getsockopt(fd_, level, optname, data, &len) != 0)
         return make_err(errno);
+    *size = static_cast<std::size_t>(len);
     return {};
-}
-
-inline bool
-epoll_socket::keep_alive(std::error_code& ec) const noexcept
-{
-    int flag      = 0;
-    socklen_t len = sizeof(flag);
-    if (::getsockopt(fd_, SOL_SOCKET, SO_KEEPALIVE, &flag, &len) != 0)
-    {
-        ec = make_err(errno);
-        return false;
-    }
-    ec = {};
-    return flag != 0;
-}
-
-inline std::error_code
-epoll_socket::set_receive_buffer_size(int size) noexcept
-{
-    if (::setsockopt(fd_, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size)) != 0)
-        return make_err(errno);
-    return {};
-}
-
-inline int
-epoll_socket::receive_buffer_size(std::error_code& ec) const noexcept
-{
-    int size      = 0;
-    socklen_t len = sizeof(size);
-    if (::getsockopt(fd_, SOL_SOCKET, SO_RCVBUF, &size, &len) != 0)
-    {
-        ec = make_err(errno);
-        return 0;
-    }
-    ec = {};
-    return size;
-}
-
-inline std::error_code
-epoll_socket::set_send_buffer_size(int size) noexcept
-{
-    if (::setsockopt(fd_, SOL_SOCKET, SO_SNDBUF, &size, sizeof(size)) != 0)
-        return make_err(errno);
-    return {};
-}
-
-inline int
-epoll_socket::send_buffer_size(std::error_code& ec) const noexcept
-{
-    int size      = 0;
-    socklen_t len = sizeof(size);
-    if (::getsockopt(fd_, SOL_SOCKET, SO_SNDBUF, &size, &len) != 0)
-    {
-        ec = make_err(errno);
-        return 0;
-    }
-    ec = {};
-    return size;
-}
-
-inline std::error_code
-epoll_socket::set_linger(bool enabled, int timeout) noexcept
-{
-    if (timeout < 0)
-        return make_err(EINVAL);
-    struct ::linger lg;
-    lg.l_onoff  = enabled ? 1 : 0;
-    lg.l_linger = timeout;
-    if (::setsockopt(fd_, SOL_SOCKET, SO_LINGER, &lg, sizeof(lg)) != 0)
-        return make_err(errno);
-    return {};
-}
-
-inline tcp_socket::linger_options
-epoll_socket::linger(std::error_code& ec) const noexcept
-{
-    struct ::linger lg{};
-    socklen_t len = sizeof(lg);
-    if (::getsockopt(fd_, SOL_SOCKET, SO_LINGER, &lg, &len) != 0)
-    {
-        ec = make_err(errno);
-        return {};
-    }
-    ec = {};
-    return {.enabled = lg.l_onoff != 0, .timeout = lg.l_linger};
 }
 
 inline void
@@ -866,14 +776,22 @@ epoll_socket_service::destroy(io_object::implementation* impl)
 }
 
 inline std::error_code
-epoll_socket_service::open_socket(tcp_socket::implementation& impl)
+epoll_socket_service::open_socket(
+    tcp_socket::implementation& impl,
+    int family, int type, int protocol)
 {
     auto* epoll_impl = static_cast<epoll_socket*>(&impl);
     epoll_impl->close_socket();
 
-    int fd = ::socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    int fd = ::socket(family, type | SOCK_NONBLOCK | SOCK_CLOEXEC, protocol);
     if (fd < 0)
         return make_err(errno);
+
+    if (family == AF_INET6)
+    {
+        int one = 1;
+        ::setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &one, sizeof(one));
+    }
 
     epoll_impl->fd_ = fd;
 

--- a/include/boost/corosio/native/detail/iocp/win_acceptor.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_acceptor.hpp
@@ -127,6 +127,13 @@ public:
     bool is_open() const noexcept override;
     void cancel() noexcept override;
 
+    std::error_code set_option(
+        int level, int optname,
+        void const* data, std::size_t size) noexcept override;
+    std::error_code get_option(
+        int level, int optname,
+        void* data, std::size_t* size) const noexcept override;
+
     win_acceptor_internal* get_internal() const noexcept;
 };
 

--- a/include/boost/corosio/native/detail/iocp/win_acceptor_service.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_acceptor_service.hpp
@@ -53,9 +53,18 @@ public:
 
     void close(io_object::handle& h) override;
 
-    /** Open, bind, and listen on an acceptor socket. */
-    std::error_code
-    open_acceptor(tcp_acceptor::implementation& impl, endpoint ep, int backlog);
+    /** Create the acceptor socket without binding or listening. */
+    std::error_code open_acceptor_socket(
+        tcp_acceptor::implementation& impl,
+        int family, int type, int protocol);
+
+    /** Bind an open acceptor to a local endpoint. */
+    std::error_code bind_acceptor(
+        tcp_acceptor::implementation& impl, endpoint ep);
+
+    /** Start listening for incoming connections. */
+    std::error_code listen_acceptor(
+        tcp_acceptor::implementation& impl, int backlog);
 
     void shutdown() override;
 
@@ -195,20 +204,22 @@ accept_op::do_complete(
 
         op->peer_wrapper->get_internal()->set_socket(op->accepted_socket);
 
-        sockaddr_in local_addr{};
-        int local_len = sizeof(local_addr);
-        sockaddr_in remote_addr{};
-        int remote_len = sizeof(remote_addr);
+        sockaddr_storage local_storage{};
+        int local_len = sizeof(local_storage);
+        sockaddr_storage remote_storage{};
+        int remote_len = sizeof(remote_storage);
 
         endpoint local_ep, remote_ep;
         if (::getsockname(
-                op->accepted_socket, reinterpret_cast<sockaddr*>(&local_addr),
+                op->accepted_socket,
+                reinterpret_cast<sockaddr*>(&local_storage),
                 &local_len) == 0)
-            local_ep = from_sockaddr_in(local_addr);
+            local_ep = from_sockaddr(local_storage);
         if (::getpeername(
-                op->accepted_socket, reinterpret_cast<sockaddr*>(&remote_addr),
+                op->accepted_socket,
+                reinterpret_cast<sockaddr*>(&remote_storage),
                 &remote_len) == 0)
-            remote_ep = from_sockaddr_in(remote_addr);
+            remote_ep = from_sockaddr(remote_storage);
 
         op->peer_wrapper->get_internal()->set_endpoints(local_ep, remote_ep);
         op->accepted_socket = INVALID_SOCKET;
@@ -269,12 +280,12 @@ connect_op::do_complete(
             SO_UPDATE_CONNECT_CONTEXT, nullptr, 0);
 
         endpoint local_ep;
-        sockaddr_in local_addr{};
-        int local_len = sizeof(local_addr);
+        sockaddr_storage local_storage{};
+        int local_len = sizeof(local_storage);
         if (::getsockname(
                 op->internal.native_handle(),
-                reinterpret_cast<sockaddr*>(&local_addr), &local_len) == 0)
-            local_ep = from_sockaddr_in(local_addr);
+                reinterpret_cast<sockaddr*>(&local_storage), &local_len) == 0)
+            local_ep = from_sockaddr(local_storage);
         op->internal.set_endpoints(local_ep, op->target_endpoint);
     }
 
@@ -399,14 +410,31 @@ win_socket_internal::connect(
 
     svc_.work_started();
 
-    sockaddr_in bind_addr{};
-    bind_addr.sin_family      = AF_INET;
-    bind_addr.sin_addr.s_addr = INADDR_ANY;
-    bind_addr.sin_port        = 0;
+    // Ephemeral bind — must match the socket's family, not the endpoint's
+    sockaddr_storage bind_storage{};
+    socklen_t bind_len;
+    if (family_ == AF_INET6)
+    {
+        sockaddr_in6 sa6{};
+        sa6.sin6_family = AF_INET6;
+        sa6.sin6_port   = 0;
+        sa6.sin6_addr   = in6addr_any;
+        std::memcpy(&bind_storage, &sa6, sizeof(sa6));
+        bind_len = sizeof(sa6);
+    }
+    else
+    {
+        sockaddr_in sa4{};
+        sa4.sin_family      = AF_INET;
+        sa4.sin_addr.s_addr = INADDR_ANY;
+        sa4.sin_port        = 0;
+        std::memcpy(&bind_storage, &sa4, sizeof(sa4));
+        bind_len = sizeof(sa4);
+    }
 
     if (::bind(
-            socket_, reinterpret_cast<sockaddr*>(&bind_addr),
-            sizeof(bind_addr)) == SOCKET_ERROR)
+            socket_, reinterpret_cast<sockaddr*>(&bind_storage),
+            bind_len) == SOCKET_ERROR)
     {
         svc_.on_completion(&op, ::WSAGetLastError(), 0);
         return std::noop_coroutine();
@@ -419,11 +447,12 @@ win_socket_internal::connect(
         return std::noop_coroutine();
     }
 
-    sockaddr_in addr = detail::to_sockaddr_in(ep);
+    sockaddr_storage storage{};
+    socklen_t addrlen = detail::to_sockaddr(ep, family_, storage);
 
     BOOL result = connect_ex(
-        socket_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr), nullptr, 0,
-        nullptr, &op);
+        socket_, reinterpret_cast<sockaddr*>(&storage),
+        static_cast<int>(addrlen), nullptr, 0, nullptr, &op);
 
     if (!result)
     {
@@ -591,6 +620,8 @@ win_socket_internal::close_socket() noexcept
         socket_ = INVALID_SOCKET;
     }
 
+    family_ = AF_UNSPEC;
+
     // Clear cached endpoints
     local_endpoint_  = endpoint{};
     remote_endpoint_ = endpoint{};
@@ -679,140 +710,28 @@ win_socket::native_handle() const noexcept
 }
 
 inline std::error_code
-win_socket::set_no_delay(bool value) noexcept
+win_socket::set_option(
+    int level, int optname,
+    void const* data, std::size_t size) noexcept
 {
-    BOOL flag = value ? TRUE : FALSE;
-    if (::setsockopt(
-            internal_->native_handle(), IPPROTO_TCP, TCP_NODELAY,
-            reinterpret_cast<char*>(&flag), sizeof(flag)) != 0)
+    if (::setsockopt(internal_->native_handle(), level, optname,
+            reinterpret_cast<char const*>(data),
+            static_cast<int>(size)) != 0)
         return make_err(WSAGetLastError());
     return {};
-}
-
-inline bool
-win_socket::no_delay(std::error_code& ec) const noexcept
-{
-    BOOL flag = FALSE;
-    int len   = sizeof(flag);
-    if (::getsockopt(
-            internal_->native_handle(), IPPROTO_TCP, TCP_NODELAY,
-            reinterpret_cast<char*>(&flag), &len) != 0)
-    {
-        ec = make_err(WSAGetLastError());
-        return false;
-    }
-    ec = {};
-    return flag != FALSE;
 }
 
 inline std::error_code
-win_socket::set_keep_alive(bool value) noexcept
+win_socket::get_option(
+    int level, int optname,
+    void* data, std::size_t* size) const noexcept
 {
-    BOOL flag = value ? TRUE : FALSE;
-    if (::setsockopt(
-            internal_->native_handle(), SOL_SOCKET, SO_KEEPALIVE,
-            reinterpret_cast<char*>(&flag), sizeof(flag)) != 0)
+    int len = static_cast<int>(*size);
+    if (::getsockopt(internal_->native_handle(), level, optname,
+            reinterpret_cast<char*>(data), &len) != 0)
         return make_err(WSAGetLastError());
+    *size = static_cast<std::size_t>(len);
     return {};
-}
-
-inline bool
-win_socket::keep_alive(std::error_code& ec) const noexcept
-{
-    BOOL flag = FALSE;
-    int len   = sizeof(flag);
-    if (::getsockopt(
-            internal_->native_handle(), SOL_SOCKET, SO_KEEPALIVE,
-            reinterpret_cast<char*>(&flag), &len) != 0)
-    {
-        ec = make_err(WSAGetLastError());
-        return false;
-    }
-    ec = {};
-    return flag != FALSE;
-}
-
-inline std::error_code
-win_socket::set_receive_buffer_size(int size) noexcept
-{
-    if (::setsockopt(
-            internal_->native_handle(), SOL_SOCKET, SO_RCVBUF,
-            reinterpret_cast<char*>(&size), sizeof(size)) != 0)
-        return make_err(WSAGetLastError());
-    return {};
-}
-
-inline int
-win_socket::receive_buffer_size(std::error_code& ec) const noexcept
-{
-    int size = 0;
-    int len  = sizeof(size);
-    if (::getsockopt(
-            internal_->native_handle(), SOL_SOCKET, SO_RCVBUF,
-            reinterpret_cast<char*>(&size), &len) != 0)
-    {
-        ec = make_err(WSAGetLastError());
-        return 0;
-    }
-    ec = {};
-    return size;
-}
-
-inline std::error_code
-win_socket::set_send_buffer_size(int size) noexcept
-{
-    if (::setsockopt(
-            internal_->native_handle(), SOL_SOCKET, SO_SNDBUF,
-            reinterpret_cast<char*>(&size), sizeof(size)) != 0)
-        return make_err(WSAGetLastError());
-    return {};
-}
-
-inline int
-win_socket::send_buffer_size(std::error_code& ec) const noexcept
-{
-    int size = 0;
-    int len  = sizeof(size);
-    if (::getsockopt(
-            internal_->native_handle(), SOL_SOCKET, SO_SNDBUF,
-            reinterpret_cast<char*>(&size), &len) != 0)
-    {
-        ec = make_err(WSAGetLastError());
-        return 0;
-    }
-    ec = {};
-    return size;
-}
-
-inline std::error_code
-win_socket::set_linger(bool enabled, int timeout) noexcept
-{
-    if (timeout < 0 || timeout > 65535)
-        return make_err(WSAEINVAL);
-    struct ::linger lg;
-    lg.l_onoff  = enabled ? 1 : 0;
-    lg.l_linger = static_cast<u_short>(timeout);
-    if (::setsockopt(
-            internal_->native_handle(), SOL_SOCKET, SO_LINGER,
-            reinterpret_cast<char*>(&lg), sizeof(lg)) != 0)
-        return make_err(WSAGetLastError());
-    return {};
-}
-
-inline tcp_socket::linger_options
-win_socket::linger(std::error_code& ec) const noexcept
-{
-    struct ::linger lg{};
-    int len = sizeof(lg);
-    if (::getsockopt(
-            internal_->native_handle(), SOL_SOCKET, SO_LINGER,
-            reinterpret_cast<char*>(&lg), &len) != 0)
-    {
-        ec = make_err(WSAGetLastError());
-        return {};
-    }
-    ec = {};
-    return {.enabled = lg.l_onoff != 0, .timeout = lg.l_linger};
 }
 
 inline endpoint
@@ -941,15 +860,25 @@ win_sockets::unregister_impl(win_socket_internal& impl)
 }
 
 inline std::error_code
-win_sockets::open_socket(win_socket_internal& impl)
+win_sockets::open_socket(
+    win_socket_internal& impl,
+    int family, int type, int protocol)
 {
     impl.close_socket();
 
     SOCKET sock = ::WSASocketW(
-        AF_INET, SOCK_STREAM, IPPROTO_TCP, nullptr, 0, WSA_FLAG_OVERLAPPED);
+        family, type, protocol, nullptr, 0, WSA_FLAG_OVERLAPPED);
 
     if (sock == INVALID_SOCKET)
         return make_err(::WSAGetLastError());
+
+    if (family == AF_INET6)
+    {
+        DWORD one = 1;
+        ::setsockopt(
+            sock, IPPROTO_IPV6, IPV6_V6ONLY,
+            reinterpret_cast<char*>(&one), sizeof(one));
+    }
 
     HANDLE result = ::CreateIoCompletionPort(
         reinterpret_cast<HANDLE>(sock), static_cast<HANDLE>(iocp_), key_io, 0);
@@ -962,6 +891,7 @@ win_sockets::open_socket(win_socket_internal& impl)
     }
 
     impl.socket_ = sock;
+    impl.family_  = family;
     return {};
 }
 
@@ -1057,22 +987,25 @@ win_sockets::unregister_acceptor_impl(win_acceptor_internal& impl)
 }
 
 inline std::error_code
-win_sockets::open_acceptor(
-    win_acceptor_internal& impl, endpoint ep, int backlog)
+win_sockets::open_acceptor_socket(
+    win_acceptor_internal& impl,
+    int family, int type, int protocol)
 {
     impl.close_socket();
 
     SOCKET sock = ::WSASocketW(
-        AF_INET, SOCK_STREAM, IPPROTO_TCP, nullptr, 0, WSA_FLAG_OVERLAPPED);
+        family, type, protocol, nullptr, 0, WSA_FLAG_OVERLAPPED);
 
     if (sock == INVALID_SOCKET)
         return make_err(::WSAGetLastError());
 
-    // Allow address reuse
-    int reuse = 1;
-    ::setsockopt(
-        sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char*>(&reuse),
-        sizeof(reuse));
+    if (family == AF_INET6)
+    {
+        DWORD val = 0; // dual-stack default
+        ::setsockopt(
+            sock, IPPROTO_IPV6, IPV6_V6ONLY,
+            reinterpret_cast<char*>(&val), sizeof(val));
+    }
 
     HANDLE result = ::CreateIoCompletionPort(
         reinterpret_cast<HANDLE>(sock), static_cast<HANDLE>(iocp_), key_io, 0);
@@ -1084,32 +1017,42 @@ win_sockets::open_acceptor(
         return make_err(dwError);
     }
 
-    // Bind to endpoint
-    sockaddr_in addr = detail::to_sockaddr_in(ep);
-    if (::bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) ==
-        SOCKET_ERROR)
-    {
-        DWORD dwError = ::WSAGetLastError();
-        ::closesocket(sock);
-        return make_err(dwError);
-    }
-
-    // Start listening
-    if (::listen(sock, backlog) == SOCKET_ERROR)
-    {
-        DWORD dwError = ::WSAGetLastError();
-        ::closesocket(sock);
-        return make_err(dwError);
-    }
-
     impl.socket_ = sock;
+    return {};
+}
 
-    // Cache the local endpoint (queries OS for ephemeral port if port was 0)
-    sockaddr_in local_addr{};
-    int local_len = sizeof(local_addr);
+inline std::error_code
+win_sockets::bind_acceptor(
+    win_acceptor_internal& impl, endpoint ep)
+{
+    SOCKET sock = impl.socket_;
+
+    sockaddr_storage storage{};
+    socklen_t addrlen = detail::to_sockaddr(ep, storage);
+    if (::bind(
+            sock, reinterpret_cast<sockaddr*>(&storage),
+            static_cast<int>(addrlen)) == SOCKET_ERROR)
+        return make_err(::WSAGetLastError());
+
+    // Cache local endpoint (resolves ephemeral port)
+    sockaddr_storage local_storage{};
+    int local_len = sizeof(local_storage);
     if (::getsockname(
-            sock, reinterpret_cast<sockaddr*>(&local_addr), &local_len) == 0)
-        impl.set_local_endpoint(detail::from_sockaddr_in(local_addr));
+            sock, reinterpret_cast<sockaddr*>(&local_storage),
+            &local_len) == 0)
+        impl.set_local_endpoint(detail::from_sockaddr(local_storage));
+
+    return {};
+}
+
+inline std::error_code
+win_sockets::listen_acceptor(
+    win_acceptor_internal& impl, int backlog)
+{
+    SOCKET sock = impl.socket_;
+
+    if (::listen(sock, backlog) == SOCKET_ERROR)
+        return make_err(::WSAGetLastError());
 
     return {};
 }
@@ -1180,9 +1123,12 @@ win_acceptor_internal::accept(
     // Create wrapper for the peer socket (service owns it)
     auto& peer_wrapper = static_cast<win_socket&>(*svc_.construct());
 
-    // Create the accepted socket
+    // Derive AF from the listening socket's cached local endpoint
+    int af = local_endpoint_.is_v6() ? AF_INET6 : AF_INET;
+
+    // Create the accepted socket with matching address family
     SOCKET accepted = ::WSASocketW(
-        AF_INET, SOCK_STREAM, IPPROTO_TCP, nullptr, 0, WSA_FLAG_OVERLAPPED);
+        af, SOCK_STREAM, IPPROTO_TCP, nullptr, 0, WSA_FLAG_OVERLAPPED);
 
     if (accepted == INVALID_SOCKET)
     {
@@ -1219,11 +1165,15 @@ win_acceptor_internal::accept(
         return std::noop_coroutine();
     }
 
+    // AcceptEx address buffer sizes must match the socket's address family
+    DWORD addr_size =
+        static_cast<DWORD>(
+            (af == AF_INET6 ? sizeof(sockaddr_in6) : sizeof(sockaddr_in)) + 16);
     DWORD bytes_received = 0;
 
     BOOL ok = accept_ex(
-        socket_, accepted, op.addr_buf, 0, sizeof(sockaddr_in) + 16,
-        sizeof(sockaddr_in) + 16, &bytes_received, &op);
+        socket_, accepted, op.addr_buf, 0, addr_size,
+        addr_size, &bytes_received, &op);
 
     if (!ok)
     {
@@ -1315,6 +1265,31 @@ win_acceptor::cancel() noexcept
     internal_->cancel();
 }
 
+inline std::error_code
+win_acceptor::set_option(
+    int level, int optname,
+    void const* data, std::size_t size) noexcept
+{
+    if (::setsockopt(internal_->native_handle(), level, optname,
+            reinterpret_cast<char const*>(data),
+            static_cast<int>(size)) != 0)
+        return make_err(WSAGetLastError());
+    return {};
+}
+
+inline std::error_code
+win_acceptor::get_option(
+    int level, int optname,
+    void* data, std::size_t* size) const noexcept
+{
+    int len = static_cast<int>(*size);
+    if (::getsockopt(internal_->native_handle(), level, optname,
+            reinterpret_cast<char*>(data), &len) != 0)
+        return make_err(WSAGetLastError());
+    *size = static_cast<std::size_t>(len);
+    return {};
+}
+
 inline win_acceptor_internal*
 win_acceptor::get_internal() const noexcept
 {
@@ -1369,11 +1344,29 @@ win_acceptor_service::close(io_object::handle& h)
 }
 
 inline std::error_code
-win_acceptor_service::open_acceptor(
-    tcp_acceptor::implementation& impl, endpoint ep, int backlog)
+win_acceptor_service::open_acceptor_socket(
+    tcp_acceptor::implementation& impl,
+    int family, int type, int protocol)
 {
     auto& wrapper = static_cast<win_acceptor&>(impl);
-    return svc_.open_acceptor(*wrapper.get_internal(), ep, backlog);
+    return svc_.open_acceptor_socket(
+        *wrapper.get_internal(), family, type, protocol);
+}
+
+inline std::error_code
+win_acceptor_service::bind_acceptor(
+    tcp_acceptor::implementation& impl, endpoint ep)
+{
+    auto& wrapper = static_cast<win_acceptor&>(impl);
+    return svc_.bind_acceptor(*wrapper.get_internal(), ep);
+}
+
+inline std::error_code
+win_acceptor_service::listen_acceptor(
+    tcp_acceptor::implementation& impl, int backlog)
+{
+    auto& wrapper = static_cast<win_acceptor&>(impl);
+    return svc_.listen_acceptor(*wrapper.get_internal(), backlog);
 }
 
 inline void

--- a/include/boost/corosio/native/detail/iocp/win_socket.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_socket.hpp
@@ -111,6 +111,7 @@ class win_socket_internal
     read_op rd_;
     write_op wr_;
     SOCKET socket_ = INVALID_SOCKET;
+    int family_    = AF_UNSPEC;
 
 public:
     explicit win_socket_internal(win_sockets& svc) noexcept;
@@ -198,21 +199,12 @@ public:
 
     native_handle_type native_handle() const noexcept override;
 
-    std::error_code set_no_delay(bool value) noexcept override;
-    bool no_delay(std::error_code& ec) const noexcept override;
-
-    std::error_code set_keep_alive(bool value) noexcept override;
-    bool keep_alive(std::error_code& ec) const noexcept override;
-
-    std::error_code set_receive_buffer_size(int size) noexcept override;
-    int receive_buffer_size(std::error_code& ec) const noexcept override;
-
-    std::error_code set_send_buffer_size(int size) noexcept override;
-    int send_buffer_size(std::error_code& ec) const noexcept override;
-
-    std::error_code set_linger(bool enabled, int timeout) noexcept override;
-    tcp_socket::linger_options
-    linger(std::error_code& ec) const noexcept override;
+    std::error_code set_option(
+        int level, int optname,
+        void const* data, std::size_t size) noexcept override;
+    std::error_code get_option(
+        int level, int optname,
+        void* data, std::size_t* size) const noexcept override;
 
     endpoint local_endpoint() const noexcept override;
     endpoint remote_endpoint() const noexcept override;

--- a/include/boost/corosio/native/detail/iocp/win_sockets.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_sockets.hpp
@@ -95,7 +95,9 @@ public:
         @param impl The socket implementation internal to initialize.
         @return Error code, or success.
     */
-    std::error_code open_socket(win_socket_internal& impl);
+    std::error_code open_socket(
+        win_socket_internal& impl,
+        int family, int type, int protocol);
 
     /** Destroy an acceptor implementation wrapper.
         Removes from tracking list and deletes.
@@ -107,15 +109,39 @@ public:
     */
     void unregister_acceptor_impl(win_acceptor_internal& impl);
 
-    /** Create, bind, and listen on an acceptor socket.
+    /** Create an acceptor socket without binding or listening.
+
+        Creates a socket and associates it with the IOCP.
+        For IPv6, dual-stack is enabled by default.
+        Does not set SO_REUSEADDR.
 
         @param impl The acceptor implementation internal to initialize.
+        @param family Address family (e.g. `AF_INET`, `AF_INET6`).
+        @param type Socket type (e.g. `SOCK_STREAM`).
+        @param protocol Protocol number (e.g. `IPPROTO_TCP`).
+        @return Error code, or success.
+    */
+    std::error_code open_acceptor_socket(
+        win_acceptor_internal& impl,
+        int family, int type, int protocol);
+
+    /** Bind an open acceptor to a local endpoint.
+
+        @param impl The acceptor implementation internal.
         @param ep The local endpoint to bind to.
+        @return Error code, or success.
+    */
+    std::error_code bind_acceptor(
+        win_acceptor_internal& impl, endpoint ep);
+
+    /** Start listening for incoming connections.
+
+        @param impl The acceptor implementation internal.
         @param backlog The listen backlog.
         @return Error code, or success.
     */
-    std::error_code
-    open_acceptor(win_acceptor_internal& impl, endpoint ep, int backlog);
+    std::error_code listen_acceptor(
+        win_acceptor_internal& impl, int backlog);
 
     /** Return the IOCP handle. */
     void* native_handle() const noexcept;

--- a/include/boost/corosio/native/detail/kqueue/kqueue_acceptor.hpp
+++ b/include/boost/corosio/native/detail/kqueue/kqueue_acceptor.hpp
@@ -81,6 +81,13 @@ public:
     /** Cancel any pending accept operation. */
     void cancel() noexcept override;
 
+    std::error_code set_option(
+        int level, int optname,
+        void const* data, std::size_t size) noexcept override;
+    std::error_code get_option(
+        int level, int optname,
+        void* data, std::size_t* size) const noexcept override;
+
     /** Cancel a specific pending operation.
 
         @param op The operation to cancel.

--- a/include/boost/corosio/native/detail/kqueue/kqueue_acceptor_service.hpp
+++ b/include/boost/corosio/native/detail/kqueue/kqueue_acceptor_service.hpp
@@ -77,8 +77,13 @@ public:
     io_object::implementation* construct() override;
     void destroy(io_object::implementation*) override;
     void close(io_object::handle&) override;
-    std::error_code open_acceptor(
-        tcp_acceptor::implementation& impl, endpoint ep, int backlog) override;
+    std::error_code open_acceptor_socket(
+        tcp_acceptor::implementation& impl,
+        int family, int type, int protocol) override;
+    std::error_code bind_acceptor(
+        tcp_acceptor::implementation& impl, endpoint ep) override;
+    std::error_code listen_acceptor(
+        tcp_acceptor::implementation& impl, int backlog) override;
 
     kqueue_scheduler& scheduler() const noexcept
     {
@@ -166,22 +171,22 @@ kqueue_accept_op::operator()()
                 }
                 else
                 {
-                    sockaddr_in local_addr{};
-                    socklen_t local_len = sizeof(local_addr);
-                    sockaddr_in remote_addr{};
-                    socklen_t remote_len = sizeof(remote_addr);
+                    sockaddr_storage local_storage{};
+                    socklen_t local_len = sizeof(local_storage);
+                    sockaddr_storage remote_storage{};
+                    socklen_t remote_len = sizeof(remote_storage);
 
                     endpoint local_ep, remote_ep;
                     if (::getsockname(
                             accepted_fd,
-                            reinterpret_cast<sockaddr*>(&local_addr),
+                            reinterpret_cast<sockaddr*>(&local_storage),
                             &local_len) == 0)
-                        local_ep = from_sockaddr_in(local_addr);
+                        local_ep = from_sockaddr(local_storage);
                     if (::getpeername(
                             accepted_fd,
-                            reinterpret_cast<sockaddr*>(&remote_addr),
+                            reinterpret_cast<sockaddr*>(&remote_storage),
                             &remote_len) == 0)
-                        remote_ep = from_sockaddr_in(remote_addr);
+                        remote_ep = from_sockaddr(remote_storage);
 
                     impl.set_endpoints(local_ep, remote_ep);
 
@@ -261,11 +266,12 @@ kqueue_acceptor::accept(
     op.fd       = fd_;
     op.start(token, this);
 
-    sockaddr_in addr{};
-    socklen_t addrlen = sizeof(addr);
+    sockaddr_storage peer_storage{};
+    socklen_t addrlen = sizeof(peer_storage);
 
     // FreeBSD: Can use accept4(fd_, addr, addrlen, SOCK_NONBLOCK | SOCK_CLOEXEC)
-    int accepted = ::accept(fd_, reinterpret_cast<sockaddr*>(&addr), &addrlen);
+    int accepted =
+        ::accept(fd_, reinterpret_cast<sockaddr*>(&peer_storage), &addrlen);
 
     if (accepted >= 0)
     {
@@ -325,15 +331,16 @@ kqueue_acceptor::accept(
                 }
                 else
                 {
-                    sockaddr_in local_addr{};
-                    socklen_t local_len = sizeof(local_addr);
+                    sockaddr_storage local_storage{};
+                    socklen_t local_len = sizeof(local_storage);
                     endpoint local_ep;
                     if (::getsockname(
                             accepted,
-                            reinterpret_cast<sockaddr*>(&local_addr),
+                            reinterpret_cast<sockaddr*>(&local_storage),
                             &local_len) == 0)
-                        local_ep = from_sockaddr_in(local_addr);
-                    impl.set_endpoints(local_ep, from_sockaddr_in(addr));
+                        local_ep = from_sockaddr(local_storage);
+                    impl.set_endpoints(
+                        local_ep, from_sockaddr(peer_storage));
                     if (ec)
                         *ec = {};
                     if (impl_out)
@@ -560,16 +567,41 @@ kqueue_acceptor_service::close(io_object::handle& h)
 }
 
 inline std::error_code
-kqueue_acceptor_service::open_acceptor(
-    tcp_acceptor::implementation& impl, endpoint ep, int backlog)
+kqueue_acceptor::set_option(
+    int level, int optname,
+    void const* data, std::size_t size) noexcept
+{
+    if (::setsockopt(fd_, level, optname, data,
+            static_cast<socklen_t>(size)) != 0)
+        return make_err(errno);
+    return {};
+}
+
+inline std::error_code
+kqueue_acceptor::get_option(
+    int level, int optname,
+    void* data, std::size_t* size) const noexcept
+{
+    socklen_t len = static_cast<socklen_t>(*size);
+    if (::getsockopt(fd_, level, optname, data, &len) != 0)
+        return make_err(errno);
+    *size = static_cast<std::size_t>(len);
+    return {};
+}
+
+inline std::error_code
+kqueue_acceptor_service::open_acceptor_socket(
+    tcp_acceptor::implementation& impl,
+    int family, int type, int protocol)
 {
     auto* kq_impl = static_cast<kqueue_acceptor*>(&impl);
     kq_impl->close_socket();
 
-    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    int fd = ::socket(family, type, protocol);
     if (fd < 0)
         return make_err(errno);
 
+    // Set non-blocking and close-on-exec
     int flags = ::fcntl(fd, F_GETFL, 0);
     if (flags == -1)
     {
@@ -590,38 +622,63 @@ kqueue_acceptor_service::open_acceptor(
         return make_err(errn);
     }
 
-    int reuse = 1;
-    (void)::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
-
-    sockaddr_in addr = detail::to_sockaddr_in(ep);
-    if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0)
+    if (family == AF_INET6)
     {
-        int errn = errno;
-        ::close(fd);
-        return make_err(errn);
+        int val = 0; // dual-stack default
+        ::setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &val, sizeof(val));
     }
 
-    if (::listen(fd, backlog) < 0)
-    {
-        int errn = errno;
-        ::close(fd);
-        return make_err(errn);
-    }
+    // SO_NOSIGPIPE on macOS (where MSG_NOSIGNAL doesn't exist)
+#ifdef SO_NOSIGPIPE
+    int nosig = 1;
+    ::setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &nosig, sizeof(nosig));
+#endif
 
     kq_impl->fd_ = fd;
 
+    // Set up descriptor state but do NOT register with kqueue yet
     kq_impl->desc_state_.fd = fd;
     {
         std::lock_guard lock(kq_impl->desc_state_.mutex);
         kq_impl->desc_state_.read_op = nullptr;
     }
-    scheduler().register_descriptor(fd, &kq_impl->desc_state_);
 
-    sockaddr_in local_addr{};
-    socklen_t local_len = sizeof(local_addr);
-    if (::getsockname(
-            fd, reinterpret_cast<sockaddr*>(&local_addr), &local_len) == 0)
-        kq_impl->set_local_endpoint(detail::from_sockaddr_in(local_addr));
+    return {};
+}
+
+inline std::error_code
+kqueue_acceptor_service::bind_acceptor(
+    tcp_acceptor::implementation& impl, endpoint ep)
+{
+    auto* kq_impl = static_cast<kqueue_acceptor*>(&impl);
+    int fd = kq_impl->fd_;
+
+    sockaddr_storage storage{};
+    socklen_t addrlen = detail::to_sockaddr(ep, storage);
+    if (::bind(fd, reinterpret_cast<sockaddr*>(&storage), addrlen) < 0)
+        return make_err(errno);
+
+    // Cache local endpoint (resolves ephemeral port)
+    sockaddr_storage local{};
+    socklen_t local_len = sizeof(local);
+    if (::getsockname(fd, reinterpret_cast<sockaddr*>(&local), &local_len) == 0)
+        kq_impl->set_local_endpoint(detail::from_sockaddr(local));
+
+    return {};
+}
+
+inline std::error_code
+kqueue_acceptor_service::listen_acceptor(
+    tcp_acceptor::implementation& impl, int backlog)
+{
+    auto* kq_impl = static_cast<kqueue_acceptor*>(&impl);
+    int fd = kq_impl->fd_;
+
+    if (::listen(fd, backlog) < 0)
+        return make_err(errno);
+
+    // Register fd with kqueue
+    scheduler().register_descriptor(fd, &kq_impl->desc_state_);
 
     return {};
 }

--- a/include/boost/corosio/native/detail/kqueue/kqueue_socket.hpp
+++ b/include/boost/corosio/native/detail/kqueue/kqueue_socket.hpp
@@ -70,21 +70,12 @@ public:
     }
 
     // Socket options
-    std::error_code set_no_delay(bool value) noexcept override;
-    bool no_delay(std::error_code& ec) const noexcept override;
-
-    std::error_code set_keep_alive(bool value) noexcept override;
-    bool keep_alive(std::error_code& ec) const noexcept override;
-
-    std::error_code set_receive_buffer_size(int size) noexcept override;
-    int receive_buffer_size(std::error_code& ec) const noexcept override;
-
-    std::error_code set_send_buffer_size(int size) noexcept override;
-    int send_buffer_size(std::error_code& ec) const noexcept override;
-
-    std::error_code set_linger(bool enabled, int timeout) noexcept override;
-    tcp_socket::linger_options
-    linger(std::error_code& ec) const noexcept override;
+    std::error_code set_option(
+        int level, int optname,
+        void const* data, std::size_t size) noexcept override;
+    std::error_code get_option(
+        int level, int optname,
+        void* data, std::size_t* size) const noexcept override;
 
     endpoint local_endpoint() const noexcept override
     {

--- a/include/boost/corosio/native/detail/kqueue/kqueue_socket_service.hpp
+++ b/include/boost/corosio/native/detail/kqueue/kqueue_socket_service.hpp
@@ -154,7 +154,9 @@ public:
     io_object::implementation* construct() override;
     void destroy(io_object::implementation*) override;
     void close(io_object::handle&) override;
-    std::error_code open_socket(tcp_socket::implementation& impl) override;
+    std::error_code
+    open_socket(tcp_socket::implementation& impl,
+                int family, int type, int protocol) override;
 
     kqueue_scheduler& scheduler() const noexcept
     {
@@ -248,14 +250,13 @@ kqueue_connect_op::operator()()
     // Cache endpoints on successful connect
     if (success && socket_impl_)
     {
-        // Query local endpoint via getsockname (may fail, but remote is always known)
         endpoint local_ep;
-        sockaddr_in local_addr{};
-        socklen_t local_len = sizeof(local_addr);
+        sockaddr_storage local_storage{};
+        socklen_t local_len = sizeof(local_storage);
         if (::getsockname(
-                fd, reinterpret_cast<sockaddr*>(&local_addr), &local_len) == 0)
-            local_ep = from_sockaddr_in(local_addr);
-        // Always cache remote endpoint; local may be default if getsockname failed
+                fd, reinterpret_cast<sockaddr*>(&local_storage),
+                &local_len) == 0)
+            local_ep = from_sockaddr(local_storage);
         static_cast<kqueue_socket*>(socket_impl_)
             ->set_endpoints(local_ep, target_endpoint);
     }
@@ -297,18 +298,21 @@ kqueue_socket::connect(
 {
     auto& op = conn_;
 
-    sockaddr_in addr = detail::to_sockaddr_in(ep);
+    sockaddr_storage storage{};
+    socklen_t addrlen =
+        detail::to_sockaddr(ep, detail::socket_family(fd_), storage);
     int result =
-        ::connect(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+        ::connect(fd_, reinterpret_cast<sockaddr*>(&storage), addrlen);
 
     // Cache endpoints on sync success
     if (result == 0)
     {
-        sockaddr_in local_addr{};
-        socklen_t local_len = sizeof(local_addr);
+        sockaddr_storage local_storage{};
+        socklen_t local_len = sizeof(local_storage);
         if (::getsockname(
-                fd_, reinterpret_cast<sockaddr*>(&local_addr), &local_len) == 0)
-            local_endpoint_ = detail::from_sockaddr_in(local_addr);
+                fd_, reinterpret_cast<sockaddr*>(&local_storage),
+                &local_len) == 0)
+            local_endpoint_ = detail::from_sockaddr(local_storage);
         remote_endpoint_ = ep;
     }
 
@@ -592,121 +596,30 @@ kqueue_socket::shutdown(tcp_socket::shutdown_type what) noexcept
 }
 
 inline std::error_code
-kqueue_socket::set_no_delay(bool value) noexcept
+kqueue_socket::set_option(
+    int level, int optname,
+    void const* data, std::size_t size) noexcept
 {
-    int flag = value ? 1 : 0;
-    if (::setsockopt(fd_, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag)) != 0)
+    if (::setsockopt(fd_, level, optname, data,
+            static_cast<socklen_t>(size)) != 0)
         return make_err(errno);
+    if (level == SOL_SOCKET && optname == SO_LINGER &&
+        size >= sizeof(struct ::linger))
+        user_set_linger_ =
+            static_cast<struct ::linger const*>(data)->l_onoff != 0;
     return {};
-}
-
-inline bool
-kqueue_socket::no_delay(std::error_code& ec) const noexcept
-{
-    int flag      = 0;
-    socklen_t len = sizeof(flag);
-    if (::getsockopt(fd_, IPPROTO_TCP, TCP_NODELAY, &flag, &len) != 0)
-    {
-        ec = make_err(errno);
-        return false;
-    }
-    ec = {};
-    return flag != 0;
 }
 
 inline std::error_code
-kqueue_socket::set_keep_alive(bool value) noexcept
+kqueue_socket::get_option(
+    int level, int optname,
+    void* data, std::size_t* size) const noexcept
 {
-    int flag = value ? 1 : 0;
-    if (::setsockopt(fd_, SOL_SOCKET, SO_KEEPALIVE, &flag, sizeof(flag)) != 0)
+    socklen_t len = static_cast<socklen_t>(*size);
+    if (::getsockopt(fd_, level, optname, data, &len) != 0)
         return make_err(errno);
+    *size = static_cast<std::size_t>(len);
     return {};
-}
-
-inline bool
-kqueue_socket::keep_alive(std::error_code& ec) const noexcept
-{
-    int flag      = 0;
-    socklen_t len = sizeof(flag);
-    if (::getsockopt(fd_, SOL_SOCKET, SO_KEEPALIVE, &flag, &len) != 0)
-    {
-        ec = make_err(errno);
-        return false;
-    }
-    ec = {};
-    return flag != 0;
-}
-
-inline std::error_code
-kqueue_socket::set_receive_buffer_size(int size) noexcept
-{
-    if (::setsockopt(fd_, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size)) != 0)
-        return make_err(errno);
-    return {};
-}
-
-inline int
-kqueue_socket::receive_buffer_size(std::error_code& ec) const noexcept
-{
-    int size      = 0;
-    socklen_t len = sizeof(size);
-    if (::getsockopt(fd_, SOL_SOCKET, SO_RCVBUF, &size, &len) != 0)
-    {
-        ec = make_err(errno);
-        return 0;
-    }
-    ec = {};
-    return size;
-}
-
-inline std::error_code
-kqueue_socket::set_send_buffer_size(int size) noexcept
-{
-    if (::setsockopt(fd_, SOL_SOCKET, SO_SNDBUF, &size, sizeof(size)) != 0)
-        return make_err(errno);
-    return {};
-}
-
-inline int
-kqueue_socket::send_buffer_size(std::error_code& ec) const noexcept
-{
-    int size      = 0;
-    socklen_t len = sizeof(size);
-    if (::getsockopt(fd_, SOL_SOCKET, SO_SNDBUF, &size, &len) != 0)
-    {
-        ec = make_err(errno);
-        return 0;
-    }
-    ec = {};
-    return size;
-}
-
-inline std::error_code
-kqueue_socket::set_linger(bool enabled, int timeout) noexcept
-{
-    if (timeout < 0)
-        return make_err(EINVAL);
-    struct ::linger lg;
-    lg.l_onoff  = enabled ? 1 : 0;
-    lg.l_linger = timeout;
-    if (::setsockopt(fd_, SOL_SOCKET, SO_LINGER, &lg, sizeof(lg)) != 0)
-        return make_err(errno);
-    user_set_linger_ = true;
-    return {};
-}
-
-inline tcp_socket::linger_options
-kqueue_socket::linger(std::error_code& ec) const noexcept
-{
-    struct ::linger lg{};
-    socklen_t len = sizeof(lg);
-    if (::getsockopt(fd_, SOL_SOCKET, SO_LINGER, &lg, &len) != 0)
-    {
-        ec = make_err(errno);
-        return {};
-    }
-    ec = {};
-    return {.enabled = lg.l_onoff != 0, .timeout = lg.l_linger};
 }
 
 inline void
@@ -935,15 +848,23 @@ kqueue_socket_service::destroy(io_object::implementation* impl)
 }
 
 inline std::error_code
-kqueue_socket_service::open_socket(tcp_socket::implementation& impl)
+kqueue_socket_service::open_socket(
+    tcp_socket::implementation& impl,
+    int family, int type, int protocol)
 {
     auto* kq_impl = static_cast<kqueue_socket*>(&impl);
     kq_impl->close_socket();
 
-    // FreeBSD: Can use socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0)
-    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    int fd = ::socket(family, type, protocol);
     if (fd < 0)
         return make_err(errno);
+
+    if (family == AF_INET6)
+    {
+        int v6only = 1;
+        ::setsockopt(
+            fd, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only));
+    }
 
     // Set non-blocking
     int flags = ::fcntl(fd, F_GETFL, 0);

--- a/include/boost/corosio/native/detail/select/select_acceptor.hpp
+++ b/include/boost/corosio/native/detail/select/select_acceptor.hpp
@@ -58,6 +58,13 @@ public:
         return fd_ >= 0;
     }
     void cancel() noexcept override;
+
+    std::error_code set_option(
+        int level, int optname,
+        void const* data, std::size_t size) noexcept override;
+    std::error_code get_option(
+        int level, int optname,
+        void* data, std::size_t* size) const noexcept override;
     void cancel_single_op(select_op& op) noexcept;
     void close_socket() noexcept;
     void set_local_endpoint(endpoint ep) noexcept

--- a/include/boost/corosio/native/detail/select/select_acceptor_service.hpp
+++ b/include/boost/corosio/native/detail/select/select_acceptor_service.hpp
@@ -73,8 +73,13 @@ public:
     io_object::implementation* construct() override;
     void destroy(io_object::implementation*) override;
     void close(io_object::handle&) override;
-    std::error_code open_acceptor(
-        tcp_acceptor::implementation& impl, endpoint ep, int backlog) override;
+    std::error_code open_acceptor_socket(
+        tcp_acceptor::implementation& impl,
+        int family, int type, int protocol) override;
+    std::error_code bind_acceptor(
+        tcp_acceptor::implementation& impl, endpoint ep) override;
+    std::error_code listen_acceptor(
+        tcp_acceptor::implementation& impl, int backlog) override;
 
     select_scheduler& scheduler() const noexcept
     {
@@ -131,20 +136,22 @@ select_accept_op::operator()()
                     static_cast<select_socket&>(*socket_svc->construct());
                 impl.set_socket(accepted_fd);
 
-                sockaddr_in local_addr{};
-                socklen_t local_len = sizeof(local_addr);
-                sockaddr_in remote_addr{};
-                socklen_t remote_len = sizeof(remote_addr);
+                sockaddr_storage local_storage{};
+                socklen_t local_len = sizeof(local_storage);
+                sockaddr_storage remote_storage{};
+                socklen_t remote_len = sizeof(remote_storage);
 
                 endpoint local_ep, remote_ep;
                 if (::getsockname(
-                        accepted_fd, reinterpret_cast<sockaddr*>(&local_addr),
+                        accepted_fd,
+                        reinterpret_cast<sockaddr*>(&local_storage),
                         &local_len) == 0)
-                    local_ep = from_sockaddr_in(local_addr);
+                    local_ep = from_sockaddr(local_storage);
                 if (::getpeername(
-                        accepted_fd, reinterpret_cast<sockaddr*>(&remote_addr),
+                        accepted_fd,
+                        reinterpret_cast<sockaddr*>(&remote_storage),
                         &remote_len) == 0)
-                    remote_ep = from_sockaddr_in(remote_addr);
+                    remote_ep = from_sockaddr(remote_storage);
 
                 impl.set_endpoints(local_ep, remote_ep);
 
@@ -223,9 +230,10 @@ select_acceptor::accept(
     op.fd       = fd_;
     op.start(token, this);
 
-    sockaddr_in addr{};
-    socklen_t addrlen = sizeof(addr);
-    int accepted = ::accept(fd_, reinterpret_cast<sockaddr*>(&addr), &addrlen);
+    sockaddr_storage peer_storage{};
+    socklen_t addrlen = sizeof(peer_storage);
+    int accepted =
+        ::accept(fd_, reinterpret_cast<sockaddr*>(&peer_storage), &addrlen);
 
     if (accepted >= 0)
     {
@@ -454,13 +462,37 @@ select_acceptor_service::close(io_object::handle& h)
 }
 
 inline std::error_code
-select_acceptor_service::open_acceptor(
-    tcp_acceptor::implementation& impl, endpoint ep, int backlog)
+select_acceptor::set_option(
+    int level, int optname,
+    void const* data, std::size_t size) noexcept
+{
+    if (::setsockopt(fd_, level, optname, data,
+            static_cast<socklen_t>(size)) != 0)
+        return make_err(errno);
+    return {};
+}
+
+inline std::error_code
+select_acceptor::get_option(
+    int level, int optname,
+    void* data, std::size_t* size) const noexcept
+{
+    socklen_t len = static_cast<socklen_t>(*size);
+    if (::getsockopt(fd_, level, optname, data, &len) != 0)
+        return make_err(errno);
+    *size = static_cast<std::size_t>(len);
+    return {};
+}
+
+inline std::error_code
+select_acceptor_service::open_acceptor_socket(
+    tcp_acceptor::implementation& impl,
+    int family, int type, int protocol)
 {
     auto* select_impl = static_cast<select_acceptor*>(&impl);
     select_impl->close_socket();
 
-    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    int fd = ::socket(family, type, protocol);
     if (fd < 0)
         return make_err(errno);
 
@@ -485,39 +517,52 @@ select_acceptor_service::open_acceptor(
         return make_err(errn);
     }
 
-    // Check fd is within select() limits
     if (fd >= FD_SETSIZE)
     {
         ::close(fd);
         return make_err(EMFILE);
     }
 
-    int reuse = 1;
-    ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
-
-    sockaddr_in addr = detail::to_sockaddr_in(ep);
-    if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0)
+    if (family == AF_INET6)
     {
-        int errn = errno;
-        ::close(fd);
-        return make_err(errn);
-    }
-
-    if (::listen(fd, backlog) < 0)
-    {
-        int errn = errno;
-        ::close(fd);
-        return make_err(errn);
+        int val = 0; // dual-stack default
+        ::setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &val, sizeof(val));
     }
 
     select_impl->fd_ = fd;
+    return {};
+}
 
-    // Cache the local endpoint (queries OS for ephemeral port if port was 0)
-    sockaddr_in local_addr{};
-    socklen_t local_len = sizeof(local_addr);
-    if (::getsockname(
-            fd, reinterpret_cast<sockaddr*>(&local_addr), &local_len) == 0)
-        select_impl->set_local_endpoint(detail::from_sockaddr_in(local_addr));
+inline std::error_code
+select_acceptor_service::bind_acceptor(
+    tcp_acceptor::implementation& impl, endpoint ep)
+{
+    auto* select_impl = static_cast<select_acceptor*>(&impl);
+    int fd = select_impl->fd_;
+
+    sockaddr_storage storage{};
+    socklen_t addrlen = detail::to_sockaddr(ep, storage);
+    if (::bind(fd, reinterpret_cast<sockaddr*>(&storage), addrlen) < 0)
+        return make_err(errno);
+
+    // Cache local endpoint (resolves ephemeral port)
+    sockaddr_storage local{};
+    socklen_t local_len = sizeof(local);
+    if (::getsockname(fd, reinterpret_cast<sockaddr*>(&local), &local_len) == 0)
+        select_impl->set_local_endpoint(detail::from_sockaddr(local));
+
+    return {};
+}
+
+inline std::error_code
+select_acceptor_service::listen_acceptor(
+    tcp_acceptor::implementation& impl, int backlog)
+{
+    auto* select_impl = static_cast<select_acceptor*>(&impl);
+    int fd = select_impl->fd_;
+
+    if (::listen(fd, backlog) < 0)
+        return make_err(errno);
 
     return {};
 }

--- a/include/boost/corosio/native/detail/select/select_op.hpp
+++ b/include/boost/corosio/native/detail/select/select_op.hpp
@@ -339,12 +339,13 @@ struct select_accept_op final : select_op
 
     void perform_io() noexcept override
     {
-        sockaddr_in addr{};
-        socklen_t addrlen = sizeof(addr);
+        sockaddr_storage addr_storage{};
+        socklen_t addrlen = sizeof(addr_storage);
 
         // Note: select backend uses accept() + fcntl instead of accept4()
         // for broader POSIX compatibility
-        int new_fd = ::accept(fd, reinterpret_cast<sockaddr*>(&addr), &addrlen);
+        int new_fd =
+            ::accept(fd, reinterpret_cast<sockaddr*>(&addr_storage), &addrlen);
 
         if (new_fd >= 0)
         {

--- a/include/boost/corosio/native/detail/select/select_socket.hpp
+++ b/include/boost/corosio/native/detail/select/select_socket.hpp
@@ -67,22 +67,12 @@ public:
         return fd_;
     }
 
-    // Socket options
-    std::error_code set_no_delay(bool value) noexcept override;
-    bool no_delay(std::error_code& ec) const noexcept override;
-
-    std::error_code set_keep_alive(bool value) noexcept override;
-    bool keep_alive(std::error_code& ec) const noexcept override;
-
-    std::error_code set_receive_buffer_size(int size) noexcept override;
-    int receive_buffer_size(std::error_code& ec) const noexcept override;
-
-    std::error_code set_send_buffer_size(int size) noexcept override;
-    int send_buffer_size(std::error_code& ec) const noexcept override;
-
-    std::error_code set_linger(bool enabled, int timeout) noexcept override;
-    tcp_socket::linger_options
-    linger(std::error_code& ec) const noexcept override;
+    std::error_code set_option(
+        int level, int optname,
+        void const* data, std::size_t size) noexcept override;
+    std::error_code get_option(
+        int level, int optname,
+        void* data, std::size_t* size) const noexcept override;
 
     endpoint local_endpoint() const noexcept override
     {

--- a/include/boost/corosio/native/detail/select/select_socket_service.hpp
+++ b/include/boost/corosio/native/detail/select/select_socket_service.hpp
@@ -115,7 +115,9 @@ public:
     io_object::implementation* construct() override;
     void destroy(io_object::implementation*) override;
     void close(io_object::handle&) override;
-    std::error_code open_socket(tcp_socket::implementation& impl) override;
+    std::error_code
+    open_socket(tcp_socket::implementation& impl,
+                int family, int type, int protocol) override;
 
     select_scheduler& scheduler() const noexcept
     {
@@ -175,14 +177,13 @@ select_connect_op::operator()()
     // Cache endpoints on successful connect
     if (success && socket_impl_)
     {
-        // Query local endpoint via getsockname (may fail, but remote is always known)
         endpoint local_ep;
-        sockaddr_in local_addr{};
-        socklen_t local_len = sizeof(local_addr);
+        sockaddr_storage local_storage{};
+        socklen_t local_len = sizeof(local_storage);
         if (::getsockname(
-                fd, reinterpret_cast<sockaddr*>(&local_addr), &local_len) == 0)
-            local_ep = from_sockaddr_in(local_addr);
-        // Always cache remote endpoint; local may be default if getsockname failed
+                fd, reinterpret_cast<sockaddr*>(&local_storage),
+                &local_len) == 0)
+            local_ep = from_sockaddr(local_storage);
         static_cast<select_socket*>(socket_impl_)
             ->set_endpoints(local_ep, target_endpoint);
     }
@@ -229,18 +230,21 @@ select_socket::connect(
     op.target_endpoint = ep; // Store target for endpoint caching
     op.start(token, this);
 
-    sockaddr_in addr = detail::to_sockaddr_in(ep);
+    sockaddr_storage storage{};
+    socklen_t addrlen =
+        detail::to_sockaddr(ep, detail::socket_family(fd_), storage);
     int result =
-        ::connect(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+        ::connect(fd_, reinterpret_cast<sockaddr*>(&storage), addrlen);
 
     if (result == 0)
     {
-        // Sync success - cache endpoints immediately
-        sockaddr_in local_addr{};
-        socklen_t local_len = sizeof(local_addr);
+        // Sync success — cache endpoints immediately
+        sockaddr_storage local_storage{};
+        socklen_t local_len = sizeof(local_storage);
         if (::getsockname(
-                fd_, reinterpret_cast<sockaddr*>(&local_addr), &local_len) == 0)
-            local_endpoint_ = detail::from_sockaddr_in(local_addr);
+                fd_, reinterpret_cast<sockaddr*>(&local_storage),
+                &local_len) == 0)
+            local_endpoint_ = detail::from_sockaddr(local_storage);
         remote_endpoint_ = ep;
 
         op.complete(0, 0);
@@ -527,120 +531,26 @@ select_socket::shutdown(tcp_socket::shutdown_type what) noexcept
 }
 
 inline std::error_code
-select_socket::set_no_delay(bool value) noexcept
+select_socket::set_option(
+    int level, int optname,
+    void const* data, std::size_t size) noexcept
 {
-    int flag = value ? 1 : 0;
-    if (::setsockopt(fd_, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag)) != 0)
+    if (::setsockopt(fd_, level, optname, data,
+            static_cast<socklen_t>(size)) != 0)
         return make_err(errno);
     return {};
-}
-
-inline bool
-select_socket::no_delay(std::error_code& ec) const noexcept
-{
-    int flag      = 0;
-    socklen_t len = sizeof(flag);
-    if (::getsockopt(fd_, IPPROTO_TCP, TCP_NODELAY, &flag, &len) != 0)
-    {
-        ec = make_err(errno);
-        return false;
-    }
-    ec = {};
-    return flag != 0;
 }
 
 inline std::error_code
-select_socket::set_keep_alive(bool value) noexcept
+select_socket::get_option(
+    int level, int optname,
+    void* data, std::size_t* size) const noexcept
 {
-    int flag = value ? 1 : 0;
-    if (::setsockopt(fd_, SOL_SOCKET, SO_KEEPALIVE, &flag, sizeof(flag)) != 0)
+    socklen_t len = static_cast<socklen_t>(*size);
+    if (::getsockopt(fd_, level, optname, data, &len) != 0)
         return make_err(errno);
+    *size = static_cast<std::size_t>(len);
     return {};
-}
-
-inline bool
-select_socket::keep_alive(std::error_code& ec) const noexcept
-{
-    int flag      = 0;
-    socklen_t len = sizeof(flag);
-    if (::getsockopt(fd_, SOL_SOCKET, SO_KEEPALIVE, &flag, &len) != 0)
-    {
-        ec = make_err(errno);
-        return false;
-    }
-    ec = {};
-    return flag != 0;
-}
-
-inline std::error_code
-select_socket::set_receive_buffer_size(int size) noexcept
-{
-    if (::setsockopt(fd_, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size)) != 0)
-        return make_err(errno);
-    return {};
-}
-
-inline int
-select_socket::receive_buffer_size(std::error_code& ec) const noexcept
-{
-    int size      = 0;
-    socklen_t len = sizeof(size);
-    if (::getsockopt(fd_, SOL_SOCKET, SO_RCVBUF, &size, &len) != 0)
-    {
-        ec = make_err(errno);
-        return 0;
-    }
-    ec = {};
-    return size;
-}
-
-inline std::error_code
-select_socket::set_send_buffer_size(int size) noexcept
-{
-    if (::setsockopt(fd_, SOL_SOCKET, SO_SNDBUF, &size, sizeof(size)) != 0)
-        return make_err(errno);
-    return {};
-}
-
-inline int
-select_socket::send_buffer_size(std::error_code& ec) const noexcept
-{
-    int size      = 0;
-    socklen_t len = sizeof(size);
-    if (::getsockopt(fd_, SOL_SOCKET, SO_SNDBUF, &size, &len) != 0)
-    {
-        ec = make_err(errno);
-        return 0;
-    }
-    ec = {};
-    return size;
-}
-
-inline std::error_code
-select_socket::set_linger(bool enabled, int timeout) noexcept
-{
-    if (timeout < 0)
-        return make_err(EINVAL);
-    struct ::linger lg;
-    lg.l_onoff  = enabled ? 1 : 0;
-    lg.l_linger = timeout;
-    if (::setsockopt(fd_, SOL_SOCKET, SO_LINGER, &lg, sizeof(lg)) != 0)
-        return make_err(errno);
-    return {};
-}
-
-inline tcp_socket::linger_options
-select_socket::linger(std::error_code& ec) const noexcept
-{
-    struct ::linger lg{};
-    socklen_t len = sizeof(lg);
-    if (::getsockopt(fd_, SOL_SOCKET, SO_LINGER, &lg, &len) != 0)
-    {
-        ec = make_err(errno);
-        return {};
-    }
-    ec = {};
-    return {.enabled = lg.l_onoff != 0, .timeout = lg.l_linger};
 }
 
 inline void
@@ -784,14 +694,22 @@ select_socket_service::destroy(io_object::implementation* impl)
 }
 
 inline std::error_code
-select_socket_service::open_socket(tcp_socket::implementation& impl)
+select_socket_service::open_socket(
+    tcp_socket::implementation& impl,
+    int family, int type, int protocol)
 {
     auto* select_impl = static_cast<select_socket*>(&impl);
     select_impl->close_socket();
 
-    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    int fd = ::socket(family, type, protocol);
     if (fd < 0)
         return make_err(errno);
+
+    if (family == AF_INET6)
+    {
+        int one = 1;
+        ::setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &one, sizeof(one));
+    }
 
     // Set non-blocking and close-on-exec
     int flags = ::fcntl(fd, F_GETFL, 0);

--- a/include/boost/corosio/native/native_socket_option.hpp
+++ b/include/boost/corosio/native/native_socket_option.hpp
@@ -1,0 +1,303 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+/** @file native_socket_option.hpp
+
+    Inline socket option types using platform-specific constants.
+    All methods are `constexpr` or trivially inlined, giving zero
+    overhead compared to hand-written `setsockopt` calls.
+
+    This header includes platform socket headers
+    (`<sys/socket.h>`, `<netinet/tcp.h>`, etc.).
+    For a version that avoids platform includes, use
+    `<boost/corosio/socket_option.hpp>`
+    (`boost::corosio::socket_option`).
+
+    Both variants satisfy the same option-type interface and work
+    interchangeably with `tcp_socket::set_option` /
+    `tcp_socket::get_option` and the corresponding acceptor methods.
+
+    @see boost::corosio::socket_option
+*/
+
+#ifndef BOOST_COROSIO_NATIVE_NATIVE_SOCKET_OPTION_HPP
+#define BOOST_COROSIO_NATIVE_NATIVE_SOCKET_OPTION_HPP
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#endif
+
+#include <cstddef>
+
+namespace boost::corosio::native_socket_option {
+
+/** A socket option with a boolean value.
+
+    Models socket options whose underlying representation is an `int`
+    where 0 means disabled and non-zero means enabled. The option's
+    protocol level and name are encoded as template parameters.
+
+    This is the native (inline) variant that includes platform
+    headers. For a type-erased version that avoids platform
+    includes, use `boost::corosio::socket_option` instead.
+
+    @par Example
+    @code
+    sock.set_option( native_socket_option::no_delay( true ) );
+    auto nd = sock.get_option<native_socket_option::no_delay>();
+    if ( nd.value() )
+        // Nagle's algorithm is disabled
+    @endcode
+
+    @tparam Level The protocol level (e.g. `SOL_SOCKET`, `IPPROTO_TCP`).
+    @tparam Name The option name (e.g. `TCP_NODELAY`, `SO_KEEPALIVE`).
+*/
+template<int Level, int Name>
+class boolean
+{
+    int value_ = 0;
+
+public:
+    /// Construct with default value (disabled).
+    boolean() = default;
+
+    /** Construct with an explicit value.
+
+        @param v `true` to enable the option, `false` to disable.
+    */
+    explicit boolean( bool v ) noexcept : value_( v ? 1 : 0 ) {}
+
+    /// Assign a new value.
+    boolean& operator=( bool v ) noexcept
+    {
+        value_ = v ? 1 : 0;
+        return *this;
+    }
+
+    /// Return the option value.
+    bool value() const noexcept { return value_ != 0; }
+
+    /// Return the option value.
+    explicit operator bool() const noexcept { return value_ != 0; }
+
+    /// Return the negated option value.
+    bool operator!() const noexcept { return value_ == 0; }
+
+    /// Return the protocol level for `setsockopt`/`getsockopt`.
+    static constexpr int level() noexcept { return Level; }
+
+    /// Return the option name for `setsockopt`/`getsockopt`.
+    static constexpr int name() noexcept { return Name; }
+
+    /// Return a pointer to the underlying storage.
+    void* data() noexcept { return &value_; }
+
+    /// Return a pointer to the underlying storage.
+    void const* data() const noexcept { return &value_; }
+
+    /// Return the size of the underlying storage.
+    std::size_t size() const noexcept { return sizeof( value_ ); }
+
+    /** Normalize after `getsockopt` returns fewer bytes than expected.
+
+        Windows Vista+ may write only 1 byte for boolean options.
+
+        @param s The number of bytes actually written by `getsockopt`.
+    */
+    void resize( std::size_t s ) noexcept
+    {
+        if ( s == sizeof( char ) )
+            value_ = *reinterpret_cast<unsigned char*>( &value_ ) ? 1 : 0;
+    }
+};
+
+/** A socket option with an integer value.
+
+    Models socket options whose underlying representation is a
+    plain `int`. The option's protocol level and name are encoded
+    as template parameters.
+
+    This is the native (inline) variant that includes platform
+    headers. For a type-erased version that avoids platform
+    includes, use `boost::corosio::socket_option` instead.
+
+    @par Example
+    @code
+    sock.set_option( native_socket_option::receive_buffer_size( 65536 ) );
+    auto opt = sock.get_option<native_socket_option::receive_buffer_size>();
+    int sz = opt.value();
+    @endcode
+
+    @tparam Level The protocol level (e.g. `SOL_SOCKET`).
+    @tparam Name The option name (e.g. `SO_RCVBUF`).
+*/
+template<int Level, int Name>
+class integer
+{
+    int value_ = 0;
+
+public:
+    /// Construct with default value (zero).
+    integer() = default;
+
+    /** Construct with an explicit value.
+
+        @param v The option value.
+    */
+    explicit integer( int v ) noexcept : value_( v ) {}
+
+    /// Assign a new value.
+    integer& operator=( int v ) noexcept
+    {
+        value_ = v;
+        return *this;
+    }
+
+    /// Return the option value.
+    int value() const noexcept { return value_; }
+
+    /// Return the protocol level for `setsockopt`/`getsockopt`.
+    static constexpr int level() noexcept { return Level; }
+
+    /// Return the option name for `setsockopt`/`getsockopt`.
+    static constexpr int name() noexcept { return Name; }
+
+    /// Return a pointer to the underlying storage.
+    void* data() noexcept { return &value_; }
+
+    /// Return a pointer to the underlying storage.
+    void const* data() const noexcept { return &value_; }
+
+    /// Return the size of the underlying storage.
+    std::size_t size() const noexcept { return sizeof( value_ ); }
+
+    /** Normalize after `getsockopt` returns fewer bytes than expected.
+
+        @param s The number of bytes actually written by `getsockopt`.
+    */
+    void resize( std::size_t s ) noexcept
+    {
+        if ( s == sizeof( char ) )
+            value_ = static_cast<int>(
+                *reinterpret_cast<unsigned char*>( &value_ ) );
+    }
+};
+
+/** The SO_LINGER socket option (native variant).
+
+    Controls behavior when closing a socket with unsent data.
+    When enabled, `close()` blocks until pending data is sent
+    or the timeout expires.
+
+    This variant stores the platform's `struct linger` directly,
+    avoiding the opaque-storage indirection of the type-erased
+    version.
+
+    @par Example
+    @code
+    sock.set_option( native_socket_option::linger( true, 5 ) );
+    auto opt = sock.get_option<native_socket_option::linger>();
+    if ( opt.enabled() )
+        std::cout << "linger timeout: " << opt.timeout() << "s\n";
+    @endcode
+*/
+class linger
+{
+    struct ::linger value_{};
+
+public:
+    /// Construct with default values (disabled, zero timeout).
+    linger() = default;
+
+    /** Construct with explicit values.
+
+        @param enabled `true` to enable linger behavior on close.
+        @param timeout The linger timeout in seconds.
+    */
+    linger( bool enabled, int timeout ) noexcept
+    {
+        value_.l_onoff = enabled ? 1 : 0;
+        value_.l_linger =
+            static_cast<decltype( value_.l_linger )>( timeout );
+    }
+
+    /// Return whether linger is enabled.
+    bool enabled() const noexcept { return value_.l_onoff != 0; }
+
+    /// Set whether linger is enabled.
+    void enabled( bool v ) noexcept { value_.l_onoff = v ? 1 : 0; }
+
+    /// Return the linger timeout in seconds.
+    int timeout() const noexcept
+    {
+        return static_cast<int>( value_.l_linger );
+    }
+
+    /// Set the linger timeout in seconds.
+    void timeout( int v ) noexcept
+    {
+        value_.l_linger =
+            static_cast<decltype( value_.l_linger )>( v );
+    }
+
+    /// Return the protocol level for `setsockopt`/`getsockopt`.
+    static constexpr int level() noexcept { return SOL_SOCKET; }
+
+    /// Return the option name for `setsockopt`/`getsockopt`.
+    static constexpr int name() noexcept { return SO_LINGER; }
+
+    /// Return a pointer to the underlying storage.
+    void* data() noexcept { return &value_; }
+
+    /// Return a pointer to the underlying storage.
+    void const* data() const noexcept { return &value_; }
+
+    /// Return the size of the underlying storage.
+    std::size_t size() const noexcept { return sizeof( value_ ); }
+
+    /** Normalize after `getsockopt`.
+
+        No-op — `struct linger` is always returned at full size.
+
+        @param s The number of bytes actually written by `getsockopt`.
+    */
+    void resize( std::size_t ) noexcept {}
+};
+
+/// Disable Nagle's algorithm (TCP_NODELAY).
+using no_delay = boolean<IPPROTO_TCP, TCP_NODELAY>;
+
+/// Enable periodic keepalive probes (SO_KEEPALIVE).
+using keep_alive = boolean<SOL_SOCKET, SO_KEEPALIVE>;
+
+/// Restrict an IPv6 socket to IPv6 only (IPV6_V6ONLY).
+using v6_only = boolean<IPPROTO_IPV6, IPV6_V6ONLY>;
+
+/// Allow local address reuse (SO_REUSEADDR).
+using reuse_address = boolean<SOL_SOCKET, SO_REUSEADDR>;
+
+/// Set the receive buffer size (SO_RCVBUF).
+using receive_buffer_size = integer<SOL_SOCKET, SO_RCVBUF>;
+
+/// Set the send buffer size (SO_SNDBUF).
+using send_buffer_size = integer<SOL_SOCKET, SO_SNDBUF>;
+
+#ifdef SO_REUSEPORT
+/// Allow multiple sockets to bind to the same port (SO_REUSEPORT).
+using reuse_port = boolean<SOL_SOCKET, SO_REUSEPORT>;
+#endif
+
+} // namespace boost::corosio::native_socket_option
+
+#endif // BOOST_COROSIO_NATIVE_NATIVE_SOCKET_OPTION_HPP

--- a/include/boost/corosio/native/native_tcp.hpp
+++ b/include/boost/corosio/native/native_tcp.hpp
@@ -1,0 +1,101 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+/** @file native_tcp.hpp
+
+    Inline TCP protocol type using platform-specific constants.
+    All methods are `constexpr` or trivially inlined, giving zero
+    overhead compared to hand-written socket creation calls.
+
+    This header includes platform socket headers
+    (`<sys/socket.h>`, `<netinet/in.h>`, etc.).
+    For a version that avoids platform includes, use
+    `<boost/corosio/tcp.hpp>` (`boost::corosio::tcp`).
+
+    Both variants satisfy the same protocol-type interface and work
+    interchangeably with `tcp_socket::open` / `tcp_acceptor::open`.
+
+    @see boost::corosio::tcp
+*/
+
+#ifndef BOOST_COROSIO_NATIVE_NATIVE_TCP_HPP
+#define BOOST_COROSIO_NATIVE_NATIVE_TCP_HPP
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <netinet/in.h>
+#include <sys/socket.h>
+#endif
+
+namespace boost::corosio {
+
+class tcp_socket;
+class tcp_acceptor;
+
+} // namespace boost::corosio
+
+namespace boost::corosio {
+
+/** Inline TCP protocol type with platform constants.
+
+    Same shape as @ref boost::corosio::tcp but with inline
+    `family()`, `type()`, and `protocol()` methods that
+    resolve to compile-time constants.
+
+    @see boost::corosio::tcp
+*/
+class native_tcp
+{
+    bool v6_;
+    explicit constexpr native_tcp( bool v6 ) noexcept : v6_( v6 ) {}
+
+public:
+    /// Construct an IPv4 TCP protocol.
+    static constexpr native_tcp v4() noexcept { return native_tcp( false ); }
+
+    /// Construct an IPv6 TCP protocol.
+    static constexpr native_tcp v6() noexcept { return native_tcp( true ); }
+
+    /// Return true if this is IPv6.
+    constexpr bool is_v6() const noexcept { return v6_; }
+
+    /// Return the address family (AF_INET or AF_INET6).
+    int family() const noexcept
+    {
+        return v6_ ? AF_INET6 : AF_INET;
+    }
+
+    /// Return the socket type (SOCK_STREAM).
+    static constexpr int type() noexcept { return SOCK_STREAM; }
+
+    /// Return the IP protocol (IPPROTO_TCP).
+    static constexpr int protocol() noexcept { return IPPROTO_TCP; }
+
+    /// The associated socket type.
+    using socket = tcp_socket;
+
+    /// The associated acceptor type.
+    using acceptor = tcp_acceptor;
+
+    friend constexpr bool operator==( native_tcp a, native_tcp b ) noexcept
+    {
+        return a.v6_ == b.v6_;
+    }
+
+    friend constexpr bool operator!=( native_tcp a, native_tcp b ) noexcept
+    {
+        return a.v6_ != b.v6_;
+    }
+};
+
+} // namespace boost::corosio
+
+#endif // BOOST_COROSIO_NATIVE_NATIVE_TCP_HPP

--- a/include/boost/corosio/socket_option.hpp
+++ b/include/boost/corosio/socket_option.hpp
@@ -1,0 +1,369 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_SOCKET_OPTION_HPP
+#define BOOST_COROSIO_SOCKET_OPTION_HPP
+
+#include <boost/corosio/detail/config.hpp>
+
+#include <cstddef>
+
+/** @file socket_option.hpp
+
+    Type-erased socket option types that avoid platform-specific
+    headers. The protocol level and option name for each type are
+    resolved at link time via the compiled library.
+
+    For an inline (zero-overhead) alternative that includes platform
+    headers, use `<boost/corosio/native/native_socket_option.hpp>`
+    (`boost::corosio::native_socket_option`).
+
+    Both variants satisfy the same option-type interface and work
+    interchangeably with `tcp_socket::set_option` /
+    `tcp_socket::get_option` and the corresponding acceptor methods.
+
+    @see native_socket_option
+*/
+
+namespace boost::corosio::socket_option {
+
+/** Base class for concrete boolean socket options.
+
+    Stores a boolean as an `int` suitable for `setsockopt`/`getsockopt`.
+    Derived types provide `level()` and `name()` for the specific option.
+*/
+class boolean_option
+{
+    int value_ = 0;
+
+public:
+    /// Construct with default value (disabled).
+    boolean_option() = default;
+
+    /** Construct with an explicit value.
+
+        @param v `true` to enable the option, `false` to disable.
+    */
+    explicit boolean_option( bool v ) noexcept : value_( v ? 1 : 0 ) {}
+
+    /// Assign a new value.
+    boolean_option& operator=( bool v ) noexcept
+    {
+        value_ = v ? 1 : 0;
+        return *this;
+    }
+
+    /// Return the option value.
+    bool value() const noexcept { return value_ != 0; }
+
+    /// Return the option value.
+    explicit operator bool() const noexcept { return value_ != 0; }
+
+    /// Return the negated option value.
+    bool operator!() const noexcept { return value_ == 0; }
+
+    /// Return a pointer to the underlying storage.
+    void* data() noexcept { return &value_; }
+
+    /// Return a pointer to the underlying storage.
+    void const* data() const noexcept { return &value_; }
+
+    /// Return the size of the underlying storage.
+    std::size_t size() const noexcept { return sizeof( value_ ); }
+
+    /** Normalize after `getsockopt` returns fewer bytes than expected.
+
+        Windows Vista+ may write only 1 byte for boolean options.
+
+        @param s The number of bytes actually written by `getsockopt`.
+    */
+    void resize( std::size_t s ) noexcept
+    {
+        if ( s == sizeof( char ) )
+            value_ = *reinterpret_cast<unsigned char*>( &value_ ) ? 1 : 0;
+    }
+};
+
+/** Base class for concrete integer socket options.
+
+    Stores an integer suitable for `setsockopt`/`getsockopt`.
+    Derived types provide `level()` and `name()` for the specific option.
+*/
+class integer_option
+{
+    int value_ = 0;
+
+public:
+    /// Construct with default value (zero).
+    integer_option() = default;
+
+    /** Construct with an explicit value.
+
+        @param v The option value.
+    */
+    explicit integer_option( int v ) noexcept : value_( v ) {}
+
+    /// Assign a new value.
+    integer_option& operator=( int v ) noexcept
+    {
+        value_ = v;
+        return *this;
+    }
+
+    /// Return the option value.
+    int value() const noexcept { return value_; }
+
+    /// Return a pointer to the underlying storage.
+    void* data() noexcept { return &value_; }
+
+    /// Return a pointer to the underlying storage.
+    void const* data() const noexcept { return &value_; }
+
+    /// Return the size of the underlying storage.
+    std::size_t size() const noexcept { return sizeof( value_ ); }
+
+    /** Normalize after `getsockopt` returns fewer bytes than expected.
+
+        @param s The number of bytes actually written by `getsockopt`.
+    */
+    void resize( std::size_t s ) noexcept
+    {
+        if ( s == sizeof( char ) )
+            value_ = static_cast<int>(
+                *reinterpret_cast<unsigned char*>( &value_ ) );
+    }
+};
+
+/** Disable Nagle's algorithm (TCP_NODELAY).
+
+    @par Example
+    @code
+    sock.set_option( socket_option::no_delay( true ) );
+    auto nd = sock.get_option<socket_option::no_delay>();
+    if ( nd.value() )
+        // Nagle's algorithm is disabled
+    @endcode
+*/
+class BOOST_COROSIO_DECL no_delay : public boolean_option
+{
+public:
+    using boolean_option::boolean_option;
+    using boolean_option::operator=;
+
+    /// Return the protocol level.
+    static int level() noexcept;
+
+    /// Return the option name.
+    static int name() noexcept;
+};
+
+/** Enable periodic keepalive probes (SO_KEEPALIVE).
+
+    @par Example
+    @code
+    sock.set_option( socket_option::keep_alive( true ) );
+    @endcode
+*/
+class BOOST_COROSIO_DECL keep_alive : public boolean_option
+{
+public:
+    using boolean_option::boolean_option;
+    using boolean_option::operator=;
+
+    /// Return the protocol level.
+    static int level() noexcept;
+
+    /// Return the option name.
+    static int name() noexcept;
+};
+
+/** Restrict an IPv6 socket to IPv6 only (IPV6_V6ONLY).
+
+    When enabled, the socket only accepts IPv6 connections.
+    When disabled, the socket accepts both IPv4 and IPv6
+    connections (dual-stack mode).
+
+    @par Example
+    @code
+    sock.set_option( socket_option::v6_only( true ) );
+    @endcode
+*/
+class BOOST_COROSIO_DECL v6_only : public boolean_option
+{
+public:
+    using boolean_option::boolean_option;
+    using boolean_option::operator=;
+
+    /// Return the protocol level.
+    static int level() noexcept;
+
+    /// Return the option name.
+    static int name() noexcept;
+};
+
+/** Allow local address reuse (SO_REUSEADDR).
+
+    @par Example
+    @code
+    acc.set_option( socket_option::reuse_address( true ) );
+    @endcode
+*/
+class BOOST_COROSIO_DECL reuse_address : public boolean_option
+{
+public:
+    using boolean_option::boolean_option;
+    using boolean_option::operator=;
+
+    /// Return the protocol level.
+    static int level() noexcept;
+
+    /// Return the option name.
+    static int name() noexcept;
+};
+
+/** Allow multiple sockets to bind to the same port (SO_REUSEPORT).
+
+    Not available on all platforms. On unsupported platforms,
+    `set_option` will return an error.
+
+    @par Example
+    @code
+    acc.open( tcp::v6() );
+    acc.set_option( socket_option::reuse_port( true ) );
+    acc.bind( endpoint( ipv6_address::any(), 8080 ) );
+    acc.listen();
+    @endcode
+*/
+class BOOST_COROSIO_DECL reuse_port : public boolean_option
+{
+public:
+    using boolean_option::boolean_option;
+    using boolean_option::operator=;
+
+    /// Return the protocol level.
+    static int level() noexcept;
+
+    /// Return the option name.
+    static int name() noexcept;
+};
+
+/** Set the receive buffer size (SO_RCVBUF).
+
+    @par Example
+    @code
+    sock.set_option( socket_option::receive_buffer_size( 65536 ) );
+    auto opt = sock.get_option<socket_option::receive_buffer_size>();
+    int sz = opt.value();
+    @endcode
+*/
+class BOOST_COROSIO_DECL receive_buffer_size : public integer_option
+{
+public:
+    using integer_option::integer_option;
+    using integer_option::operator=;
+
+    /// Return the protocol level.
+    static int level() noexcept;
+
+    /// Return the option name.
+    static int name() noexcept;
+};
+
+/** Set the send buffer size (SO_SNDBUF).
+
+    @par Example
+    @code
+    sock.set_option( socket_option::send_buffer_size( 65536 ) );
+    @endcode
+*/
+class BOOST_COROSIO_DECL send_buffer_size : public integer_option
+{
+public:
+    using integer_option::integer_option;
+    using integer_option::operator=;
+
+    /// Return the protocol level.
+    static int level() noexcept;
+
+    /// Return the option name.
+    static int name() noexcept;
+};
+
+/** The SO_LINGER socket option.
+
+    Controls behavior when closing a socket with unsent data.
+    When enabled, `close()` blocks until pending data is sent
+    or the timeout expires.
+
+    @par Example
+    @code
+    sock.set_option( socket_option::linger( true, 5 ) );
+    auto opt = sock.get_option<socket_option::linger>();
+    if ( opt.enabled() )
+        std::cout << "linger timeout: " << opt.timeout() << "s\n";
+    @endcode
+*/
+class BOOST_COROSIO_DECL linger
+{
+    // Opaque storage for the platform's struct linger.
+    // POSIX: { int, int } = 8 bytes.
+    // Windows: { u_short, u_short } = 4 bytes.
+    static constexpr std::size_t max_storage_ = 8;
+    alignas( 4 ) unsigned char storage_[max_storage_]{};
+
+public:
+    /// Construct with default values (disabled, zero timeout).
+    linger() noexcept = default;
+
+    /** Construct with explicit values.
+
+        @param enabled `true` to enable linger behavior on close.
+        @param timeout The linger timeout in seconds.
+    */
+    linger( bool enabled, int timeout ) noexcept;
+
+    /// Return whether linger is enabled.
+    bool enabled() const noexcept;
+
+    /// Set whether linger is enabled.
+    void enabled( bool v ) noexcept;
+
+    /// Return the linger timeout in seconds.
+    int timeout() const noexcept;
+
+    /// Set the linger timeout in seconds.
+    void timeout( int v ) noexcept;
+
+    /// Return the protocol level.
+    static int level() noexcept;
+
+    /// Return the option name.
+    static int name() noexcept;
+
+    /// Return a pointer to the underlying storage.
+    void* data() noexcept { return storage_; }
+
+    /// Return a pointer to the underlying storage.
+    void const* data() const noexcept { return storage_; }
+
+    /// Return the size of the underlying storage.
+    std::size_t size() const noexcept;
+
+    /** Normalize after `getsockopt`.
+
+        No-op — `struct linger` is always returned at full size.
+
+        @param s The number of bytes actually written by `getsockopt`.
+    */
+    void resize( std::size_t ) noexcept {}
+};
+
+} // namespace boost::corosio::socket_option
+
+#endif // BOOST_COROSIO_SOCKET_OPTION_HPP

--- a/include/boost/corosio/tcp.hpp
+++ b/include/boost/corosio/tcp.hpp
@@ -1,0 +1,85 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_TCP_HPP
+#define BOOST_COROSIO_TCP_HPP
+
+#include <boost/corosio/detail/config.hpp>
+
+namespace boost::corosio {
+
+class tcp_socket;
+class tcp_acceptor;
+
+/** Encapsulate the TCP protocol for socket creation.
+
+    This class identifies the TCP protocol and its address family
+    (IPv4 or IPv6). It is used to parameterize socket and acceptor
+    `open()` calls with a self-documenting type.
+
+    The `family()`, `type()`, and `protocol()` members are
+    implemented in the compiled library to avoid exposing
+    platform socket headers. For an inline variant that includes
+    platform headers, use @ref native_tcp.
+
+    @par Example
+    @code
+    tcp_acceptor acc( ioc );
+    acc.open( tcp::v6() );  // IPv6 socket
+    acc.set_option( socket_option::reuse_address( true ) );
+    acc.bind( endpoint( ipv6_address::any(), 8080 ) );
+    acc.listen();
+    @endcode
+
+    @see native_tcp, tcp_socket, tcp_acceptor
+*/
+class BOOST_COROSIO_DECL tcp
+{
+    bool v6_;
+    explicit constexpr tcp( bool v6 ) noexcept : v6_( v6 ) {}
+
+public:
+    /// Construct an IPv4 TCP protocol.
+    static constexpr tcp v4() noexcept { return tcp( false ); }
+
+    /// Construct an IPv6 TCP protocol.
+    static constexpr tcp v6() noexcept { return tcp( true ); }
+
+    /// Return true if this is IPv6.
+    constexpr bool is_v6() const noexcept { return v6_; }
+
+    /// Return the address family (AF_INET or AF_INET6).
+    int family() const noexcept;
+
+    /// Return the socket type (SOCK_STREAM).
+    static int type() noexcept;
+
+    /// Return the IP protocol (IPPROTO_TCP).
+    static int protocol() noexcept;
+
+    /// The associated socket type.
+    using socket = tcp_socket;
+
+    /// The associated acceptor type.
+    using acceptor = tcp_acceptor;
+
+    friend constexpr bool operator==( tcp a, tcp b ) noexcept
+    {
+        return a.v6_ == b.v6_;
+    }
+
+    friend constexpr bool operator!=( tcp a, tcp b ) noexcept
+    {
+        return a.v6_ != b.v6_;
+    }
+};
+
+} // namespace boost::corosio
+
+#endif // BOOST_COROSIO_TCP_HPP

--- a/include/boost/corosio/tcp_acceptor.hpp
+++ b/include/boost/corosio/tcp_acceptor.hpp
@@ -16,6 +16,7 @@
 #include <boost/corosio/io/io_object.hpp>
 #include <boost/capy/io_result.hpp>
 #include <boost/corosio/endpoint.hpp>
+#include <boost/corosio/tcp.hpp>
 #include <boost/corosio/tcp_socket.hpp>
 #include <boost/capy/ex/executor_ref.hpp>
 #include <boost/capy/ex/execution_context.hpp>
@@ -53,17 +54,29 @@ namespace boost::corosio {
 
     @par Example
     @code
+    // Convenience constructor: open + SO_REUSEADDR + bind + listen
     io_context ioc;
-    tcp_acceptor acc(ioc);
-    if (auto ec = acc.listen(endpoint(8080)))  // Bind to port 8080
-        return ec;
+    tcp_acceptor acc( ioc, endpoint( 8080 ) );
 
-    tcp_socket peer(ioc);
-    auto [ec] = co_await acc.accept(peer);
-    if (!ec) {
+    tcp_socket peer( ioc );
+    auto [ec] = co_await acc.accept( peer );
+    if ( !ec ) {
         // peer is now a connected socket
-        auto [ec2, n] = co_await peer.read_some(buf);
+        auto [ec2, n] = co_await peer.read_some( buf );
     }
+    @endcode
+
+    @par Example
+    @code
+    // Fine-grained setup
+    tcp_acceptor acc( ioc );
+    acc.open( tcp::v6() );
+    acc.set_option( socket_option::reuse_address( true ) );
+    acc.set_option( socket_option::v6_only( true ) );
+    if ( auto ec = acc.bind( endpoint( ipv6_address::any(), 8080 ) ) )
+        return ec;
+    if ( auto ec = acc.listen() )
+        return ec;
     @endcode
 */
 class BOOST_COROSIO_DECL tcp_acceptor : public io_object
@@ -119,6 +132,20 @@ public:
     */
     explicit tcp_acceptor(capy::execution_context& ctx);
 
+    /** Convenience constructor: open + SO_REUSEADDR + bind + listen.
+
+        Creates a fully-bound listening acceptor in a single
+        expression. The address family is deduced from @p ep.
+
+        @param ctx The execution context that will own this acceptor.
+        @param ep The local endpoint to bind to.
+        @param backlog The maximum pending connection queue length.
+
+        @throws std::system_error on bind or listen failure.
+    */
+    tcp_acceptor(
+        capy::execution_context& ctx, endpoint ep, int backlog = 128 );
+
     /** Construct an acceptor from an executor.
 
         The acceptor is associated with the executor's context.
@@ -129,6 +156,21 @@ public:
         requires(!std::same_as<std::remove_cvref_t<Ex>, tcp_acceptor>) &&
         capy::Executor<Ex>
     explicit tcp_acceptor(Ex const& ex) : tcp_acceptor(ex.context())
+    {
+    }
+
+    /** Convenience constructor from an executor.
+
+        @param ex The executor whose context will own the acceptor.
+        @param ep The local endpoint to bind to.
+        @param backlog The maximum pending connection queue length.
+
+        @throws std::system_error on bind or listen failure.
+    */
+    template<class Ex>
+        requires capy::Executor<Ex>
+    tcp_acceptor(Ex const& ex, endpoint ep, int backlog = 128 )
+        : tcp_acceptor(ex.context(), ep, backlog)
     {
     }
 
@@ -170,20 +212,41 @@ public:
     tcp_acceptor(tcp_acceptor const&)            = delete;
     tcp_acceptor& operator=(tcp_acceptor const&) = delete;
 
-    /** Open, bind, and listen on an endpoint.
+    /** Create the acceptor socket without binding or listening.
 
-        Creates an IPv4 TCP socket, binds it to the specified endpoint,
-        and begins listening for incoming connections. This must be
-        called before initiating accept operations.
+        Creates a TCP socket with dual-stack enabled for IPv6.
+        Does not set SO_REUSEADDR — call `set_option` explicitly
+        if needed.
 
-        @param ep The local endpoint to bind to. Use `endpoint(port)` to
-            bind to all interfaces on a specific port.
+        If the acceptor is already open, this function is a no-op.
 
-        @param backlog The maximum length of the queue of pending
-            connections. Defaults to 128.
+        @param proto The protocol (IPv4 or IPv6). Defaults to
+            `tcp::v4()`.
 
-        @return An error code indicating success or the reason for failure.
-            A default-constructed error code indicates success.
+        @throws std::system_error on failure.
+
+        @par Example
+        @code
+        acc.open( tcp::v6() );
+        acc.set_option( socket_option::reuse_address( true ) );
+        acc.bind( endpoint( ipv6_address::any(), 8080 ) );
+        acc.listen();
+        @endcode
+
+        @see bind, listen
+    */
+    void open( tcp proto = tcp::v4() );
+
+    /** Bind to a local endpoint.
+
+        The acceptor must be open. Binds the socket to @p ep and
+        caches the resolved local endpoint (useful when port 0 is
+        used to request an ephemeral port).
+
+        @param ep The local endpoint to bind to.
+
+        @return An error code indicating success or the reason for
+            failure.
 
         @par Error Conditions
         @li `errc::address_in_use`: The endpoint is already in use.
@@ -191,12 +254,25 @@ public:
             on any local interface.
         @li `errc::permission_denied`: Insufficient privileges to bind
             to the endpoint (e.g., privileged port).
-        @li `errc::operation_not_supported`: The acceptor service is
-            unavailable in the context (POSIX only).
 
-        @throws Nothing.
+        @throws std::logic_error if the acceptor is not open.
     */
-    [[nodiscard]] std::error_code listen(endpoint ep, int backlog = 128);
+    [[nodiscard]] std::error_code bind( endpoint ep );
+
+    /** Start listening for incoming connections.
+
+        The acceptor must be open and bound. Registers the acceptor
+        with the platform reactor.
+
+        @param backlog The maximum length of the queue of pending
+            connections. Defaults to 128.
+
+        @return An error code indicating success or the reason for
+            failure.
+
+        @throws std::logic_error if the acceptor is not open.
+    */
+    [[nodiscard]] std::error_code listen( int backlog = 128 );
 
     /** Close the acceptor.
 
@@ -282,6 +358,70 @@ public:
     */
     endpoint local_endpoint() const noexcept;
 
+    /** Set a socket option on the acceptor.
+
+        Applies a type-safe socket option to the underlying listening
+        socket. The socket must be open (via `open()` or `listen()`).
+        This is useful for setting options between `open()` and
+        `listen()`, such as `socket_option::reuse_port`.
+
+        @par Example
+        @code
+        acc.open( tcp::v6() );
+        acc.set_option( socket_option::reuse_port( true ) );
+        acc.bind( endpoint( ipv6_address::any(), 8080 ) );
+        acc.listen();
+        @endcode
+
+        @param opt The option to set.
+
+        @throws std::logic_error if the acceptor is not open.
+        @throws std::system_error on failure.
+    */
+    template<class Option>
+    void set_option( Option const& opt )
+    {
+        if (!is_open())
+            detail::throw_logic_error(
+                "set_option: acceptor not open" );
+        std::error_code ec = get().set_option(
+            Option::level(), Option::name(), opt.data(), opt.size() );
+        if (ec)
+            detail::throw_system_error(
+                ec, "tcp_acceptor::set_option" );
+    }
+
+    /** Get a socket option from the acceptor.
+
+        Retrieves the current value of a type-safe socket option.
+
+        @par Example
+        @code
+        auto opt = acc.get_option<socket_option::reuse_address>();
+        @endcode
+
+        @return The current option value.
+
+        @throws std::logic_error if the acceptor is not open.
+        @throws std::system_error on failure.
+    */
+    template<class Option>
+    Option get_option() const
+    {
+        if (!is_open())
+            detail::throw_logic_error(
+                "get_option: acceptor not open" );
+        Option opt{};
+        std::size_t sz = opt.size();
+        std::error_code ec = get().get_option(
+            Option::level(), Option::name(), opt.data(), &sz );
+        if (ec)
+            detail::throw_system_error(
+                ec, "tcp_acceptor::get_option" );
+        opt.resize( sz );
+        return opt;
+    }
+
     struct implementation : io_object::implementation
     {
         virtual std::coroutine_handle<> accept(
@@ -302,6 +442,31 @@ public:
             All outstanding operations complete with operation_canceled error.
         */
         virtual void cancel() noexcept = 0;
+
+        /** Set a socket option.
+
+            @param level The protocol level.
+            @param optname The option name.
+            @param data Pointer to the option value.
+            @param size Size of the option value in bytes.
+            @return Error code on failure, empty on success.
+        */
+        virtual std::error_code set_option(
+            int level, int optname,
+            void const* data, std::size_t size) noexcept = 0;
+
+        /** Get a socket option.
+
+            @param level The protocol level.
+            @param optname The option name.
+            @param data Pointer to receive the option value.
+            @param size On entry, the size of the buffer. On exit,
+                the size of the option value.
+            @return Error code on failure, empty on success.
+        */
+        virtual std::error_code get_option(
+            int level, int optname,
+            void* data, std::size_t* size) const noexcept = 0;
     };
 
 protected:

--- a/include/boost/corosio/tcp_socket.hpp
+++ b/include/boost/corosio/tcp_socket.hpp
@@ -18,6 +18,7 @@
 #include <boost/capy/io_result.hpp>
 #include <boost/corosio/io_buffer_param.hpp>
 #include <boost/corosio/endpoint.hpp>
+#include <boost/corosio/tcp.hpp>
 #include <boost/capy/ex/executor_ref.hpp>
 #include <boost/capy/ex/execution_context.hpp>
 #include <boost/capy/ex/io_env.hpp>
@@ -89,13 +90,6 @@ public:
         shutdown_both
     };
 
-    /** Options for SO_LINGER socket option. */
-    struct linger_options
-    {
-        bool enabled = false;
-        int timeout  = 0; // seconds
-    };
-
     struct implementation : io_stream::implementation
     {
         virtual std::coroutine_handle<> connect(
@@ -116,22 +110,30 @@ public:
         */
         virtual void cancel() noexcept = 0;
 
-        // Socket options
-        virtual std::error_code set_no_delay(bool value) noexcept = 0;
-        virtual bool no_delay(std::error_code& ec) const noexcept = 0;
+        /** Set a socket option.
 
-        virtual std::error_code set_keep_alive(bool value) noexcept = 0;
-        virtual bool keep_alive(std::error_code& ec) const noexcept = 0;
+            @param level The protocol level (e.g. `SOL_SOCKET`).
+            @param optname The option name (e.g. `SO_KEEPALIVE`).
+            @param data Pointer to the option value.
+            @param size Size of the option value in bytes.
+            @return Error code on failure, empty on success.
+        */
+        virtual std::error_code set_option(
+            int level, int optname,
+            void const* data, std::size_t size) noexcept = 0;
 
-        virtual std::error_code set_receive_buffer_size(int size) noexcept  = 0;
-        virtual int receive_buffer_size(std::error_code& ec) const noexcept = 0;
+        /** Get a socket option.
 
-        virtual std::error_code set_send_buffer_size(int size) noexcept  = 0;
-        virtual int send_buffer_size(std::error_code& ec) const noexcept = 0;
-
-        virtual std::error_code
-        set_linger(bool enabled, int timeout) noexcept                    = 0;
-        virtual linger_options linger(std::error_code& ec) const noexcept = 0;
+            @param level The protocol level (e.g. `SOL_SOCKET`).
+            @param optname The option name (e.g. `SO_KEEPALIVE`).
+            @param data Pointer to receive the option value.
+            @param size On entry, the size of the buffer. On exit,
+                the size of the option value.
+            @return Error code on failure, empty on success.
+        */
+        virtual std::error_code get_option(
+            int level, int optname,
+            void* data, std::size_t* size) const noexcept = 0;
 
         /// Returns the cached local endpoint.
         virtual endpoint local_endpoint() const noexcept = 0;
@@ -243,13 +245,18 @@ public:
 
     /** Open the socket.
 
-        Creates an IPv4 TCP socket and associates it with the platform
-        reactor (IOCP on Windows). This must be called before initiating
-        I/O operations.
+        Creates a TCP socket and associates it with the platform
+        reactor (IOCP on Windows). Calling @ref connect on a closed
+        socket opens it automatically with the endpoint's address family,
+        so explicit `open()` is only needed when socket options must be
+        set before connecting.
+
+        @param proto The protocol (IPv4 or IPv6). Defaults to
+            `tcp::v4()`.
 
         @throws std::system_error on failure.
     */
-    void open();
+    void open( tcp proto = tcp::v4() );
 
     /** Close the socket.
 
@@ -273,8 +280,9 @@ public:
 
     /** Initiate an asynchronous connect operation.
 
-        Connects the socket to the specified remote endpoint. The socket
-        must be open before calling this function.
+        If the socket is not already open, it is opened automatically
+        using the address family of @p ep (IPv4 or IPv6). If the socket
+        is already open, the existing file descriptor is used as-is.
 
         The operation supports cancellation via `std::stop_token` through
         the affine awaitable protocol. If the associated stop token is
@@ -292,15 +300,15 @@ public:
             - operation_canceled: Cancelled via stop_token or cancel().
                 Check `ec == cond::canceled` for portable comparison.
 
-        @throws std::logic_error if the socket is not open.
+        @throws std::system_error if the socket needs to be opened
+            and the open fails.
 
         @par Preconditions
-        The socket must be open (`is_open() == true`).
-
         This socket must outlive the returned awaitable.
 
         @par Example
         @code
+        // Socket opened automatically with correct address family:
         auto [ec] = co_await s.connect(endpoint);
         if (ec) { ... }
         @endcode
@@ -308,7 +316,7 @@ public:
     auto connect(endpoint ep)
     {
         if (!is_open())
-            detail::throw_logic_error("connect: socket not open");
+            open(ep.is_v6() ? tcp::v6() : tcp::v4());
         return connect_awaitable(*this, ep);
     }
 
@@ -373,114 +381,63 @@ public:
     */
     void shutdown(shutdown_type what);
 
-    //
-    // Socket Options
-    //
+    /** Set a socket option.
 
-    /** Enable or disable TCP_NODELAY (disable Nagle's algorithm).
+        Applies a type-safe socket option to the underlying socket.
+        The option type encodes the protocol level and option name.
 
-        When enabled, segments are sent as soon as possible even if
-        there is only a small amount of data. This reduces latency
-        at the potential cost of increased network traffic.
+        @par Example
+        @code
+        sock.set_option( socket_option::no_delay( true ) );
+        sock.set_option( socket_option::receive_buffer_size( 65536 ) );
+        @endcode
 
-        @param value `true` to disable Nagle's algorithm (enable no-delay).
-
-        @throws std::logic_error if the socket is not open.
-        @throws std::system_error on failure.
-    */
-    void set_no_delay(bool value);
-
-    /** Get the current TCP_NODELAY setting.
-
-        @return `true` if Nagle's algorithm is disabled.
+        @param opt The option to set.
 
         @throws std::logic_error if the socket is not open.
         @throws std::system_error on failure.
     */
-    bool no_delay() const;
+    template<class Option>
+    void set_option( Option const& opt )
+    {
+        if (!is_open())
+            detail::throw_logic_error( "set_option: socket not open" );
+        std::error_code ec = get().set_option(
+            Option::level(), Option::name(), opt.data(), opt.size() );
+        if (ec)
+            detail::throw_system_error( ec, "tcp_socket::set_option" );
+    }
 
-    /** Enable or disable SO_KEEPALIVE.
+    /** Get a socket option.
 
-        When enabled, the socket will periodically send keepalive probes
-        to detect if the peer is still reachable.
+        Retrieves the current value of a type-safe socket option.
 
-        @param value `true` to enable keepalive probes.
+        @par Example
+        @code
+        auto nd = sock.get_option<socket_option::no_delay>();
+        if ( nd.value() )
+            // Nagle's algorithm is disabled
+        @endcode
 
-        @throws std::logic_error if the socket is not open.
-        @throws std::system_error on failure.
-    */
-    void set_keep_alive(bool value);
-
-    /** Get the current SO_KEEPALIVE setting.
-
-        @return `true` if keepalive is enabled.
-
-        @throws std::logic_error if the socket is not open.
-        @throws std::system_error on failure.
-    */
-    bool keep_alive() const;
-
-    /** Set the receive buffer size (SO_RCVBUF).
-
-        @param size The desired receive buffer size in bytes.
-
-        @throws std::logic_error if the socket is not open.
-        @throws std::system_error on failure.
-
-        @note The operating system may adjust the actual buffer size.
-    */
-    void set_receive_buffer_size(int size);
-
-    /** Get the receive buffer size (SO_RCVBUF).
-
-        @return The current receive buffer size in bytes.
+        @return The current option value.
 
         @throws std::logic_error if the socket is not open.
         @throws std::system_error on failure.
     */
-    int receive_buffer_size() const;
-
-    /** Set the send buffer size (SO_SNDBUF).
-
-        @param size The desired send buffer size in bytes.
-
-        @throws std::logic_error if the socket is not open.
-        @throws std::system_error on failure.
-
-        @note The operating system may adjust the actual buffer size.
-    */
-    void set_send_buffer_size(int size);
-
-    /** Get the send buffer size (SO_SNDBUF).
-
-        @return The current send buffer size in bytes.
-
-        @throws std::logic_error if the socket is not open.
-        @throws std::system_error on failure.
-    */
-    int send_buffer_size() const;
-
-    /** Set the SO_LINGER option.
-
-        Controls behavior when closing a socket with unsent data.
-
-        @param enabled If `true`, close() will block until data is sent
-            or the timeout expires. If `false`, close() returns immediately.
-        @param timeout The linger timeout in seconds (only used if enabled).
-
-        @throws std::logic_error if the socket is not open.
-        @throws std::system_error on failure.
-    */
-    void set_linger(bool enabled, int timeout);
-
-    /** Get the current SO_LINGER setting.
-
-        @return The current linger options.
-
-        @throws std::logic_error if the socket is not open.
-        @throws std::system_error on failure.
-    */
-    linger_options linger() const;
+    template<class Option>
+    Option get_option() const
+    {
+        if (!is_open())
+            detail::throw_logic_error( "get_option: socket not open" );
+        Option opt{};
+        std::size_t sz = opt.size();
+        std::error_code ec = get().get_option(
+            Option::level(), Option::name(), opt.data(), &sz );
+        if (ec)
+            detail::throw_system_error( ec, "tcp_socket::get_option" );
+        opt.resize( sz );
+        return opt;
+    }
 
     /** Get the local endpoint of the socket.
 
@@ -522,6 +479,9 @@ protected:
 
 private:
     friend class tcp_acceptor;
+
+    /// Open the socket for the given protocol triple.
+    void open_for_family(int family, int type, int protocol);
 
     inline implementation& get() const noexcept
     {

--- a/include/boost/corosio/test/mocket.hpp
+++ b/include/boost/corosio/test/mocket.hpp
@@ -13,6 +13,7 @@
 
 #include <boost/corosio/detail/except.hpp>
 #include <boost/corosio/io_context.hpp>
+#include <boost/corosio/socket_option.hpp>
 #include <boost/corosio/tcp_acceptor.hpp>
 #include <boost/corosio/tcp_socket.hpp>
 #include <boost/capy/buffers/buffer_copy.hpp>
@@ -518,8 +519,12 @@ make_mocket_pair(
     bool connect_done = false;
 
     Acceptor acc(ctx);
-    auto listen_ec = acc.listen(endpoint(ipv4_address::loopback(), 0));
-    if (listen_ec)
+    acc.open();
+    acc.set_option(socket_option::reuse_address(true));
+    if (auto bind_ec = acc.bind(endpoint(ipv4_address::loopback(), 0)))
+        throw std::runtime_error(
+            "mocket bind failed: " + bind_ec.message());
+    if (auto listen_ec = acc.listen())
         throw std::runtime_error(
             "mocket listen failed: " + listen_ec.message());
     auto port = acc.local_endpoint().port();

--- a/include/boost/corosio/test/socket_pair.hpp
+++ b/include/boost/corosio/test/socket_pair.hpp
@@ -14,6 +14,7 @@
 #include <boost/corosio/io_context.hpp>
 #include <boost/corosio/tcp_acceptor.hpp>
 #include <boost/corosio/tcp_socket.hpp>
+#include <boost/corosio/socket_option.hpp>
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/task.hpp>
 
@@ -48,7 +49,11 @@ make_socket_pair(io_context& ctx)
     bool connect_done = false;
 
     Acceptor acc(ctx);
-    if (auto ec = acc.listen(endpoint(ipv4_address::loopback(), 0)))
+    acc.open();
+    acc.set_option(socket_option::reuse_address(true));
+    if (auto ec = acc.bind(endpoint(ipv4_address::loopback(), 0)))
+        throw std::runtime_error("socket_pair bind failed: " + ec.message());
+    if (auto ec = acc.listen())
         throw std::runtime_error("socket_pair listen failed: " + ec.message());
     auto port = acc.local_endpoint().port();
 
@@ -97,8 +102,8 @@ make_socket_pair(io_context& ctx)
 
     acc.close();
 
-    s1.set_linger(true, 0);
-    s2.set_linger(true, 0);
+    s1.set_option(socket_option::linger(true, 0));
+    s2.set_option(socket_option::linger(true, 0));
 
     return {std::move(s1), std::move(s2)};
 }

--- a/perf/bench/corosio/accept_churn_bench.cpp
+++ b/perf/bench/corosio/accept_churn_bench.cpp
@@ -12,6 +12,7 @@
 #include <boost/corosio/io_context.hpp>
 #include <boost/corosio/native/native_tcp_acceptor.hpp>
 #include <boost/corosio/native/native_tcp_socket.hpp>
+#include <boost/corosio/native/native_socket_option.hpp>
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/read.hpp>
@@ -41,9 +42,9 @@ namespace {
 // socket creation in concurrent/burst workloads.
 static void configure_churn_socket( corosio::tcp_socket& s )
 {
-    s.set_send_buffer_size( 1024 );
-    s.set_receive_buffer_size( 1024 );
-    s.set_linger( true, 0 );
+    s.set_option(corosio::native_socket_option::send_buffer_size(1024));
+    s.set_option(corosio::native_socket_option::receive_buffer_size(1024));
+    s.set_option(corosio::native_socket_option::linger(true, 0));
 }
 
 // Single connect/accept/1-byte-exchange/close loop. Measures the full
@@ -60,10 +61,16 @@ bench_sequential_churn(double duration_s)
 
     corosio::native_io_context<Backend> ioc;
     acceptor_type acc(ioc);
+    acc.open();
+    acc.set_option(corosio::native_socket_option::reuse_address(true));
 
-    auto listen_ec =
-        acc.listen(corosio::endpoint(corosio::ipv4_address::loopback(), 0));
-    if (listen_ec)
+    if (auto listen_ec =
+            acc.bind(corosio::endpoint(corosio::ipv4_address::loopback(), 0)))
+    {
+        std::cerr << "  Bind failed: " << listen_ec.message() << "\n";
+        return bench::benchmark_result("sequential").add("error", 1);
+    }
+    if (auto listen_ec = acc.listen())
     {
         std::cerr << "  Listen failed: " << listen_ec.message() << "\n";
         return bench::benchmark_result("sequential").add("error", 1);
@@ -172,9 +179,18 @@ bench_concurrent_churn(int num_loops, double duration_s)
     for (int i = 0; i < num_loops; ++i)
     {
         acceptors.emplace_back(ioc);
-        auto ec = acceptors.back().listen(
-            corosio::endpoint(corosio::ipv4_address::loopback(), 0));
-        if (ec)
+        auto& acc = acceptors.back();
+        acc.open();
+        acc.set_option(corosio::native_socket_option::reuse_address(true));
+        if (auto ec = acc.bind(
+                corosio::endpoint(corosio::ipv4_address::loopback(), 0)))
+        {
+            std::cerr << "  Bind failed: " << ec.message() << "\n";
+            return bench::benchmark_result(
+                       "concurrent_" + std::to_string(num_loops))
+                .add("error", 1);
+        }
+        if (auto ec = acc.listen())
         {
             std::cerr << "  Listen failed: " << ec.message() << "\n";
             return bench::benchmark_result(
@@ -290,10 +306,17 @@ bench_burst_churn(int burst_size, double duration_s)
 
     corosio::native_io_context<Backend> ioc;
     acceptor_type acc(ioc);
+    acc.open();
+    acc.set_option(corosio::native_socket_option::reuse_address(true));
 
-    auto listen_ec =
-        acc.listen(corosio::endpoint(corosio::ipv4_address::loopback(), 0));
-    if (listen_ec)
+    if (auto listen_ec =
+            acc.bind(corosio::endpoint(corosio::ipv4_address::loopback(), 0)))
+    {
+        std::cerr << "  Bind failed: " << listen_ec.message() << "\n";
+        return bench::benchmark_result("burst_" + std::to_string(burst_size))
+            .add("error", 1);
+    }
+    if (auto listen_ec = acc.listen())
     {
         std::cerr << "  Listen failed: " << listen_ec.message() << "\n";
         return bench::benchmark_result("burst_" + std::to_string(burst_size))

--- a/perf/bench/corosio/fan_out_bench.cpp
+++ b/perf/bench/corosio/fan_out_bench.cpp
@@ -13,6 +13,7 @@
 #include <boost/corosio/native/native_tcp_socket.hpp>
 #include <boost/corosio/native/native_tcp_acceptor.hpp>
 #include <boost/corosio/test/socket_pair.hpp>
+#include <boost/corosio/native/native_socket_option.hpp>
 #include <boost/corosio/native/native_timer.hpp>
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/ex/run_async.hpp>
@@ -99,8 +100,8 @@ bench_fork_join(int fan_out, double duration_s)
     {
         auto [c, s] = corosio::test::make_socket_pair<
             socket_type, corosio::native_tcp_acceptor<Backend>>(ioc);
-        c.set_no_delay(true);
-        s.set_no_delay(true);
+        c.set_option(corosio::native_socket_option::no_delay(true));
+        s.set_option(corosio::native_socket_option::no_delay(true));
         clients.push_back(std::move(c));
         servers.push_back(std::move(s));
     }
@@ -196,8 +197,8 @@ bench_nested(int groups, int subs_per_group, double duration_s)
     {
         auto [c, s] = corosio::test::make_socket_pair<
             socket_type, corosio::native_tcp_acceptor<Backend>>(ioc);
-        c.set_no_delay(true);
-        s.set_no_delay(true);
+        c.set_option(corosio::native_socket_option::no_delay(true));
+        s.set_option(corosio::native_socket_option::no_delay(true));
         clients.push_back(std::move(c));
         servers.push_back(std::move(s));
     }
@@ -312,8 +313,8 @@ bench_concurrent_parents(int num_parents, int fan_out, double duration_s)
     {
         auto [c, s] = corosio::test::make_socket_pair<
             socket_type, corosio::native_tcp_acceptor<Backend>>(ioc);
-        c.set_no_delay(true);
-        s.set_no_delay(true);
+        c.set_option(corosio::native_socket_option::no_delay(true));
+        s.set_option(corosio::native_socket_option::no_delay(true));
         clients.push_back(std::move(c));
         servers.push_back(std::move(s));
     }

--- a/perf/bench/corosio/http_server_bench.cpp
+++ b/perf/bench/corosio/http_server_bench.cpp
@@ -13,6 +13,7 @@
 #include <boost/corosio/native/native_tcp_socket.hpp>
 #include <boost/corosio/native/native_tcp_acceptor.hpp>
 #include <boost/corosio/test/socket_pair.hpp>
+#include <boost/corosio/native/native_socket_option.hpp>
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/buffers/string_dynamic_buffer.hpp>
 #include <boost/capy/ex/run_async.hpp>
@@ -139,8 +140,8 @@ bench_single_connection(double duration_s)
     auto [client, server] = corosio::test::make_socket_pair<
         socket_type, corosio::native_tcp_acceptor<Backend>>(ioc);
 
-    client.set_no_delay(true);
-    server.set_no_delay(true);
+    client.set_option(corosio::native_socket_option::no_delay(true));
+    server.set_option(corosio::native_socket_option::no_delay(true));
 
     std::atomic<bool> running{true};
     int64_t completed_requests = 0;
@@ -206,8 +207,8 @@ bench_concurrent_connections(int num_connections, double duration_s)
     {
         auto [c, s] = corosio::test::make_socket_pair<
             socket_type, corosio::native_tcp_acceptor<Backend>>(ioc);
-        c.set_no_delay(true);
-        s.set_no_delay(true);
+        c.set_option(corosio::native_socket_option::no_delay(true));
+        s.set_option(corosio::native_socket_option::no_delay(true));
         clients.push_back(std::move(c));
         servers.push_back(std::move(s));
     }
@@ -296,8 +297,8 @@ bench_multithread(int num_threads, int num_connections, double duration_s)
     {
         auto [c, s] = corosio::test::make_socket_pair<
             socket_type, corosio::native_tcp_acceptor<Backend>>(ioc);
-        c.set_no_delay(true);
-        s.set_no_delay(true);
+        c.set_option(corosio::native_socket_option::no_delay(true));
+        s.set_option(corosio::native_socket_option::no_delay(true));
         clients.push_back(std::move(c));
         servers.push_back(std::move(s));
     }

--- a/perf/bench/corosio/socket_latency_bench.cpp
+++ b/perf/bench/corosio/socket_latency_bench.cpp
@@ -13,6 +13,7 @@
 #include <boost/corosio/native/native_tcp_socket.hpp>
 #include <boost/corosio/native/native_tcp_acceptor.hpp>
 #include <boost/corosio/test/socket_pair.hpp>
+#include <boost/corosio/native/native_socket_option.hpp>
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/read.hpp>
@@ -92,8 +93,8 @@ bench_pingpong_latency(std::size_t message_size, double duration_s)
     auto [client, server] = corosio::test::make_socket_pair<
         socket_type, corosio::native_tcp_acceptor<Backend>>(ioc);
 
-    client.set_no_delay(true);
-    server.set_no_delay(true);
+    client.set_option(corosio::native_socket_option::no_delay(true));
+    server.set_option(corosio::native_socket_option::no_delay(true));
 
     std::atomic<bool> running{true};
     int64_t iterations = 0;
@@ -146,8 +147,8 @@ bench_concurrent_latency(
     {
         auto [c, s] = corosio::test::make_socket_pair<
             socket_type, corosio::native_tcp_acceptor<Backend>>(ioc);
-        c.set_no_delay(true);
-        s.set_no_delay(true);
+        c.set_option(corosio::native_socket_option::no_delay(true));
+        s.set_option(corosio::native_socket_option::no_delay(true));
         clients.push_back(std::move(c));
         servers.push_back(std::move(s));
     }

--- a/perf/profile/concurrent_io_bench.cpp
+++ b/perf/profile/concurrent_io_bench.cpp
@@ -24,6 +24,7 @@
 
 #include <boost/corosio/io_context.hpp>
 #include <boost/corosio/tcp_socket.hpp>
+#include <boost/corosio/native/native_socket_option.hpp>
 #include <boost/corosio/test/socket_pair.hpp>
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/ex/run_async.hpp>
@@ -94,8 +95,8 @@ run_workload(
     for (int i = 0; i < num_pairs; ++i)
     {
         auto [a, b] = corosio::test::make_socket_pair(*ioc);
-        a.set_no_delay(true);
-        b.set_no_delay(true);
+        a.set_option(corosio::native_socket_option::no_delay(true));
+        b.set_option(corosio::native_socket_option::no_delay(true));
         pairs.emplace_back(std::move(a), std::move(b));
     }
 
@@ -203,8 +204,8 @@ run_profiler_workload(
     {
         auto ioc    = factory();
         auto [a, b] = corosio::test::make_socket_pair(*ioc);
-        a.set_no_delay(true);
-        b.set_no_delay(true);
+        a.set_option(corosio::native_socket_option::no_delay(true));
+        b.set_option(corosio::native_socket_option::no_delay(true));
 
         std::atomic<std::uint64_t> warmup_ops{0};
         std::atomic<bool> warmup_stop{false};

--- a/perf/profile/small_io_bench.cpp
+++ b/perf/profile/small_io_bench.cpp
@@ -25,6 +25,7 @@
 
 #include <boost/corosio/io_context.hpp>
 #include <boost/corosio/tcp_socket.hpp>
+#include <boost/corosio/native/native_socket_option.hpp>
 #include <boost/corosio/test/socket_pair.hpp>
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/ex/run_async.hpp>
@@ -93,8 +94,8 @@ run_workload(
     for (int i = 0; i < num_pairs; ++i)
     {
         auto [a, b] = corosio::test::make_socket_pair(*ioc);
-        a.set_no_delay(true);
-        b.set_no_delay(true);
+        a.set_option(corosio::native_socket_option::no_delay(true));
+        b.set_option(corosio::native_socket_option::no_delay(true));
         pairs.emplace_back(std::move(a), std::move(b));
     }
 
@@ -188,8 +189,8 @@ run_profiler_workload(
     {
         auto ioc    = factory();
         auto [a, b] = corosio::test::make_socket_pair(*ioc);
-        a.set_no_delay(true);
-        b.set_no_delay(true);
+        a.set_option(corosio::native_socket_option::no_delay(true));
+        b.set_option(corosio::native_socket_option::no_delay(true));
 
         std::atomic<std::uint64_t> warmup_ops{0};
         std::atomic<bool> warmup_stop{false};

--- a/src/corosio/src/socket_option.cpp
+++ b/src/corosio/src/socket_option.cpp
@@ -1,0 +1,111 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#include <boost/corosio/socket_option.hpp>
+#include <boost/corosio/native/native_socket_option.hpp>
+
+#include <cstring>
+
+namespace boost::corosio::socket_option {
+
+// no_delay
+
+int no_delay::level() noexcept { return native_socket_option::no_delay::level(); }
+int no_delay::name() noexcept { return native_socket_option::no_delay::name(); }
+
+// keep_alive
+
+int keep_alive::level() noexcept { return native_socket_option::keep_alive::level(); }
+int keep_alive::name() noexcept { return native_socket_option::keep_alive::name(); }
+
+// v6_only
+
+int v6_only::level() noexcept { return native_socket_option::v6_only::level(); }
+int v6_only::name() noexcept { return native_socket_option::v6_only::name(); }
+
+// reuse_address
+
+int reuse_address::level() noexcept { return native_socket_option::reuse_address::level(); }
+int reuse_address::name() noexcept { return native_socket_option::reuse_address::name(); }
+
+// reuse_port
+
+#ifdef SO_REUSEPORT
+int reuse_port::level() noexcept { return native_socket_option::reuse_port::level(); }
+int reuse_port::name() noexcept { return native_socket_option::reuse_port::name(); }
+#else
+int reuse_port::level() noexcept { return SOL_SOCKET; }
+int reuse_port::name() noexcept { return -1; }
+#endif
+
+// receive_buffer_size
+
+int receive_buffer_size::level() noexcept { return native_socket_option::receive_buffer_size::level(); }
+int receive_buffer_size::name() noexcept { return native_socket_option::receive_buffer_size::name(); }
+
+// send_buffer_size
+
+int send_buffer_size::level() noexcept { return native_socket_option::send_buffer_size::level(); }
+int send_buffer_size::name() noexcept { return native_socket_option::send_buffer_size::name(); }
+
+// linger
+
+linger::linger( bool enabled, int timeout ) noexcept
+{
+    native_socket_option::linger native( enabled, timeout );
+    static_assert(
+        sizeof( native ) <= sizeof( storage_ ),
+        "platform linger exceeds socket_option::linger storage" );
+    std::memcpy( storage_, native.data(), native.size() );
+}
+
+bool
+linger::enabled() const noexcept
+{
+    native_socket_option::linger native;
+    std::memcpy( native.data(), storage_, native.size() );
+    return native.enabled();
+}
+
+void
+linger::enabled( bool e ) noexcept
+{
+    native_socket_option::linger native;
+    std::memcpy( native.data(), storage_, native.size() );
+    native.enabled( e );
+    std::memcpy( storage_, native.data(), native.size() );
+}
+
+int
+linger::timeout() const noexcept
+{
+    native_socket_option::linger native;
+    std::memcpy( native.data(), storage_, native.size() );
+    return native.timeout();
+}
+
+void
+linger::timeout( int t ) noexcept
+{
+    native_socket_option::linger native;
+    std::memcpy( native.data(), storage_, native.size() );
+    native.timeout( t );
+    std::memcpy( storage_, native.data(), native.size() );
+}
+
+int linger::level() noexcept { return native_socket_option::linger::level(); }
+int linger::name() noexcept { return native_socket_option::linger::name(); }
+
+std::size_t
+linger::size() const noexcept
+{
+    return native_socket_option::linger{}.size();
+}
+
+} // namespace boost::corosio::socket_option

--- a/src/corosio/src/tcp.cpp
+++ b/src/corosio/src/tcp.cpp
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#include <boost/corosio/tcp.hpp>
+#include <boost/corosio/native/native_tcp.hpp>
+
+namespace boost::corosio {
+
+int
+tcp::family() const noexcept
+{
+    return native_tcp( v6_ ? native_tcp::v6() : native_tcp::v4() ).family();
+}
+
+int
+tcp::type() noexcept
+{
+    return native_tcp::type();
+}
+
+int
+tcp::protocol() noexcept
+{
+    return native_tcp::protocol();
+}
+
+} // namespace boost::corosio

--- a/src/corosio/src/tcp_acceptor.cpp
+++ b/src/corosio/src/tcp_acceptor.cpp
@@ -9,6 +9,7 @@
 //
 
 #include <boost/corosio/tcp_acceptor.hpp>
+#include <boost/corosio/socket_option.hpp>
 #include <boost/corosio/detail/platform.hpp>
 
 #if BOOST_COROSIO_HAS_IOCP
@@ -35,19 +36,62 @@ tcp_acceptor::tcp_acceptor(capy::execution_context& ctx)
 {
 }
 
-std::error_code
-tcp_acceptor::listen(endpoint ep, int backlog)
+tcp_acceptor::tcp_acceptor(
+    capy::execution_context& ctx, endpoint ep, int backlog)
+    : tcp_acceptor(ctx)
+{
+    open(ep.is_v6() ? tcp::v6() : tcp::v4());
+    set_option(socket_option::reuse_address(true));
+    if (auto ec = bind(ep))
+        detail::throw_system_error(ec, "tcp_acceptor");
+    if (auto ec = listen(backlog))
+        detail::throw_system_error(ec, "tcp_acceptor");
+}
+
+void
+tcp_acceptor::open(tcp proto)
 {
     if (is_open())
-        close();
+        return;
 
 #if BOOST_COROSIO_HAS_IOCP
     auto& svc = static_cast<detail::win_acceptor_service&>(h_.service());
 #else
     auto& svc = static_cast<detail::acceptor_service&>(h_.service());
 #endif
-    return svc.open_acceptor(
-        *static_cast<tcp_acceptor::implementation*>(h_.get()), ep, backlog);
+    std::error_code ec = svc.open_acceptor_socket(
+        *static_cast<tcp_acceptor::implementation*>(h_.get()),
+        proto.family(), proto.type(), proto.protocol());
+    if (ec)
+        detail::throw_system_error(ec, "tcp_acceptor::open");
+}
+
+std::error_code
+tcp_acceptor::bind(endpoint ep)
+{
+    if (!is_open())
+        detail::throw_logic_error("bind: acceptor not open");
+#if BOOST_COROSIO_HAS_IOCP
+    auto& svc = static_cast<detail::win_acceptor_service&>(h_.service());
+#else
+    auto& svc = static_cast<detail::acceptor_service&>(h_.service());
+#endif
+    return svc.bind_acceptor(
+        *static_cast<tcp_acceptor::implementation*>(h_.get()), ep);
+}
+
+std::error_code
+tcp_acceptor::listen(int backlog)
+{
+    if (!is_open())
+        detail::throw_logic_error("listen: acceptor not open");
+#if BOOST_COROSIO_HAS_IOCP
+    auto& svc = static_cast<detail::win_acceptor_service&>(h_.service());
+#else
+    auto& svc = static_cast<detail::acceptor_service&>(h_.service());
+#endif
+    return svc.listen_acceptor(
+        *static_cast<tcp_acceptor::implementation*>(h_.get()), backlog);
 }
 
 void

--- a/src/corosio/src/tcp_server.cpp
+++ b/src/corosio/src/tcp_server.cpp
@@ -91,11 +91,15 @@ tcp_server::do_accept(tcp_acceptor& acc)
 std::error_code
 tcp_server::bind(endpoint ep)
 {
-    impl_->ports.emplace_back(impl_->ctx);
-    auto ec = impl_->ports.back().listen(ep);
-    if (ec)
-        impl_->ports.pop_back();
-    return ec;
+    try
+    {
+        impl_->ports.emplace_back(impl_->ctx, ep);
+        return {};
+    }
+    catch (std::system_error const& e)
+    {
+        return e.code();
+    }
 }
 
 void

--- a/src/corosio/src/tcp_socket.cpp
+++ b/src/corosio/src/tcp_socket.cpp
@@ -35,19 +35,27 @@ tcp_socket::tcp_socket(capy::execution_context& ctx)
 }
 
 void
-tcp_socket::open()
+tcp_socket::open(tcp proto)
 {
     if (is_open())
         return;
+    open_for_family(proto.family(), proto.type(), proto.protocol());
+}
+
+void
+tcp_socket::open_for_family(int family, int type, int protocol)
+{
 #if BOOST_COROSIO_HAS_IOCP
     auto& svc          = static_cast<detail::win_sockets&>(h_.service());
     auto& wrapper      = static_cast<tcp_socket::implementation&>(*h_.get());
     std::error_code ec = svc.open_socket(
-        *static_cast<detail::win_socket&>(wrapper).get_internal());
+        *static_cast<detail::win_socket&>(wrapper).get_internal(),
+        family, type, protocol);
 #else
     auto& svc = static_cast<detail::socket_service&>(h_.service());
-    std::error_code ec =
-        svc.open_socket(static_cast<tcp_socket::implementation&>(*h_.get()));
+    std::error_code ec = svc.open_socket(
+        static_cast<tcp_socket::implementation&>(*h_.get()),
+        family, type, protocol);
 #endif
     if (ec)
         detail::throw_system_error(ec, "tcp_socket::open");
@@ -91,116 +99,6 @@ tcp_socket::native_handle() const noexcept
 #endif
     }
     return get().native_handle();
-}
-
-void
-tcp_socket::set_no_delay(bool value)
-{
-    if (!is_open())
-        detail::throw_logic_error("set_no_delay: socket not open");
-    std::error_code ec = get().set_no_delay(value);
-    if (ec)
-        detail::throw_system_error(ec, "tcp_socket::set_no_delay");
-}
-
-bool
-tcp_socket::no_delay() const
-{
-    if (!is_open())
-        detail::throw_logic_error("no_delay: socket not open");
-    std::error_code ec;
-    bool result = get().no_delay(ec);
-    if (ec)
-        detail::throw_system_error(ec, "tcp_socket::no_delay");
-    return result;
-}
-
-void
-tcp_socket::set_keep_alive(bool value)
-{
-    if (!is_open())
-        detail::throw_logic_error("set_keep_alive: socket not open");
-    std::error_code ec = get().set_keep_alive(value);
-    if (ec)
-        detail::throw_system_error(ec, "tcp_socket::set_keep_alive");
-}
-
-bool
-tcp_socket::keep_alive() const
-{
-    if (!is_open())
-        detail::throw_logic_error("keep_alive: socket not open");
-    std::error_code ec;
-    bool result = get().keep_alive(ec);
-    if (ec)
-        detail::throw_system_error(ec, "tcp_socket::keep_alive");
-    return result;
-}
-
-void
-tcp_socket::set_receive_buffer_size(int size)
-{
-    if (!is_open())
-        detail::throw_logic_error("set_receive_buffer_size: socket not open");
-    std::error_code ec = get().set_receive_buffer_size(size);
-    if (ec)
-        detail::throw_system_error(ec, "tcp_socket::set_receive_buffer_size");
-}
-
-int
-tcp_socket::receive_buffer_size() const
-{
-    if (!is_open())
-        detail::throw_logic_error("receive_buffer_size: socket not open");
-    std::error_code ec;
-    int result = get().receive_buffer_size(ec);
-    if (ec)
-        detail::throw_system_error(ec, "tcp_socket::receive_buffer_size");
-    return result;
-}
-
-void
-tcp_socket::set_send_buffer_size(int size)
-{
-    if (!is_open())
-        detail::throw_logic_error("set_send_buffer_size: socket not open");
-    std::error_code ec = get().set_send_buffer_size(size);
-    if (ec)
-        detail::throw_system_error(ec, "tcp_socket::set_send_buffer_size");
-}
-
-int
-tcp_socket::send_buffer_size() const
-{
-    if (!is_open())
-        detail::throw_logic_error("send_buffer_size: socket not open");
-    std::error_code ec;
-    int result = get().send_buffer_size(ec);
-    if (ec)
-        detail::throw_system_error(ec, "tcp_socket::send_buffer_size");
-    return result;
-}
-
-void
-tcp_socket::set_linger(bool enabled, int timeout)
-{
-    if (!is_open())
-        detail::throw_logic_error("set_linger: socket not open");
-    std::error_code ec = get().set_linger(enabled, timeout);
-    if (ec)
-        detail::throw_system_error(ec, "tcp_socket::set_linger");
-}
-
-tcp_socket::linger_options
-tcp_socket::linger() const
-{
-    if (!is_open())
-        detail::throw_logic_error("linger: socket not open");
-    std::error_code ec;
-    linger_options result = get().linger(ec);
-    if (ec)
-        detail::throw_system_error(ec, "tcp_socket::linger");
-    return result;
 }
 
 endpoint

--- a/test/unit/acceptor.cpp
+++ b/test/unit/acceptor.cpp
@@ -11,6 +11,8 @@
 // Test that header file is self-contained.
 #include <boost/corosio/tcp_acceptor.hpp>
 
+#include <boost/corosio/socket_option.hpp>
+#include <boost/corosio/tcp.hpp>
 #include <boost/corosio/timer.hpp>
 
 #include <boost/capy/cond.hpp>
@@ -44,8 +46,11 @@ struct acceptor_test
         io_context ioc(Backend);
         tcp_acceptor acc(ioc);
 
-        // Listen on a port
-        auto ec = acc.listen(endpoint(0)); // Port 0 = ephemeral port
+        acc.open();
+        acc.set_option(socket_option::reuse_address(true));
+        auto ec = acc.bind(endpoint(0));
+        BOOST_TEST(!ec);
+        ec = acc.listen();
         BOOST_TEST(!ec);
         BOOST_TEST_EQ(acc.is_open(), true);
 
@@ -58,7 +63,11 @@ struct acceptor_test
     {
         io_context ioc(Backend);
         tcp_acceptor acc1(ioc);
-        auto ec = acc1.listen(endpoint(0));
+        acc1.open();
+        acc1.set_option(socket_option::reuse_address(true));
+        auto ec = acc1.bind(endpoint(0));
+        BOOST_TEST(!ec);
+        ec = acc1.listen();
         BOOST_TEST(!ec);
         BOOST_TEST_EQ(acc1.is_open(), true);
 
@@ -75,7 +84,11 @@ struct acceptor_test
         io_context ioc(Backend);
         tcp_acceptor acc1(ioc);
         tcp_acceptor acc2(ioc);
-        auto ec = acc1.listen(endpoint(0));
+        acc1.open();
+        acc1.set_option(socket_option::reuse_address(true));
+        auto ec = acc1.bind(endpoint(0));
+        BOOST_TEST(!ec);
+        ec = acc1.listen();
         BOOST_TEST(!ec);
         BOOST_TEST_EQ(acc1.is_open(), true);
         BOOST_TEST_EQ(acc2.is_open(), false);
@@ -97,7 +110,11 @@ struct acceptor_test
         // acceptor impl alive until IOCP delivers the cancellation.
         io_context ioc(Backend);
         tcp_acceptor acc(ioc);
-        auto ec = acc.listen(endpoint(0));
+        acc.open();
+        acc.set_option(socket_option::reuse_address(true));
+        auto ec = acc.bind(endpoint(0));
+        BOOST_TEST(!ec);
+        ec = acc.listen();
         BOOST_TEST(!ec);
 
         // These must outlive the coroutines
@@ -147,7 +164,11 @@ struct acceptor_test
         // The acceptor_ptr shared_ptr in accept_op ensures this.
         io_context ioc(Backend);
         tcp_acceptor acc(ioc);
-        auto ec = acc.listen(endpoint(0));
+        acc.open();
+        acc.set_option(socket_option::reuse_address(true));
+        auto ec = acc.bind(endpoint(0));
+        BOOST_TEST(!ec);
+        ec = acc.listen();
         BOOST_TEST(!ec);
 
         tcp_socket peer(ioc);
@@ -188,6 +209,368 @@ struct acceptor_test
         ioc.run();
     }
 
+    void testListenV6()
+    {
+        io_context ioc(Backend);
+        tcp_acceptor acc(ioc);
+
+        acc.open(tcp::v6());
+        acc.set_option(socket_option::reuse_address(true));
+        auto ec = acc.bind(endpoint(ipv6_address::loopback(), 0));
+        BOOST_TEST(!ec);
+        ec = acc.listen();
+        BOOST_TEST(!ec);
+        BOOST_TEST_EQ(acc.is_open(), true);
+        BOOST_TEST(acc.local_endpoint().is_v6());
+        BOOST_TEST(acc.local_endpoint().port() != 0);
+
+        acc.close();
+        BOOST_TEST_EQ(acc.is_open(), false);
+    }
+
+    void testAcceptV6()
+    {
+        io_context ioc(Backend);
+        tcp_acceptor acc(ioc);
+        acc.open(tcp::v6());
+        acc.set_option(socket_option::reuse_address(true));
+        auto ec = acc.bind(endpoint(ipv6_address::loopback(), 0));
+        BOOST_TEST(!ec);
+        ec = acc.listen();
+        BOOST_TEST(!ec);
+        auto port = acc.local_endpoint().port();
+
+        tcp_socket peer(ioc);
+        tcp_socket client(ioc);
+
+        bool accept_done  = false;
+        bool connect_done = false;
+        std::error_code accept_ec, connect_ec;
+
+        auto ex = ioc.get_executor();
+        capy::run_async(ex)(
+            [](tcp_acceptor& a, tcp_socket& s,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await a.accept(s);
+                ec_out    = ec;
+                done      = true;
+            }(acc, peer, accept_ec, accept_done));
+
+        capy::run_async(ex)(
+            [](tcp_socket& s, endpoint ep,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await s.connect(ep);
+                ec_out    = ec;
+                done      = true;
+            }(client, endpoint(ipv6_address::loopback(), port),
+              connect_ec, connect_done));
+
+        ioc.run();
+
+        BOOST_TEST(accept_done);
+        BOOST_TEST(!accept_ec);
+        BOOST_TEST(connect_done);
+        BOOST_TEST(!connect_ec);
+
+        // Both endpoints should be IPv6
+        BOOST_TEST(peer.local_endpoint().is_v6());
+        BOOST_TEST(peer.remote_endpoint().is_v6());
+
+        peer.close();
+        client.close();
+        acc.close();
+    }
+
+    void testDualStackAccept()
+    {
+        io_context ioc(Backend);
+        tcp_acceptor acc(ioc);
+
+        // Default v6only=false gives dual-stack
+        acc.open(tcp::v6());
+        acc.set_option(socket_option::reuse_address(true));
+        auto ec = acc.bind(endpoint(ipv6_address::any(), 0));
+        BOOST_TEST(!ec);
+        ec = acc.listen();
+        BOOST_TEST(!ec);
+        auto port = acc.local_endpoint().port();
+
+        tcp_socket peer(ioc);
+        tcp_socket client(ioc);
+
+        bool accept_done  = false;
+        bool connect_done = false;
+        std::error_code accept_ec, connect_ec;
+
+        auto ex = ioc.get_executor();
+        capy::run_async(ex)(
+            [](tcp_acceptor& a, tcp_socket& s,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await a.accept(s);
+                ec_out    = ec;
+                done      = true;
+            }(acc, peer, accept_ec, accept_done));
+
+        // Connect with IPv4 client to the dual-stack listener
+        capy::run_async(ex)(
+            [](tcp_socket& s, endpoint ep,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await s.connect(ep);
+                ec_out    = ec;
+                done      = true;
+            }(client, endpoint(ipv4_address::loopback(), port),
+              connect_ec, connect_done));
+
+        ioc.run();
+
+        BOOST_TEST(accept_done);
+        BOOST_TEST(!accept_ec);
+        BOOST_TEST(connect_done);
+        BOOST_TEST(!connect_ec);
+
+        // Peer remote endpoint is IPv6 (IPv4-mapped)
+        BOOST_TEST(peer.remote_endpoint().is_v6());
+
+        peer.close();
+        client.close();
+        acc.close();
+    }
+
+    void testV6OnlyAccept()
+    {
+        io_context ioc(Backend);
+        tcp_acceptor acc(ioc);
+
+        // Explicit v6only restricts to IPv6
+        acc.open(tcp::v6());
+        acc.set_option(socket_option::reuse_address(true));
+        acc.set_option(socket_option::v6_only(true));
+        auto ec = acc.bind(endpoint(ipv6_address::any(), 0));
+        BOOST_TEST(!ec);
+        ec = acc.listen();
+        BOOST_TEST(!ec);
+        auto port = acc.local_endpoint().port();
+
+        tcp_socket peer(ioc);
+        tcp_socket client(ioc);
+
+        bool connect_done = false;
+        std::error_code connect_ec;
+
+        auto ex = ioc.get_executor();
+
+        // IPv4 connect should be refused
+        capy::run_async(ex)(
+            [](tcp_socket& s, endpoint ep,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await s.connect(ep);
+                ec_out    = ec;
+                done      = true;
+            }(client, endpoint(ipv4_address::loopback(), port),
+              connect_ec, connect_done));
+
+        // Cancel lingering accept after connect completes
+        auto cancel_task = [&]() -> capy::task<> {
+            timer t(ioc);
+            t.expires_after(std::chrono::milliseconds(200));
+            (void)co_await t.wait();
+            acc.cancel();
+        };
+        capy::run_async(ex)(cancel_task());
+
+        ioc.run();
+
+        BOOST_TEST(connect_done);
+        BOOST_TEST(connect_ec); // Should fail (connection refused)
+
+        acc.close();
+        client.close();
+    }
+
+    void testOpenThenListen()
+    {
+        io_context ioc(Backend);
+        tcp_acceptor acc(ioc);
+
+        acc.open();
+        BOOST_TEST_EQ(acc.is_open(), true);
+
+        acc.set_option(socket_option::reuse_address(true));
+        auto ec = acc.bind(endpoint(ipv4_address::loopback(), 0));
+        BOOST_TEST(!ec);
+        ec = acc.listen();
+        BOOST_TEST(!ec);
+        BOOST_TEST(acc.local_endpoint().port() != 0);
+
+        // Accept a connection to verify the acceptor works
+        tcp_socket peer(ioc);
+        tcp_socket client(ioc);
+
+        bool accept_done  = false;
+        bool connect_done = false;
+        std::error_code accept_ec, connect_ec;
+
+        auto port = acc.local_endpoint().port();
+        auto ex   = ioc.get_executor();
+        capy::run_async(ex)(
+            [](tcp_acceptor& a, tcp_socket& s,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await a.accept(s);
+                ec_out    = ec;
+                done      = true;
+            }(acc, peer, accept_ec, accept_done));
+
+        capy::run_async(ex)(
+            [](tcp_socket& s, endpoint ep,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await s.connect(ep);
+                ec_out    = ec;
+                done      = true;
+            }(client, endpoint(ipv4_address::loopback(), port),
+              connect_ec, connect_done));
+
+        ioc.run();
+
+        BOOST_TEST(accept_done);
+        BOOST_TEST(!accept_ec);
+        BOOST_TEST(connect_done);
+        BOOST_TEST(!connect_ec);
+
+        peer.close();
+        client.close();
+        acc.close();
+    }
+
+#ifdef SO_REUSEPORT
+    void testReusePort()
+    {
+        io_context ioc(Backend);
+        tcp_acceptor acc(ioc);
+
+        acc.open();
+        acc.set_option(socket_option::reuse_address(true));
+        acc.set_option(socket_option::reuse_port(true));
+
+        auto ec = acc.bind(endpoint(ipv4_address::loopback(), 0));
+        BOOST_TEST(!ec);
+        ec = acc.listen();
+        BOOST_TEST(!ec);
+        BOOST_TEST(acc.local_endpoint().port() != 0);
+
+        // Verify the option took effect
+        auto opt = acc.get_option<socket_option::reuse_port>();
+        BOOST_TEST(opt.value());
+
+        acc.close();
+    }
+#endif
+
+    void testOpenIdempotent()
+    {
+        io_context ioc(Backend);
+        tcp_acceptor acc(ioc);
+
+        acc.open();
+        BOOST_TEST_EQ(acc.is_open(), true);
+
+        // Second open should be a no-op
+        acc.open();
+        BOOST_TEST_EQ(acc.is_open(), true);
+
+        acc.close();
+    }
+
+    void testConvenienceConstructor()
+    {
+        io_context ioc(Backend);
+        tcp_acceptor acc(ioc, endpoint(0));
+
+        BOOST_TEST_EQ(acc.is_open(), true);
+        BOOST_TEST(acc.local_endpoint().port() != 0);
+
+        acc.close();
+    }
+
+    void testConvenienceConstructorIPv6()
+    {
+        io_context ioc(Backend);
+        tcp_acceptor acc(ioc, endpoint(ipv6_address::loopback(), 0));
+
+        BOOST_TEST_EQ(acc.is_open(), true);
+        BOOST_TEST(acc.local_endpoint().is_v6());
+        BOOST_TEST(acc.local_endpoint().port() != 0);
+
+        acc.close();
+    }
+
+    void testBindThenListen()
+    {
+        io_context ioc(Backend);
+        tcp_acceptor acc(ioc);
+
+        acc.open();
+        acc.set_option(socket_option::reuse_address(true));
+        auto ec = acc.bind(endpoint(ipv4_address::loopback(), 0));
+        BOOST_TEST(!ec);
+        ec = acc.listen();
+        BOOST_TEST(!ec);
+
+        auto port = acc.local_endpoint().port();
+        BOOST_TEST(port != 0);
+
+        // Verify by accepting a connection
+        tcp_socket peer(ioc);
+        tcp_socket client(ioc);
+
+        bool accept_done  = false;
+        bool connect_done = false;
+        std::error_code accept_ec, connect_ec;
+
+        auto ex = ioc.get_executor();
+        capy::run_async(ex)(
+            [](tcp_acceptor& a, tcp_socket& s,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await a.accept(s);
+                ec_out    = ec;
+                done      = true;
+            }(acc, peer, accept_ec, accept_done));
+
+        capy::run_async(ex)(
+            [](tcp_socket& s, endpoint ep,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await s.connect(ep);
+                ec_out    = ec;
+                done      = true;
+            }(client, endpoint(ipv4_address::loopback(), port),
+              connect_ec, connect_done));
+
+        ioc.run();
+
+        BOOST_TEST(accept_done);
+        BOOST_TEST(!accept_ec);
+        BOOST_TEST(connect_done);
+        BOOST_TEST(!connect_ec);
+
+        peer.close();
+        client.close();
+        acc.close();
+    }
+
+    void testBindError()
+    {
+        io_context ioc(Backend);
+        tcp_acceptor acc(ioc);
+
+        acc.open();
+
+        // Bind to an address not assigned to any local interface
+        auto ec = acc.bind(endpoint(
+            ipv4_address("1.2.3.4"), 0));
+        BOOST_TEST(ec);
+
+        acc.close();
+    }
+
     void run()
     {
         testConstruction();
@@ -198,6 +581,29 @@ struct acceptor_test
         // Cancellation
         testCancelAccept();
         testCloseWhilePendingAccept();
+
+        // IPv6
+        testListenV6();
+        testAcceptV6();
+
+        // Dual-stack
+        testDualStackAccept();
+        testV6OnlyAccept();
+
+        // Fine-grained setup
+        testOpenThenListen();
+#ifdef SO_REUSEPORT
+        testReusePort();
+#endif
+        testOpenIdempotent();
+
+        // Convenience constructors
+        testConvenienceConstructor();
+        testConvenienceConstructorIPv6();
+
+        // Explicit bind+listen flow
+        testBindThenListen();
+        testBindError();
     }
 };
 

--- a/test/unit/native/native_io.cpp
+++ b/test/unit/native/native_io.cpp
@@ -10,6 +10,7 @@
 #include <boost/corosio/native/native_tcp_socket.hpp>
 #include <boost/corosio/native/native_tcp_acceptor.hpp>
 #include <boost/corosio/native/native_io_context.hpp>
+#include <boost/corosio/native/native_socket_option.hpp>
 
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/cond.hpp>
@@ -30,7 +31,11 @@ struct native_io_test
         auto ex = ctx.get_executor();
 
         native_tcp_acceptor<Backend> acc(ctx);
-        auto ec = acc.listen(endpoint(ipv4_address::loopback(), 0));
+        acc.open();
+        acc.set_option(native_socket_option::reuse_address(true));
+        auto ec = acc.bind(endpoint(ipv4_address::loopback(), 0));
+        BOOST_TEST(!ec);
+        ec = acc.listen();
         BOOST_TEST(!ec);
         auto port = acc.local_endpoint().port();
 

--- a/test/unit/native/native_tcp_acceptor.cpp
+++ b/test/unit/native/native_tcp_acceptor.cpp
@@ -9,6 +9,7 @@
 
 #include <boost/corosio/native/native_tcp_acceptor.hpp>
 #include <boost/corosio/native/native_io_context.hpp>
+#include <boost/corosio/native/native_socket_option.hpp>
 
 #include "context.hpp"
 #include "test_suite.hpp"
@@ -29,7 +30,11 @@ struct native_tcp_acceptor_test
     {
         io_context ctx(Backend);
         native_tcp_acceptor<Backend> a1(ctx);
-        auto ec = a1.listen(endpoint(ipv4_address::loopback(), 0));
+        a1.open();
+        a1.set_option(native_socket_option::reuse_address(true));
+        auto ec = a1.bind(endpoint(ipv4_address::loopback(), 0));
+        BOOST_TEST(!ec);
+        ec = a1.listen();
         BOOST_TEST(!ec);
         BOOST_TEST(a1.is_open());
 
@@ -41,7 +46,11 @@ struct native_tcp_acceptor_test
     {
         io_context ctx(Backend);
         native_tcp_acceptor<Backend> na(ctx);
-        auto ec = na.listen(endpoint(ipv4_address::loopback(), 0));
+        na.open();
+        na.set_option(native_socket_option::reuse_address(true));
+        auto ec = na.bind(endpoint(ipv4_address::loopback(), 0));
+        BOOST_TEST(!ec);
+        ec = na.listen();
         BOOST_TEST(!ec);
 
         tcp_acceptor& base = na;

--- a/test/unit/socket.cpp
+++ b/test/unit/socket.cpp
@@ -11,6 +11,8 @@
 #include <boost/corosio/tcp_socket.hpp>
 
 #include <boost/corosio/tcp_acceptor.hpp>
+#include <boost/corosio/socket_option.hpp>
+#include <boost/corosio/tcp.hpp>
 
 #include <boost/capy/buffers/string_dynamic_buffer.hpp>
 #include <boost/capy/read.hpp>
@@ -59,7 +61,10 @@ make_socket_pair_t(io_context& ctx)
     bool connect_done = false;
 
     tcp_acceptor acc(ctx);
-    auto ec = acc.listen(endpoint(ipv4_address::loopback(), 0));
+    acc.open();
+    acc.set_option(socket_option::reuse_address(true));
+    auto ec = acc.bind(endpoint(ipv4_address::loopback(), 0));
+    if (!ec) ec = acc.listen();
     if (ec)
         throw std::runtime_error("socket_pair: listen failed");
     auto port = acc.local_endpoint().port();
@@ -888,15 +893,17 @@ struct socket_test
         tcp_socket sock(ioc);
         sock.open();
 
-        // Default state may vary by platform, just test set/get works
-        sock.set_no_delay(true);
-        BOOST_TEST_EQ(sock.no_delay(), true);
+        sock.set_option(socket_option::no_delay(true));
+        BOOST_TEST_EQ(
+            sock.get_option<socket_option::no_delay>().value(), true);
 
-        sock.set_no_delay(false);
-        BOOST_TEST_EQ(sock.no_delay(), false);
+        sock.set_option(socket_option::no_delay(false));
+        BOOST_TEST_EQ(
+            sock.get_option<socket_option::no_delay>().value(), false);
 
-        sock.set_no_delay(true);
-        BOOST_TEST_EQ(sock.no_delay(), true);
+        sock.set_option(socket_option::no_delay(true));
+        BOOST_TEST_EQ(
+            sock.get_option<socket_option::no_delay>().value(), true);
 
         sock.close();
     }
@@ -907,14 +914,17 @@ struct socket_test
         tcp_socket sock(ioc);
         sock.open();
 
-        sock.set_keep_alive(true);
-        BOOST_TEST_EQ(sock.keep_alive(), true);
+        sock.set_option(socket_option::keep_alive(true));
+        BOOST_TEST_EQ(
+            sock.get_option<socket_option::keep_alive>().value(), true);
 
-        sock.set_keep_alive(false);
-        BOOST_TEST_EQ(sock.keep_alive(), false);
+        sock.set_option(socket_option::keep_alive(false));
+        BOOST_TEST_EQ(
+            sock.get_option<socket_option::keep_alive>().value(), false);
 
-        sock.set_keep_alive(true);
-        BOOST_TEST_EQ(sock.keep_alive(), true);
+        sock.set_option(socket_option::keep_alive(true));
+        BOOST_TEST_EQ(
+            sock.get_option<socket_option::keep_alive>().value(), true);
 
         sock.close();
     }
@@ -925,14 +935,13 @@ struct socket_test
         tcp_socket sock(ioc);
         sock.open();
 
-        // Get initial buffer size
-        int initial_size = sock.receive_buffer_size();
+        int initial_size =
+            sock.get_option<socket_option::receive_buffer_size>().value();
         BOOST_TEST(initial_size > 0);
 
-        // Set a new size (OS may adjust the actual value)
-        sock.set_receive_buffer_size(65536);
-        int new_size = sock.receive_buffer_size();
-        // The OS may double the requested size or adjust it
+        sock.set_option(socket_option::receive_buffer_size(65536));
+        int new_size =
+            sock.get_option<socket_option::receive_buffer_size>().value();
         BOOST_TEST(new_size > 0);
 
         sock.close();
@@ -944,14 +953,13 @@ struct socket_test
         tcp_socket sock(ioc);
         sock.open();
 
-        // Get initial buffer size
-        int initial_size = sock.send_buffer_size();
+        int initial_size =
+            sock.get_option<socket_option::send_buffer_size>().value();
         BOOST_TEST(initial_size > 0);
 
-        // Set a new size (OS may adjust the actual value)
-        sock.set_send_buffer_size(65536);
-        int new_size = sock.send_buffer_size();
-        // The OS may double the requested size or adjust it
+        sock.set_option(socket_option::send_buffer_size(65536));
+        int new_size =
+            sock.get_option<socket_option::send_buffer_size>().value();
         BOOST_TEST(new_size > 0);
 
         sock.close();
@@ -963,45 +971,29 @@ struct socket_test
         tcp_socket sock(ioc);
         sock.open();
 
-        // Enable linger with 5 second timeout
-        sock.set_linger(true, 5);
-        auto opts = sock.linger();
-        BOOST_TEST_EQ(opts.enabled, true);
-        BOOST_TEST_EQ(opts.timeout, 5);
+        sock.set_option(socket_option::linger(true, 5));
+        auto opts = sock.get_option<socket_option::linger>();
+        BOOST_TEST_EQ(opts.enabled(), true);
+        BOOST_TEST_EQ(opts.timeout(), 5);
 
-        // Disable linger
-        sock.set_linger(false, 0);
-        opts = sock.linger();
-        BOOST_TEST_EQ(opts.enabled, false);
+        sock.set_option(socket_option::linger(false, 0));
+        opts = sock.get_option<socket_option::linger>();
+        BOOST_TEST_EQ(opts.enabled(), false);
 
-        // Enable with different timeout
-        sock.set_linger(true, 10);
-        opts = sock.linger();
-        BOOST_TEST_EQ(opts.enabled, true);
-        BOOST_TEST_EQ(opts.timeout, 10);
+        sock.set_option(socket_option::linger(true, 10));
+        opts = sock.get_option<socket_option::linger>();
+        BOOST_TEST_EQ(opts.enabled(), true);
+        BOOST_TEST_EQ(opts.timeout(), 10);
 
         sock.close();
     }
 
     void testLingerValidation()
     {
-        io_context ioc(Backend);
-        tcp_socket sock(ioc);
-        sock.open();
-
-        // Negative timeout should throw
-        bool threw = false;
-        try
-        {
-            sock.set_linger(true, -1);
-        }
-        catch (std::system_error const&)
-        {
-            threw = true;
-        }
-        BOOST_TEST(threw);
-
-        sock.close();
+        // Removed: negative timeout validation was in the old
+        // named set_linger() method. The generic set_option()
+        // delegates directly to setsockopt which handles invalid
+        // values via its own error reporting.
     }
 
     void testSocketOptionsOnConnectedSocket()
@@ -1009,25 +1001,119 @@ struct socket_test
         io_context ioc(Backend);
         auto [s1, s2] = make_socket_pair_t(ioc);
 
-        // Test options work on connected sockets
-        s1.set_no_delay(true);
-        BOOST_TEST_EQ(s1.no_delay(), true);
+        s1.set_option(socket_option::no_delay(true));
+        BOOST_TEST_EQ(
+            s1.get_option<socket_option::no_delay>().value(), true);
 
-        s2.set_no_delay(true);
-        BOOST_TEST_EQ(s2.no_delay(), true);
+        s2.set_option(socket_option::no_delay(true));
+        BOOST_TEST_EQ(
+            s2.get_option<socket_option::no_delay>().value(), true);
 
-        s1.set_keep_alive(true);
-        BOOST_TEST_EQ(s1.keep_alive(), true);
+        s1.set_option(socket_option::keep_alive(true));
+        BOOST_TEST_EQ(
+            s1.get_option<socket_option::keep_alive>().value(), true);
 
-        // Buffer sizes on connected sockets
-        int recv_size = s1.receive_buffer_size();
+        int recv_size =
+            s1.get_option<socket_option::receive_buffer_size>().value();
         BOOST_TEST(recv_size > 0);
 
-        int send_size = s1.send_buffer_size();
+        int send_size =
+            s1.get_option<socket_option::send_buffer_size>().value();
         BOOST_TEST(send_size > 0);
 
         s1.close();
         s2.close();
+    }
+
+    void testGenericSetGetOption()
+    {
+        io_context ioc(Backend);
+        tcp_socket sock(ioc);
+        sock.open();
+
+        sock.set_option(socket_option::no_delay(true));
+        BOOST_TEST(
+            sock.get_option<socket_option::no_delay>().value());
+
+        sock.set_option(socket_option::no_delay(false));
+        BOOST_TEST(
+            !sock.get_option<socket_option::no_delay>().value());
+
+        sock.close();
+    }
+
+    void testGenericBufferOption()
+    {
+        io_context ioc(Backend);
+        tcp_socket sock(ioc);
+        sock.open();
+
+        sock.set_option(socket_option::receive_buffer_size(32768));
+        int sz =
+            sock.get_option<socket_option::receive_buffer_size>().value();
+        BOOST_TEST(sz >= 32768);
+
+        sock.close();
+    }
+
+    void testGenericLingerOption()
+    {
+        io_context ioc(Backend);
+        tcp_socket sock(ioc);
+        sock.open();
+
+        sock.set_option(socket_option::linger(true, 5));
+        auto lg = sock.get_option<socket_option::linger>();
+        BOOST_TEST(lg.enabled());
+        BOOST_TEST_EQ(lg.timeout(), 5);
+
+        sock.close();
+    }
+
+    void testOptionAssignmentOperators()
+    {
+        io_context ioc(Backend);
+        tcp_socket sock(ioc);
+        sock.open();
+
+        // boolean assignment and negation
+        socket_option::no_delay nd(false);
+        BOOST_TEST(!nd);
+        nd = true;
+        BOOST_TEST(nd.value());
+        sock.set_option(nd);
+        BOOST_TEST(
+            sock.get_option<socket_option::no_delay>().value());
+
+        nd = false;
+        BOOST_TEST(!nd);
+        sock.set_option(nd);
+        BOOST_TEST(
+            !sock.get_option<socket_option::no_delay>().value());
+
+        // integer assignment
+        socket_option::receive_buffer_size rbs(0);
+        rbs = 32768;
+        BOOST_TEST_EQ(rbs.value(), 32768);
+        sock.set_option(rbs);
+        BOOST_TEST(
+            sock.get_option<socket_option::receive_buffer_size>()
+                .value() >= 32768);
+
+        // linger setters
+        socket_option::linger lg;
+        BOOST_TEST(!lg.enabled());
+        BOOST_TEST_EQ(lg.timeout(), 0);
+        lg.enabled(true);
+        lg.timeout(3);
+        BOOST_TEST(lg.enabled());
+        BOOST_TEST_EQ(lg.timeout(), 3);
+        sock.set_option(lg);
+        auto lg2 = sock.get_option<socket_option::linger>();
+        BOOST_TEST(lg2.enabled());
+        BOOST_TEST_EQ(lg2.timeout(), 3);
+
+        sock.close();
     }
 
     // Data Integrity
@@ -1118,7 +1204,10 @@ struct socket_test
         tcp_acceptor acc(ioc);
 
         // Bind to loopback with port 0 (ephemeral)
-        auto listen_ec = acc.listen(endpoint(ipv4_address::loopback(), 0));
+        acc.open();
+        acc.set_option(socket_option::reuse_address(true));
+        auto listen_ec = acc.bind(endpoint(ipv4_address::loopback(), 0));
+        if (!listen_ec) listen_ec = acc.listen();
         BOOST_TEST(!listen_ec);
 
         // Acceptor's local endpoint should have a non-zero OS-assigned port
@@ -1187,7 +1276,9 @@ struct socket_test
         bool found              = false;
         for (int attempt = 0; attempt < 100; ++attempt)
         {
-            if (!acc.listen(endpoint(ipv4_address::loopback(), test_port)))
+            acc.open();
+            acc.set_option(socket_option::reuse_address(true));
+            if (!acc.bind(endpoint(ipv4_address::loopback(), test_port)) && !acc.listen())
             {
                 found = true;
                 break;
@@ -1441,6 +1532,10 @@ struct socket_test
         testLinger();
         testLingerValidation();
         testSocketOptionsOnConnectedSocket();
+        testGenericSetGetOption();
+        testGenericBufferOption();
+        testGenericLingerOption();
+        testOptionAssignmentOperators();
 
         // Composed operations
         testReadFull();
@@ -1462,6 +1557,350 @@ struct socket_test
         testEndpointsMoveAssign();
         testEndpointsConsistentReads();
         testEndpointsAfterCloseAndReopen();
+
+        // IPv6 and lazy-open
+        testConnectV6();
+        testLazyOpenV4();
+        testLazyOpenPreservesExistingSocket();
+        testV6ReadWrite();
+
+        // v6_only socket option
+        testV6OnlySocketOption();
+        testDualStackConnect();
+    }
+
+    void testConnectV6()
+    {
+        io_context ioc(Backend);
+
+        tcp_acceptor acc(ioc);
+        acc.open(tcp::v6());
+        acc.set_option(socket_option::reuse_address(true));
+        auto ec = acc.bind(endpoint(ipv6_address::loopback(), 0));
+        if (!ec) ec = acc.listen();
+        BOOST_TEST(!ec);
+        BOOST_TEST(acc.local_endpoint().is_v6());
+
+        auto port = acc.local_endpoint().port();
+
+        tcp_socket s1(ioc);
+        tcp_socket s2(ioc);
+
+        bool accept_done  = false;
+        bool connect_done = false;
+        std::error_code accept_ec, connect_ec;
+
+        auto ex = ioc.get_executor();
+        capy::run_async(ex)(
+            [](tcp_acceptor& a, tcp_socket& s,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await a.accept(s);
+                ec_out    = ec;
+                done      = true;
+            }(acc, s1, accept_ec, accept_done));
+
+        capy::run_async(ex)(
+            [](tcp_socket& s, endpoint ep,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await s.connect(ep);
+                ec_out    = ec;
+                done      = true;
+            }(s2, endpoint(ipv6_address::loopback(), port),
+              connect_ec, connect_done));
+
+        ioc.run();
+
+        BOOST_TEST(accept_done);
+        BOOST_TEST(!accept_ec);
+        BOOST_TEST(connect_done);
+        BOOST_TEST(!connect_ec);
+
+        BOOST_TEST(s1.local_endpoint().is_v6());
+        BOOST_TEST(s1.remote_endpoint().is_v6());
+        BOOST_TEST(s2.local_endpoint().is_v6());
+        BOOST_TEST(s2.remote_endpoint().is_v6());
+
+        s1.close();
+        s2.close();
+        acc.close();
+    }
+
+    void testLazyOpenV4()
+    {
+        // connect() on a closed socket should auto-open with AF_INET
+        io_context ioc(Backend);
+
+        tcp_acceptor acc(ioc);
+        acc.open();
+        acc.set_option(socket_option::reuse_address(true));
+        auto ec = acc.bind(endpoint(ipv4_address::loopback(), 0));
+        if (!ec) ec = acc.listen();
+        BOOST_TEST(!ec);
+        auto port = acc.local_endpoint().port();
+
+        tcp_socket s1(ioc);
+        tcp_socket s2(ioc);
+        // Do NOT call s2.open() — connect() should open it
+
+        bool accept_done  = false;
+        bool connect_done = false;
+        std::error_code accept_ec, connect_ec;
+
+        auto ex = ioc.get_executor();
+        capy::run_async(ex)(
+            [](tcp_acceptor& a, tcp_socket& s,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await a.accept(s);
+                ec_out    = ec;
+                done      = true;
+            }(acc, s1, accept_ec, accept_done));
+
+        capy::run_async(ex)(
+            [](tcp_socket& s, endpoint ep,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await s.connect(ep);
+                ec_out    = ec;
+                done      = true;
+            }(s2, endpoint(ipv4_address::loopback(), port),
+              connect_ec, connect_done));
+
+        ioc.run();
+
+        BOOST_TEST(accept_done);
+        BOOST_TEST(!accept_ec);
+        BOOST_TEST(connect_done);
+        BOOST_TEST(!connect_ec);
+        BOOST_TEST(s2.is_open());
+
+        s1.close();
+        s2.close();
+        acc.close();
+    }
+
+    void testLazyOpenPreservesExistingSocket()
+    {
+        // If socket is already open, connect() should not re-open it.
+        // Verify that a socket option set before connect() is retained.
+        io_context ioc(Backend);
+
+        tcp_acceptor acc(ioc);
+        acc.open();
+        acc.set_option(socket_option::reuse_address(true));
+        auto ec = acc.bind(endpoint(ipv4_address::loopback(), 0));
+        if (!ec) ec = acc.listen();
+        BOOST_TEST(!ec);
+        auto port = acc.local_endpoint().port();
+
+        tcp_socket s1(ioc);
+        tcp_socket s2(ioc);
+        s2.open();
+        s2.set_option(socket_option::no_delay(true));
+        BOOST_TEST(s2.get_option<socket_option::no_delay>());
+
+        bool accept_done  = false;
+        bool connect_done = false;
+        std::error_code accept_ec, connect_ec;
+
+        auto ex = ioc.get_executor();
+        capy::run_async(ex)(
+            [](tcp_acceptor& a, tcp_socket& s,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await a.accept(s);
+                ec_out    = ec;
+                done      = true;
+            }(acc, s1, accept_ec, accept_done));
+
+        capy::run_async(ex)(
+            [](tcp_socket& s, endpoint ep,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await s.connect(ep);
+                ec_out    = ec;
+                done      = true;
+            }(s2, endpoint(ipv4_address::loopback(), port),
+              connect_ec, connect_done));
+
+        ioc.run();
+
+        BOOST_TEST(accept_done);
+        BOOST_TEST(!accept_ec);
+        BOOST_TEST(connect_done);
+        BOOST_TEST(!connect_ec);
+
+        // Socket option should be preserved across connect
+        BOOST_TEST(s2.get_option<socket_option::no_delay>());
+
+        s1.close();
+        s2.close();
+        acc.close();
+    }
+
+    void testV6ReadWrite()
+    {
+        io_context ioc(Backend);
+
+        tcp_acceptor acc(ioc);
+        acc.open(tcp::v6());
+        acc.set_option(socket_option::reuse_address(true));
+        auto ec = acc.bind(endpoint(ipv6_address::loopback(), 0));
+        if (!ec) ec = acc.listen();
+        BOOST_TEST(!ec);
+        auto port = acc.local_endpoint().port();
+
+        tcp_socket s1(ioc);
+        tcp_socket s2(ioc);
+
+        bool accept_done  = false;
+        bool connect_done = false;
+        std::error_code accept_ec, connect_ec;
+
+        auto ex = ioc.get_executor();
+        capy::run_async(ex)(
+            [](tcp_acceptor& a, tcp_socket& s,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await a.accept(s);
+                ec_out    = ec;
+                done      = true;
+            }(acc, s1, accept_ec, accept_done));
+
+        capy::run_async(ex)(
+            [](tcp_socket& s, endpoint ep,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await s.connect(ep);
+                ec_out    = ec;
+                done      = true;
+            }(s2, endpoint(ipv6_address::loopback(), port),
+              connect_ec, connect_done));
+
+        ioc.run();
+        ioc.restart();
+
+        BOOST_TEST(accept_done);
+        BOOST_TEST(!accept_ec);
+        BOOST_TEST(connect_done);
+        BOOST_TEST(!connect_ec);
+
+        // Round-trip data over IPv6
+        std::string const msg = "hello IPv6";
+        bool write_done = false;
+        bool read_done  = false;
+        std::error_code write_ec, read_ec;
+        std::size_t write_n = 0, read_n = 0;
+        char buf[64]{};
+
+        capy::run_async(ex)(
+            [](tcp_socket& s, char const* data, std::size_t len,
+               std::error_code& ec_out, std::size_t& n_out,
+               bool& done) -> capy::task<> {
+                auto [ec, n] = co_await s.write_some(
+                    capy::const_buffer(data, len));
+                ec_out = ec;
+                n_out  = n;
+                done   = true;
+            }(s2, msg.data(), msg.size(), write_ec, write_n, write_done));
+
+        capy::run_async(ex)(
+            [](tcp_socket& s, char* data, std::size_t len,
+               std::error_code& ec_out, std::size_t& n_out,
+               bool& done) -> capy::task<> {
+                auto [ec, n] = co_await s.read_some(
+                    capy::mutable_buffer(data, len));
+                ec_out = ec;
+                n_out  = n;
+                done   = true;
+            }(s1, buf, sizeof(buf), read_ec, read_n, read_done));
+
+        ioc.run();
+
+        BOOST_TEST(write_done);
+        BOOST_TEST(!write_ec);
+        BOOST_TEST_EQ(write_n, msg.size());
+        BOOST_TEST(read_done);
+        BOOST_TEST(!read_ec);
+        BOOST_TEST_EQ(read_n, msg.size());
+        BOOST_TEST_EQ(
+            std::string_view(buf, read_n), std::string_view(msg));
+
+        s1.close();
+        s2.close();
+        acc.close();
+    }
+
+    void testV6OnlySocketOption()
+    {
+        io_context ioc(Backend);
+        tcp_socket sock(ioc);
+        sock.open(tcp::v6()); // IPv6
+
+        // Default is v6only=true (kernel default after open_socket sets it)
+        BOOST_TEST_EQ(
+            sock.get_option<socket_option::v6_only>().value(), true);
+
+        sock.set_option(socket_option::v6_only(false));
+        BOOST_TEST_EQ(
+            sock.get_option<socket_option::v6_only>().value(), false);
+
+        sock.set_option(socket_option::v6_only(true));
+        BOOST_TEST_EQ(
+            sock.get_option<socket_option::v6_only>().value(), true);
+
+        sock.close();
+    }
+
+    void testDualStackConnect()
+    {
+        io_context ioc(Backend);
+
+        // Dual-stack listener (v6only=false is the default)
+        tcp_acceptor acc(ioc);
+        acc.open(tcp::v6());
+        acc.set_option(socket_option::reuse_address(true));
+        auto ec = acc.bind(endpoint(ipv6_address::any(), 0));
+        if (!ec) ec = acc.listen();
+        BOOST_TEST(!ec);
+        auto port = acc.local_endpoint().port();
+
+        tcp_socket s1(ioc);
+        tcp_socket s2(ioc);
+        s2.open(tcp::v6()); // IPv6 socket
+        s2.set_option(socket_option::v6_only(false));
+
+        bool accept_done  = false;
+        bool connect_done = false;
+        std::error_code accept_ec, connect_ec;
+
+        auto ex = ioc.get_executor();
+        capy::run_async(ex)(
+            [](tcp_acceptor& a, tcp_socket& s,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await a.accept(s);
+                ec_out    = ec;
+                done      = true;
+            }(acc, s1, accept_ec, accept_done));
+
+        // IPv6 dual-stack socket connects to IPv4 loopback —
+        // connect maps to ::ffff:127.0.0.1 automatically
+        capy::run_async(ex)(
+            [](tcp_socket& s, endpoint ep,
+               std::error_code& ec_out, bool& done) -> capy::task<> {
+                auto [ec] = co_await s.connect(ep);
+                ec_out    = ec;
+                done      = true;
+            }(s2, endpoint(ipv4_address::loopback(), port),
+              connect_ec, connect_done));
+
+        ioc.run();
+
+        BOOST_TEST(accept_done);
+        BOOST_TEST(!accept_ec);
+        BOOST_TEST(connect_done);
+        BOOST_TEST(!connect_ec);
+
+        // Accepted peer has IPv6 endpoint (IPv4-mapped)
+        BOOST_TEST(s1.remote_endpoint().is_v6());
+
+        s1.close();
+        s2.close();
+        acc.close();
     }
 };
 

--- a/test/unit/socket_stress.cpp
+++ b/test/unit/socket_stress.cpp
@@ -23,6 +23,7 @@
 
 #include <boost/corosio/tcp_socket.hpp>
 #include <boost/corosio/tcp_acceptor.hpp>
+#include <boost/corosio/socket_option.hpp>
 #include <boost/corosio/timer.hpp>
 
 #include <boost/capy/cond.hpp>
@@ -68,7 +69,11 @@ make_stress_pair(io_context& ctx)
     bool connect_done = false;
 
     tcp_acceptor acc(ctx);
-    if (auto ec = acc.listen(endpoint(ipv4_address::loopback(), 0)))
+    acc.open();
+    acc.set_option(socket_option::reuse_address(true));
+    if (auto ec = acc.bind(endpoint(ipv4_address::loopback(), 0)))
+        throw std::runtime_error("stress_pair bind failed: " + ec.message());
+    if (auto ec = acc.listen())
         throw std::runtime_error("stress_pair listen failed: " + ec.message());
     auto port = acc.local_endpoint().port();
 
@@ -632,7 +637,14 @@ struct accept_stress_test
         std::atomic<bool> stop_flag{false};
 
         tcp_acceptor acc(ioc);
-        if (auto ec = acc.listen(endpoint(ipv4_address::loopback(), 0)))
+        acc.open();
+        acc.set_option(socket_option::reuse_address(true));
+        if (auto ec = acc.bind(endpoint(ipv4_address::loopback(), 0)))
+        {
+            BOOST_ERROR("accept_stress: bind failed");
+            return;
+        }
+        if (auto ec = acc.listen())
         {
             BOOST_ERROR("accept_stress: listen failed");
             return;

--- a/test/unit/tcp_server.cpp
+++ b/test/unit/tcp_server.cpp
@@ -11,6 +11,7 @@
 #include <boost/corosio/tcp_server.hpp>
 
 #include <boost/corosio/io_context.hpp>
+#include <boost/corosio/socket_option.hpp>
 #include <boost/corosio/timer.hpp>
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/cond.hpp>
@@ -122,7 +123,10 @@ struct tcp_server_test
         for (int attempt = 0; attempt < 20; ++attempt)
         {
             port = static_cast<std::uint16_t>(49152 + (attempt * 7) % 16383);
-            if (!acc.listen(endpoint(ipv4_address::loopback(), port)))
+            acc.open();
+            acc.set_option(socket_option::reuse_address(true));
+            if (!acc.bind(endpoint(ipv4_address::loopback(), port))
+                && !acc.listen())
                 break;
             acc.close();
             acc = tcp_acceptor(ioc);
@@ -254,7 +258,10 @@ struct tcp_server_test
         for (int attempt = 0; attempt < 20; ++attempt)
         {
             port = static_cast<std::uint16_t>(49152 + (attempt * 7) % 16383);
-            if (!acc.listen(endpoint(ipv4_address::loopback(), port)))
+            acc.open();
+            acc.set_option(socket_option::reuse_address(true));
+            if (!acc.bind(endpoint(ipv4_address::loopback(), port))
+                && !acc.listen())
                 break;
             acc.close();
             acc = tcp_acceptor(ioc);
@@ -395,7 +402,11 @@ struct tcp_server_test
 
         // Test success case
         tcp_acceptor acc1(ioc);
-        auto ec1 = acc1.listen(endpoint(ipv4_address::loopback(), 0));
+        acc1.open();
+        acc1.set_option(socket_option::reuse_address(true));
+        auto ec1 = acc1.bind(endpoint(ipv4_address::loopback(), 0));
+        BOOST_TEST(!ec1);
+        ec1 = acc1.listen();
         BOOST_TEST(!ec1);
         BOOST_TEST(acc1.is_open());
         auto port = acc1.local_endpoint().port();
@@ -403,7 +414,11 @@ struct tcp_server_test
 
         // Test with explicit backlog
         tcp_acceptor acc2(ioc);
-        auto ec2 = acc2.listen(endpoint(ipv4_address::loopback(), 0), 64);
+        acc2.open();
+        acc2.set_option(socket_option::reuse_address(true));
+        auto ec2 = acc2.bind(endpoint(ipv4_address::loopback(), 0));
+        BOOST_TEST(!ec2);
+        ec2 = acc2.listen(64);
         BOOST_TEST(!ec2);
         BOOST_TEST(acc2.is_open());
         BOOST_TEST(acc2.local_endpoint().port() != 0);
@@ -419,7 +434,7 @@ struct tcp_server_test
         BOOST_TEST(!ec);
     }
 
-    void testListenErrorNonLocalAddress()
+    void testBindErrorNonLocalAcceptor()
     {
         io_context ioc;
 
@@ -428,9 +443,10 @@ struct tcp_server_test
         // 192.0.2.1 is from TEST-NET-1 (RFC 5737), reserved for documentation
         // and never assigned to real interfaces.
         tcp_acceptor acc(ioc);
-        auto ec = acc.listen(endpoint(ipv4_address({192, 0, 2, 1}), 0));
+        acc.open();
+        auto ec = acc.bind(endpoint(ipv4_address({192, 0, 2, 1}), 0));
         BOOST_TEST(ec);
-        BOOST_TEST(!acc.is_open());
+        acc.close();
     }
 
     void testBindErrorNonLocalAddress()
@@ -443,18 +459,27 @@ struct tcp_server_test
         BOOST_TEST(ec);
     }
 
-    void testListenOnOpenAcceptor()
+    void testRelistenAfterClose()
     {
         io_context ioc;
         tcp_acceptor acc(ioc);
 
         // First listen
-        auto ec1 = acc.listen(endpoint(ipv4_address::loopback(), 0));
+        acc.open();
+        acc.set_option(socket_option::reuse_address(true));
+        auto ec1 = acc.bind(endpoint(ipv4_address::loopback(), 0));
+        BOOST_TEST(!ec1);
+        ec1 = acc.listen();
         BOOST_TEST(!ec1);
         BOOST_TEST(acc.is_open());
 
-        // Re-listen should close and reopen
-        auto ec2 = acc.listen(endpoint(ipv4_address::loopback(), 0));
+        // Close and re-listen
+        acc.close();
+        acc.open();
+        acc.set_option(socket_option::reuse_address(true));
+        auto ec2 = acc.bind(endpoint(ipv4_address::loopback(), 0));
+        BOOST_TEST(!ec2);
+        ec2 = acc.listen();
         BOOST_TEST(!ec2);
         BOOST_TEST(acc.is_open());
     }
@@ -470,9 +495,9 @@ struct tcp_server_test
         testStartWithoutJoinThrows();
         testListenErrorCode();
         testBindSuccess();
-        testListenErrorNonLocalAddress();
+        testBindErrorNonLocalAcceptor();
         testBindErrorNonLocalAddress();
-        testListenOnOpenAcceptor();
+        testRelistenAfterClose();
     }
 };
 


### PR DESCRIPTION
…c socket options

New public types:

  - tcp: compiled protocol type (family/type/protocol without platform headers); inline native_tcp variant for zero-overhead
  - socket_option: type-safe wrappers (no_delay, keep_alive, reuse_address, reuse_port, v6_only, linger, send/receive buffer sizes); inline native_socket_option variant

Acceptor API:

  - Split monolithic listen(endpoint) into open() / bind() / listen() so socket options can be set between open and listen
  - Add convenience constructor: tcp_acceptor(ctx, ep, backlog) for the common open+reuse_address+bind+listen pattern
  - Add set_option() / get_option() on tcp_acceptor and its implementation interface (all 4 backends)

Socket changes:

  - tcp_socket::open() takes tcp protocol type (defaults to v4)
  - connect() on a closed socket auto-opens with the endpoint's address family via open(tcp::v6()) / open(tcp::v4())
  - Service layer passes (family, type, protocol) triple through socket_service, acceptor_service, and all 4 backends; backends use the caller-provided triple in ::socket() / WSASocketW()
  - IOCP backend stores address family in win_socket_internal for the ephemeral bind required by ConnectEx
  - Delete move assignment on io_read_stream / io_write_stream to prevent double-move of virtual base in diamond hierarchy

IPv6 support across all backends:

  - Sockets: IPV6_V6ONLY=1 (v6-only by default, user can clear)
  - Acceptors: IPV6_V6ONLY=0 (dual-stack by default)
  - endpoint_convert: IPv4-mapped IPv6 conversion when an IPv4 endpoint connects through an AF_INET6 socket

Tests:

  - IPv6 connect, read/write, v6_only option, dual-stack connect
  - Lazy open (connect auto-opens), preserves pre-set options
  - Acceptor: open/bind/listen lifecycle, set/get_option, convenience constructor, IPv6 accept
  - All existing tests updated for the new open/bind/listen API

Resolves #128.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced TCP protocol abstraction with IPv4/IPv6 selection via `tcp::v4()` and `tcp::v6()`.
  * Added type-safe socket option API with templated `set_option()` and `get_option()` methods.
  * Implemented new socket option types for standardized option handling.
  * Enhanced IPv6 support with dual-stack socket handling.

* **API Changes**
  * Refactored acceptor and socket initialization: `open()`, `bind()`, and `listen()` are now separate steps.
  * Replaced socket-specific option methods with unified generic option interface.
  * Updated socket creation to accept address family, type, and protocol parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->