### PR TITLE
Expose all platform backends in MrDocs documentation build (#171)

### DIFF
--- a/include/boost/corosio/detail/platform.hpp
+++ b/include/boost/corosio/detail/platform.hpp
@@ -13,6 +13,21 @@
 // Platform feature detection
 // Each macro is always defined to either 0 or 1
 
+#ifdef BOOST_COROSIO_MRDOCS
+
+// MrDocs documentation build: enable all backends so every
+// platform-specific tag and specialization appears in the
+// generated reference.  The native_* headers skip the real
+// implementation includes under this guard, so no platform
+// system headers are required.
+#define BOOST_COROSIO_HAS_IOCP   1
+#define BOOST_COROSIO_HAS_EPOLL  1
+#define BOOST_COROSIO_HAS_KQUEUE 1
+#define BOOST_COROSIO_HAS_SELECT 1
+#define BOOST_COROSIO_POSIX      1
+
+#else // !BOOST_COROSIO_MRDOCS
+
 // IOCP - Windows I/O completion ports
 #if defined(_WIN32)
 #define BOOST_COROSIO_HAS_IOCP 1
@@ -48,5 +63,7 @@
 #else
 #define BOOST_COROSIO_POSIX 0
 #endif
+
+#endif // BOOST_COROSIO_MRDOCS
 
 #endif // BOOST_COROSIO_DETAIL_PLATFORM_HPP

--- a/include/boost/corosio/native/native_io_context.hpp
+++ b/include/boost/corosio/native/native_io_context.hpp
@@ -13,6 +13,7 @@
 #include <boost/corosio/io_context.hpp>
 #include <boost/corosio/backend.hpp>
 
+#ifndef BOOST_COROSIO_MRDOCS
 #if BOOST_COROSIO_HAS_EPOLL
 #include <boost/corosio/native/detail/epoll/epoll_scheduler.hpp>
 #endif
@@ -28,6 +29,7 @@
 #if BOOST_COROSIO_HAS_IOCP
 #include <boost/corosio/native/detail/iocp/win_scheduler.hpp>
 #endif
+#endif // !BOOST_COROSIO_MRDOCS
 
 namespace boost::corosio {
 

--- a/include/boost/corosio/native/native_resolver.hpp
+++ b/include/boost/corosio/native/native_resolver.hpp
@@ -13,6 +13,7 @@
 #include <boost/corosio/resolver.hpp>
 #include <boost/corosio/backend.hpp>
 
+#ifndef BOOST_COROSIO_MRDOCS
 #if BOOST_COROSIO_HAS_EPOLL || BOOST_COROSIO_HAS_SELECT || \
     BOOST_COROSIO_HAS_KQUEUE
 #include <boost/corosio/native/detail/posix/posix_resolver_service.hpp>
@@ -21,6 +22,7 @@
 #if BOOST_COROSIO_HAS_IOCP
 #include <boost/corosio/native/detail/iocp/win_resolver_service.hpp>
 #endif
+#endif // !BOOST_COROSIO_MRDOCS
 
 namespace boost::corosio {
 

--- a/include/boost/corosio/native/native_signal_set.hpp
+++ b/include/boost/corosio/native/native_signal_set.hpp
@@ -13,6 +13,7 @@
 #include <boost/corosio/signal_set.hpp>
 #include <boost/corosio/backend.hpp>
 
+#ifndef BOOST_COROSIO_MRDOCS
 #if BOOST_COROSIO_HAS_EPOLL || BOOST_COROSIO_HAS_SELECT || \
     BOOST_COROSIO_HAS_KQUEUE
 #include <boost/corosio/native/detail/posix/posix_signal_service.hpp>
@@ -21,6 +22,7 @@
 #if BOOST_COROSIO_HAS_IOCP
 #include <boost/corosio/native/detail/iocp/win_signals.hpp>
 #endif
+#endif // !BOOST_COROSIO_MRDOCS
 
 namespace boost::corosio {
 

--- a/include/boost/corosio/native/native_tcp_acceptor.hpp
+++ b/include/boost/corosio/native/native_tcp_acceptor.hpp
@@ -13,6 +13,7 @@
 #include <boost/corosio/tcp_acceptor.hpp>
 #include <boost/corosio/backend.hpp>
 
+#ifndef BOOST_COROSIO_MRDOCS
 #if BOOST_COROSIO_HAS_EPOLL
 #include <boost/corosio/native/detail/epoll/epoll_acceptor_service.hpp>
 #endif
@@ -28,6 +29,7 @@
 #if BOOST_COROSIO_HAS_IOCP
 #include <boost/corosio/native/detail/iocp/win_acceptor_service.hpp>
 #endif
+#endif // !BOOST_COROSIO_MRDOCS
 
 namespace boost::corosio {
 

--- a/include/boost/corosio/native/native_tcp_socket.hpp
+++ b/include/boost/corosio/native/native_tcp_socket.hpp
@@ -13,6 +13,7 @@
 #include <boost/corosio/tcp_socket.hpp>
 #include <boost/corosio/backend.hpp>
 
+#ifndef BOOST_COROSIO_MRDOCS
 #if BOOST_COROSIO_HAS_EPOLL
 #include <boost/corosio/native/detail/epoll/epoll_socket_service.hpp>
 #endif
@@ -28,6 +29,7 @@
 #if BOOST_COROSIO_HAS_IOCP
 #include <boost/corosio/native/detail/iocp/win_acceptor_service.hpp>
 #endif
+#endif // !BOOST_COROSIO_MRDOCS
 
 namespace boost::corosio {
 

--- a/include/boost/corosio/tcp_socket.hpp
+++ b/include/boost/corosio/tcp_socket.hpp
@@ -35,7 +35,7 @@
 
 namespace boost::corosio {
 
-#if BOOST_COROSIO_HAS_IOCP
+#if BOOST_COROSIO_HAS_IOCP && !defined(BOOST_COROSIO_MRDOCS)
 using native_handle_type = std::uintptr_t; // SOCKET
 #else
 using native_handle_type = int;
@@ -271,7 +271,7 @@ public:
     */
     bool is_open() const noexcept
     {
-#if BOOST_COROSIO_HAS_IOCP
+#if BOOST_COROSIO_HAS_IOCP && !defined(BOOST_COROSIO_MRDOCS)
         return h_ && get().native_handle() != ~native_handle_type(0);
 #else
         return h_ && get().native_handle() >= 0;


### PR DESCRIPTION
Closes #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added MRDOCS build mode support to enable unified documentation generation across all platforms.
  * Improved platform detection logic with conditional compilation guards for backend-specific components.
  * Existing functionality and behavior remain unchanged for standard builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->