### PR TITLE
Add cancel_after / cancel_at timeout adapters

### DIFF
--- a/include/boost/corosio.hpp
+++ b/include/boost/corosio.hpp
@@ -11,6 +11,7 @@
 #define BOOST_COROSIO_HPP
 
 #include <boost/corosio/backend.hpp>
+#include <boost/corosio/cancel.hpp>
 #include <boost/corosio/endpoint.hpp>
 #include <boost/corosio/io_buffer_param.hpp>
 #include <boost/corosio/io_context.hpp>
@@ -19,6 +20,7 @@
 #include <boost/corosio/resolver.hpp>
 #include <boost/corosio/resolver_results.hpp>
 #include <boost/corosio/signal_set.hpp>
+#include <boost/corosio/socket_option.hpp>
 #include <boost/corosio/tcp_acceptor.hpp>
 #include <boost/corosio/tcp_server.hpp>
 #include <boost/corosio/tcp_socket.hpp>

--- a/include/boost/corosio/cancel.hpp
+++ b/include/boost/corosio/cancel.hpp
@@ -1,0 +1,212 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_CANCEL_HPP
+#define BOOST_COROSIO_CANCEL_HPP
+
+#include <boost/corosio/detail/cancel_at_awaitable.hpp>
+#include <boost/corosio/timer.hpp>
+#include <boost/capy/concept/io_awaitable.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace boost::corosio {
+
+/** Cancel an operation if it does not complete by a deadline.
+
+    Races @p op against the given timer. If the deadline is reached
+    first, the inner operation is cancelled via its stop token and
+    completes with an error comparing equal to `capy::cond::canceled`.
+    If the inner operation completes first, the timer is cancelled.
+
+    Parent cancellation (from the caller's stop token) is forwarded
+    to both the inner operation and the timeout timer.
+
+    The timer's expiry is overwritten by this call. The timer must
+    outlive the returned awaitable. Do not issue overlapping waits
+    on the same timer.
+
+    @par Completion Conditions
+    The returned awaitable resumes when either:
+    @li The inner operation completes (successfully or with error).
+    @li The deadline expires and the inner operation is cancelled.
+    @li The caller's stop token is triggered, cancelling both.
+
+    @par Error Conditions
+    @li On timeout or parent cancellation, the inner operation
+        completes with an error equal to `capy::cond::canceled`.
+    @li All other errors are propagated from the inner operation.
+
+    @par Example
+    @code
+    timer timeout_timer( ioc );
+    auto [ec, n] = co_await cancel_at(
+        sock.read_some( buf ), timeout_timer,
+        clock::now() + 5s );
+    if (ec == capy::cond::canceled)
+        // timed out or parent cancelled
+    @endcode
+
+    @param op The inner I/O awaitable to wrap.
+    @param t The timer to use for the deadline. Must outlive
+        the returned awaitable.
+    @param deadline The absolute time point at which to cancel.
+
+    @return An awaitable whose result matches @p op's result type.
+
+    @see cancel_after
+*/
+auto cancel_at(
+    capy::IoAwaitable auto&& op,
+    timer& t,
+    timer::time_point deadline)
+{
+    return detail::cancel_at_awaitable<
+        std::decay_t<decltype(op)>, timer>(
+        std::forward<decltype(op)>(op), t, deadline);
+}
+
+/** Cancel an operation if it does not complete within a duration.
+
+    Equivalent to `cancel_at( op, t, clock::now() + timeout )`.
+
+    The timer's expiry is overwritten by this call. The timer must
+    outlive the returned awaitable. Do not issue overlapping waits
+    on the same timer.
+
+    @par Completion Conditions
+    The returned awaitable resumes when either:
+    @li The inner operation completes (successfully or with error).
+    @li The timeout elapses and the inner operation is cancelled.
+    @li The caller's stop token is triggered, cancelling both.
+
+    @par Error Conditions
+    @li On timeout or parent cancellation, the inner operation
+        completes with an error equal to `capy::cond::canceled`.
+    @li All other errors are propagated from the inner operation.
+
+    @par Example
+    @code
+    timer timeout_timer( ioc );
+    auto [ec, n] = co_await cancel_after(
+        sock.read_some( buf ), timeout_timer, 5s );
+    if (ec == capy::cond::canceled)
+        // timed out
+    @endcode
+
+    @param op The inner I/O awaitable to wrap.
+    @param t The timer to use for the timeout. Must outlive
+        the returned awaitable.
+    @param timeout The relative duration after which to cancel.
+
+    @return An awaitable whose result matches @p op's result type.
+
+    @see cancel_at
+*/
+auto cancel_after(
+    capy::IoAwaitable auto&& op,
+    timer& t,
+    timer::duration timeout)
+{
+    return cancel_at(
+        std::forward<decltype(op)>(op), t,
+        timer::clock_type::now() + timeout);
+}
+
+/** Cancel an operation if it does not complete by a deadline.
+
+    Convenience overload that creates a @ref timer internally.
+    Otherwise identical to the explicit-timer overload.
+
+    @par Completion Conditions
+    The returned awaitable resumes when either:
+    @li The inner operation completes (successfully or with error).
+    @li The deadline expires and the inner operation is cancelled.
+    @li The caller's stop token is triggered, cancelling both.
+
+    @par Error Conditions
+    @li On timeout or parent cancellation, the inner operation
+        completes with an error equal to `capy::cond::canceled`.
+    @li All other errors are propagated from the inner operation.
+
+    @note Creates a timer per call. Use the explicit-timer overload
+        to amortize allocation across multiple timeouts.
+
+    @par Example
+    @code
+    auto [ec, n] = co_await cancel_at(
+        sock.read_some( buf ),
+        clock::now() + 5s );
+    if (ec == capy::cond::canceled)
+        // timed out or parent cancelled
+    @endcode
+
+    @param op The inner I/O awaitable to wrap.
+    @param deadline The absolute time point at which to cancel.
+
+    @return An awaitable whose result matches @p op's result type.
+
+    @see cancel_after
+*/
+auto cancel_at(
+    capy::IoAwaitable auto&& op,
+    timer::time_point deadline)
+{
+    return detail::cancel_at_awaitable<
+        std::decay_t<decltype(op)>, timer, true>(
+        std::forward<decltype(op)>(op), deadline);
+}
+
+/** Cancel an operation if it does not complete within a duration.
+
+    Convenience overload that creates a @ref timer internally.
+    Equivalent to `cancel_at( op, clock::now() + timeout )`.
+
+    @par Completion Conditions
+    The returned awaitable resumes when either:
+    @li The inner operation completes (successfully or with error).
+    @li The timeout elapses and the inner operation is cancelled.
+    @li The caller's stop token is triggered, cancelling both.
+
+    @par Error Conditions
+    @li On timeout or parent cancellation, the inner operation
+        completes with an error equal to `capy::cond::canceled`.
+    @li All other errors are propagated from the inner operation.
+
+    @note Creates a timer per call. Use the explicit-timer overload
+        to amortize allocation across multiple timeouts.
+
+    @par Example
+    @code
+    auto [ec, n] = co_await cancel_after(
+        sock.read_some( buf ), 5s );
+    if (ec == capy::cond::canceled)
+        // timed out
+    @endcode
+
+    @param op The inner I/O awaitable to wrap.
+    @param timeout The relative duration after which to cancel.
+
+    @return An awaitable whose result matches @p op's result type.
+
+    @see cancel_at
+*/
+auto cancel_after(
+    capy::IoAwaitable auto&& op,
+    timer::duration timeout)
+{
+    return cancel_at(
+        std::forward<decltype(op)>(op),
+        timer::clock_type::now() + timeout);
+}
+
+} // namespace boost::corosio
+
+#endif

--- a/include/boost/corosio/detail/cancel_at_awaitable.hpp
+++ b/include/boost/corosio/detail/cancel_at_awaitable.hpp
@@ -1,0 +1,182 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_DETAIL_CANCEL_AT_AWAITABLE_HPP
+#define BOOST_COROSIO_DETAIL_CANCEL_AT_AWAITABLE_HPP
+
+#include <boost/corosio/detail/timeout_coro.hpp>
+#include <boost/capy/ex/io_env.hpp>
+
+#include <chrono>
+#include <coroutine>
+#include <new>
+#include <optional>
+#include <stop_token>
+#include <type_traits>
+#include <utility>
+
+/* Races an inner IoAwaitable against a timer via a shared
+   stop_source. await_suspend arms the timer by launching a
+   fire-and-forget timeout_coro, then starts the inner op with
+   an interposed stop_token. Whichever completes first signals
+   the stop_source, cancelling the other.
+
+   Parent cancellation is forwarded through a stop_callback
+   stored in a placement-new buffer (stop_callback is not
+   movable, but the awaitable must be movable for
+   transform_awaiter). The buffer is inert during moves
+   (before await_suspend) and constructed in-place once the
+   awaitable is pinned on the coroutine frame.
+
+   The timeout_coro can outlive this awaitable — it owns its
+   env and self-destroys via suspend_never. When Owning is
+   false the caller-supplied timer must outlive both; when
+   Owning is true the timer lives in std::optional and is
+   constructed lazily in await_suspend. */
+
+namespace boost::corosio::detail {
+
+/** Awaitable adapter that cancels an inner operation after a deadline.
+
+    Races the inner awaitable against a timer. A shared stop_source
+    ties them together: whichever completes first cancels the other.
+    Parent cancellation is forwarded via stop_callback.
+
+    When @p Owning is `false` (default), the caller supplies a timer
+    reference that must outlive the awaitable. When @p Owning is
+    `true`, the timer is constructed internally in `await_suspend`
+    from the execution context in `io_env`.
+
+    @tparam A The inner IoAwaitable type (decayed).
+    @tparam Timer The timer type (`timer` or `native_timer<B>`).
+    @tparam Owning When `true`, the awaitable owns its timer.
+*/
+template<typename A, typename Timer, bool Owning = false>
+struct cancel_at_awaitable
+{
+    struct stop_forwarder
+    {
+        std::stop_source* src_;
+        void operator()() const noexcept
+        {
+            src_->request_stop();
+        }
+    };
+
+    using time_point = std::chrono::steady_clock::time_point;
+    using stop_cb_type = std::stop_callback<stop_forwarder>;
+    using timer_storage = std::conditional_t<
+        Owning, std::optional<Timer>, Timer*>;
+
+    A inner_;
+    timer_storage timer_;
+    time_point deadline_;
+    std::stop_source stop_src_;
+    capy::io_env inner_env_;
+    alignas(stop_cb_type) unsigned char cb_buf_[sizeof(stop_cb_type)];
+    bool cb_active_ = false;
+
+    /// Construct with a caller-supplied timer reference.
+    cancel_at_awaitable(
+        A&& inner,
+        Timer& timer,
+        time_point deadline)
+        requires (!Owning)
+        : inner_(std::move(inner))
+        , timer_(&timer)
+        , deadline_(deadline)
+    {
+    }
+
+    /// Construct without a timer (created in `await_suspend`).
+    cancel_at_awaitable(
+        A&& inner,
+        time_point deadline)
+        requires Owning
+        : inner_(std::move(inner))
+        , deadline_(deadline)
+    {
+    }
+
+    ~cancel_at_awaitable()
+    {
+        destroy_parent_cb();
+    }
+
+    // Only moved before await_suspend, when cb_active_ is false
+    cancel_at_awaitable(cancel_at_awaitable&& o) noexcept(
+        std::is_nothrow_move_constructible_v<A>)
+        : inner_(std::move(o.inner_))
+        , timer_(std::move(o.timer_))
+        , deadline_(o.deadline_)
+        , stop_src_(std::move(o.stop_src_))
+    {
+    }
+
+    cancel_at_awaitable(cancel_at_awaitable const&) = delete;
+    cancel_at_awaitable& operator=(cancel_at_awaitable const&) = delete;
+    cancel_at_awaitable& operator=(cancel_at_awaitable&&) = delete;
+
+    bool await_ready() const noexcept { return false; }
+
+    auto await_suspend(
+        std::coroutine_handle<> h,
+        capy::io_env const* env)
+    {
+        if constexpr (Owning)
+            timer_.emplace(env->executor.context());
+
+        timer_->expires_at(deadline_);
+
+        // Launch fire-and-forget timeout (starts suspended)
+        auto timeout = make_timeout(*timer_, stop_src_);
+        timeout.h_.promise().set_env_owned({
+            env->executor,
+            stop_src_.get_token(),
+            env->frame_allocator});
+        // Runs synchronously until timer.wait() suspends
+        timeout.h_.resume();
+        // timeout goes out of scope; destructor is a no-op,
+        // the coroutine self-destroys via suspend_never
+
+        // Forward parent cancellation
+        new (cb_buf_) stop_cb_type(
+            env->stop_token, stop_forwarder{&stop_src_});
+        cb_active_ = true;
+
+        // Start the inner op with our interposed stop_token
+        inner_env_ = {
+            env->executor,
+            stop_src_.get_token(),
+            env->frame_allocator};
+        return inner_.await_suspend(h, &inner_env_);
+    }
+
+    decltype(auto) await_resume()
+    {
+        // Cancel whichever is still pending (idempotent)
+        stop_src_.request_stop();
+        destroy_parent_cb();
+        return inner_.await_resume();
+    }
+
+    void destroy_parent_cb() noexcept
+    {
+        if (cb_active_)
+        {
+            std::launder(reinterpret_cast<stop_cb_type*>(
+                cb_buf_))->~stop_cb_type();
+            cb_active_ = false;
+        }
+    }
+};
+
+} // namespace boost::corosio::detail
+
+#endif

--- a/include/boost/corosio/detail/timeout_coro.hpp
+++ b/include/boost/corosio/detail/timeout_coro.hpp
@@ -1,0 +1,183 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_DETAIL_TIMEOUT_CORO_HPP
+#define BOOST_COROSIO_DETAIL_TIMEOUT_CORO_HPP
+
+#include <boost/capy/concept/io_awaitable.hpp>
+#include <boost/capy/ex/frame_allocator.hpp>
+#include <boost/capy/ex/io_awaitable_promise_base.hpp>
+#include <boost/capy/ex/io_env.hpp>
+
+#include <coroutine>
+#include <stop_token>
+#include <type_traits>
+#include <utility>
+
+/* Self-destroying coroutine that awaits a timer and signals a
+   stop_source on expiry. Created suspended (initial_suspend =
+   suspend_always); the caller sets an owned io_env copy then
+   resumes, which runs synchronously until the timer wait suspends.
+   At final_suspend, suspend_never destroys the frame — the
+   timeout_coro destructor is intentionally a no-op since the
+   handle is dangling after self-destruction. If the coroutine is
+   still suspended at shutdown, the timer service drains it via
+   completion_op::destroy().
+
+   The promise reuses task<>'s transform_awaiter pattern (including
+   the MSVC symmetric-transfer workaround) to inject io_env into
+   IoAwaitable co_await expressions. */
+
+namespace boost::corosio::detail {
+
+/** Fire-and-forget coroutine for the timeout side of cancel_at.
+
+    The coroutine awaits a timer and signals a stop_source if the
+    timer fires without being cancelled. It self-destroys at
+    final_suspend via suspend_never.
+
+    @see make_timeout
+*/
+struct timeout_coro
+{
+    struct promise_type
+        : capy::io_awaitable_promise_base<promise_type>
+    {
+        capy::io_env env_storage_;
+
+        /** Store an owned copy of the environment.
+
+            The timeout coroutine can outlive the cancel_at_awaitable
+            that created it, so it must own its env rather than
+            pointing to external storage.
+        */
+        void set_env_owned(capy::io_env env)
+        {
+            env_storage_ = std::move(env);
+            set_environment(&env_storage_);
+        }
+
+        timeout_coro get_return_object() noexcept
+        {
+            return timeout_coro{
+                std::coroutine_handle<promise_type>::from_promise(
+                    *this)};
+        }
+
+        std::suspend_always initial_suspend() noexcept { return {}; }
+        std::suspend_never final_suspend() noexcept { return {}; }
+        void return_void() noexcept {}
+        void unhandled_exception() noexcept {}
+
+        template<class Awaitable>
+        struct transform_awaiter
+        {
+            std::decay_t<Awaitable> a_;
+            promise_type* p_;
+
+            bool await_ready() noexcept
+            {
+                return a_.await_ready();
+            }
+
+            decltype(auto) await_resume()
+            {
+                capy::set_current_frame_allocator(
+                    p_->environment()->frame_allocator);
+                return a_.await_resume();
+            }
+
+            template<class Promise>
+            auto await_suspend(
+                std::coroutine_handle<Promise> h) noexcept
+            {
+#ifdef _MSC_VER
+                using R = decltype(
+                    a_.await_suspend(h, p_->environment()));
+                if constexpr (std::is_same_v<
+                                  R, std::coroutine_handle<>>)
+                    a_.await_suspend(h, p_->environment())
+                        .resume();
+                else
+                    return a_.await_suspend(
+                        h, p_->environment());
+#else
+                return a_.await_suspend(h, p_->environment());
+#endif
+            }
+        };
+
+        template<class Awaitable>
+        auto transform_awaitable(Awaitable&& a)
+        {
+            using A = std::decay_t<Awaitable>;
+            if constexpr (capy::IoAwaitable<A>)
+            {
+                return transform_awaiter<Awaitable>{
+                    std::forward<Awaitable>(a), this};
+            }
+            else
+            {
+                static_assert(
+                    sizeof(A) == 0, "requires IoAwaitable");
+            }
+        }
+    };
+
+    std::coroutine_handle<promise_type> h_;
+
+    timeout_coro() noexcept : h_(nullptr) {}
+
+    explicit timeout_coro(
+        std::coroutine_handle<promise_type> h) noexcept
+        : h_(h)
+    {
+    }
+
+    // Self-destroying via suspend_never at final_suspend
+    ~timeout_coro() = default;
+
+    timeout_coro(timeout_coro const&) = delete;
+    timeout_coro& operator=(timeout_coro const&) = delete;
+
+    timeout_coro(timeout_coro&& o) noexcept
+        : h_(o.h_)
+    {
+        o.h_ = nullptr;
+    }
+
+    timeout_coro& operator=(timeout_coro&& o) noexcept
+    {
+        h_   = o.h_;
+        o.h_ = nullptr;
+        return *this;
+    }
+};
+
+/** Create a fire-and-forget timeout coroutine.
+
+    Wait on the timer. If it fires without cancellation, signal
+    the stop source to cancel the paired inner operation.
+
+    @tparam Timer Timer type (`timer` or `native_timer<B>`).
+
+    @param t The timer to wait on (must have expiry set).
+    @param src Stop source to signal on timeout.
+*/
+template<typename Timer>
+timeout_coro make_timeout(Timer& t, std::stop_source src)
+{
+    auto [ec] = co_await t.wait();
+    if (!ec)
+        src.request_stop();
+}
+
+} // namespace boost::corosio::detail
+
+#endif

--- a/include/boost/corosio/native/native.hpp
+++ b/include/boost/corosio/native/native.hpp
@@ -10,6 +10,7 @@
 #ifndef BOOST_COROSIO_NATIVE_NATIVE_HPP
 #define BOOST_COROSIO_NATIVE_NATIVE_HPP
 
+#include <boost/corosio/native/native_cancel.hpp>
 #include <boost/corosio/native/native_io_context.hpp>
 #include <boost/corosio/native/native_resolver.hpp>
 #include <boost/corosio/native/native_scheduler.hpp>

--- a/include/boost/corosio/native/native_cancel.hpp
+++ b/include/boost/corosio/native/native_cancel.hpp
@@ -1,0 +1,227 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_NATIVE_NATIVE_CANCEL_HPP
+#define BOOST_COROSIO_NATIVE_NATIVE_CANCEL_HPP
+
+#include <boost/corosio/detail/cancel_at_awaitable.hpp>
+#include <boost/corosio/native/native_timer.hpp>
+#include <boost/capy/concept/io_awaitable.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace boost::corosio {
+
+/** Cancel an operation if it does not complete by a deadline.
+
+    Overload for @ref native_timer that devirtualizes the internal
+    timer wait, allowing the compiler to inline the timer path.
+    Otherwise identical to the @ref timer overload.
+
+    If the deadline is reached first, the inner operation completes
+    with an error comparing equal to `capy::cond::canceled`. If the
+    inner operation completes first, the timer is cancelled. Parent
+    cancellation is forwarded to both.
+
+    The timer's expiry is overwritten by this call. The timer must
+    outlive the returned awaitable. Do not issue overlapping waits
+    on the same timer.
+
+    @par Completion Conditions
+    The returned awaitable resumes when either:
+    @li The inner operation completes (successfully or with error).
+    @li The deadline expires and the inner operation is cancelled.
+    @li The caller's stop token is triggered, cancelling both.
+
+    @par Error Conditions
+    @li On timeout or parent cancellation, the inner operation
+        completes with an error equal to `capy::cond::canceled`.
+    @li All other errors are propagated from the inner operation.
+
+    @par Example
+    @code
+    native_timer<epoll> t( ioc );
+    auto [ec, n] = co_await cancel_at(
+        sock.read_some( buf ), t,
+        clock::now() + 5s );
+    if (ec == capy::cond::canceled)
+        // timed out or parent cancelled
+    @endcode
+
+    @tparam Backend A backend tag value (e.g., `epoll`).
+
+    @param op The inner I/O awaitable to wrap.
+    @param t The native timer to use for the deadline. Must outlive
+        the returned awaitable.
+    @param deadline The absolute time point at which to cancel.
+
+    @return An awaitable whose result matches @p op's result type.
+
+    @see cancel_after, native_timer
+*/
+template<auto Backend>
+auto cancel_at(
+    capy::IoAwaitable auto&& op,
+    native_timer<Backend>& t,
+    timer::time_point deadline)
+{
+    return detail::cancel_at_awaitable<
+        std::decay_t<decltype(op)>, native_timer<Backend>>(
+        std::forward<decltype(op)>(op), t, deadline);
+}
+
+/** Cancel an operation if it does not complete within a duration.
+
+    Overload for @ref native_timer. Equivalent to
+    `cancel_at( op, t, clock::now() + timeout )`.
+
+    The timer's expiry is overwritten by this call. The timer must
+    outlive the returned awaitable. Do not issue overlapping waits
+    on the same timer.
+
+    @par Completion Conditions
+    The returned awaitable resumes when either:
+    @li The inner operation completes (successfully or with error).
+    @li The timeout elapses and the inner operation is cancelled.
+    @li The caller's stop token is triggered, cancelling both.
+
+    @par Error Conditions
+    @li On timeout or parent cancellation, the inner operation
+        completes with an error equal to `capy::cond::canceled`.
+    @li All other errors are propagated from the inner operation.
+
+    @par Example
+    @code
+    native_timer<epoll> t( ioc );
+    auto [ec, n] = co_await cancel_after(
+        sock.read_some( buf ), t, 5s );
+    if (ec == capy::cond::canceled)
+        // timed out
+    @endcode
+
+    @tparam Backend A backend tag value (e.g., `epoll`).
+
+    @param op The inner I/O awaitable to wrap.
+    @param t The native timer to use for the timeout. Must outlive
+        the returned awaitable.
+    @param timeout The relative duration after which to cancel.
+
+    @return An awaitable whose result matches @p op's result type.
+
+    @see cancel_at, native_timer
+*/
+template<auto Backend>
+auto cancel_after(
+    capy::IoAwaitable auto&& op,
+    native_timer<Backend>& t,
+    timer::duration timeout)
+{
+    return cancel_at(
+        std::forward<decltype(op)>(op), t,
+        timer::clock_type::now() + timeout);
+}
+
+/** Cancel an operation if it does not complete by a deadline.
+
+    Convenience overload that creates a @ref native_timer internally,
+    devirtualizing the timer wait. Otherwise identical to the
+    explicit-timer overload.
+
+    @par Completion Conditions
+    The returned awaitable resumes when either:
+    @li The inner operation completes (successfully or with error).
+    @li The deadline expires and the inner operation is cancelled.
+    @li The caller's stop token is triggered, cancelling both.
+
+    @par Error Conditions
+    @li On timeout or parent cancellation, the inner operation
+        completes with an error equal to `capy::cond::canceled`.
+    @li All other errors are propagated from the inner operation.
+
+    @note Creates a timer per call. Use the explicit-timer overload
+        to amortize allocation across multiple timeouts.
+
+    @par Example
+    @code
+    auto [ec, n] = co_await cancel_at<epoll>(
+        sock.read_some( buf ),
+        clock::now() + 5s );
+    if (ec == capy::cond::canceled)
+        // timed out or parent cancelled
+    @endcode
+
+    @tparam Backend A backend tag value (e.g., `epoll`).
+
+    @param op The inner I/O awaitable to wrap.
+    @param deadline The absolute time point at which to cancel.
+
+    @return An awaitable whose result matches @p op's result type.
+
+    @see cancel_after, native_timer
+*/
+template<auto Backend>
+auto cancel_at(
+    capy::IoAwaitable auto&& op,
+    timer::time_point deadline)
+{
+    return detail::cancel_at_awaitable<
+        std::decay_t<decltype(op)>, native_timer<Backend>, true>(
+        std::forward<decltype(op)>(op), deadline);
+}
+
+/** Cancel an operation if it does not complete within a duration.
+
+    Convenience overload that creates a @ref native_timer internally.
+    Equivalent to `cancel_at<Backend>( op, clock::now() + timeout )`.
+
+    @par Completion Conditions
+    The returned awaitable resumes when either:
+    @li The inner operation completes (successfully or with error).
+    @li The timeout elapses and the inner operation is cancelled.
+    @li The caller's stop token is triggered, cancelling both.
+
+    @par Error Conditions
+    @li On timeout or parent cancellation, the inner operation
+        completes with an error equal to `capy::cond::canceled`.
+    @li All other errors are propagated from the inner operation.
+
+    @note Creates a timer per call. Use the explicit-timer overload
+        to amortize allocation across multiple timeouts.
+
+    @par Example
+    @code
+    auto [ec, n] = co_await cancel_after<epoll>(
+        sock.read_some( buf ), 5s );
+    if (ec == capy::cond::canceled)
+        // timed out
+    @endcode
+
+    @tparam Backend A backend tag value (e.g., `epoll`).
+
+    @param op The inner I/O awaitable to wrap.
+    @param timeout The relative duration after which to cancel.
+
+    @return An awaitable whose result matches @p op's result type.
+
+    @see cancel_at, native_timer
+*/
+template<auto Backend>
+auto cancel_after(
+    capy::IoAwaitable auto&& op,
+    timer::duration timeout)
+{
+    return cancel_at<Backend>(
+        std::forward<decltype(op)>(op),
+        timer::clock_type::now() + timeout);
+}
+
+} // namespace boost::corosio
+
+#endif

--- a/test/unit/cancel.cpp
+++ b/test/unit/cancel.cpp
@@ -1,0 +1,322 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+// Test that header file is self-contained.
+#include <boost/corosio/cancel.hpp>
+
+#include <boost/corosio/timer.hpp>
+#include <boost/capy/cond.hpp>
+#include <boost/capy/ex/run_async.hpp>
+#include <boost/capy/task.hpp>
+
+#include <chrono>
+#include <stop_token>
+
+#include "context.hpp"
+#include "test_suite.hpp"
+
+namespace boost::corosio {
+
+template<auto Backend>
+struct cancel_test
+{
+    void testTimeoutFires()
+    {
+        io_context ioc(Backend);
+        timer inner_timer(ioc);
+        timer timeout_timer(ioc);
+
+        bool completed = false;
+        std::error_code result_ec;
+
+        inner_timer.expires_after(std::chrono::seconds(60));
+
+        auto task = [&]() -> capy::task<> {
+            auto [ec] = co_await cancel_after(
+                inner_timer.wait(), timeout_timer,
+                std::chrono::milliseconds(10));
+            result_ec = ec;
+            completed = true;
+        };
+        capy::run_async(ioc.get_executor())(task());
+
+        ioc.run();
+        BOOST_TEST(completed);
+        BOOST_TEST(result_ec == capy::cond::canceled);
+    }
+
+    void testInnerCompletesFirst()
+    {
+        io_context ioc(Backend);
+        timer inner_timer(ioc);
+        timer timeout_timer(ioc);
+
+        bool completed = false;
+        std::error_code result_ec;
+
+        inner_timer.expires_after(std::chrono::milliseconds(10));
+
+        auto task = [&]() -> capy::task<> {
+            auto [ec] = co_await cancel_after(
+                inner_timer.wait(), timeout_timer,
+                std::chrono::seconds(1));
+            result_ec = ec;
+            completed = true;
+        };
+        capy::run_async(ioc.get_executor())(task());
+
+        ioc.run();
+        BOOST_TEST(completed);
+        BOOST_TEST(!result_ec);
+    }
+
+    void testZeroTimeout()
+    {
+        io_context ioc(Backend);
+        timer inner_timer(ioc);
+        timer timeout_timer(ioc);
+
+        bool completed = false;
+        std::error_code result_ec;
+
+        inner_timer.expires_after(std::chrono::seconds(60));
+
+        auto task = [&]() -> capy::task<> {
+            auto [ec] = co_await cancel_after(
+                inner_timer.wait(), timeout_timer,
+                std::chrono::milliseconds(0));
+            result_ec = ec;
+            completed = true;
+        };
+        capy::run_async(ioc.get_executor())(task());
+
+        ioc.run();
+        BOOST_TEST(completed);
+        BOOST_TEST(result_ec == capy::cond::canceled);
+    }
+
+    void testParentCancellation()
+    {
+        io_context ioc(Backend);
+        timer inner_timer(ioc);
+        timer timeout_timer(ioc);
+        timer delay(ioc);
+
+        std::stop_source stop_src;
+        bool completed = false;
+        std::error_code result_ec;
+
+        inner_timer.expires_after(std::chrono::seconds(60));
+
+        auto task = [&]() -> capy::task<> {
+            auto [ec] = co_await cancel_after(
+                inner_timer.wait(), timeout_timer,
+                std::chrono::seconds(60));
+            result_ec = ec;
+            completed = true;
+        };
+
+        auto canceller = [&]() -> capy::task<> {
+            delay.expires_after(std::chrono::milliseconds(10));
+            (void)co_await delay.wait();
+            stop_src.request_stop();
+        };
+
+        capy::run_async(ioc.get_executor(), stop_src.get_token())(
+            task());
+        capy::run_async(ioc.get_executor())(canceller());
+
+        ioc.run();
+        BOOST_TEST(completed);
+        BOOST_TEST(result_ec == capy::cond::canceled);
+    }
+
+    void testAlreadyExpiredDeadline()
+    {
+        io_context ioc(Backend);
+        timer inner_timer(ioc);
+        timer timeout_timer(ioc);
+
+        bool completed = false;
+        std::error_code result_ec;
+
+        inner_timer.expires_after(std::chrono::seconds(60));
+
+        auto task = [&]() -> capy::task<> {
+            auto [ec] = co_await cancel_at(
+                inner_timer.wait(), timeout_timer,
+                timer::clock_type::now() - std::chrono::seconds(1));
+            result_ec = ec;
+            completed = true;
+        };
+        capy::run_async(ioc.get_executor())(task());
+
+        ioc.run();
+        BOOST_TEST(completed);
+        BOOST_TEST(result_ec == capy::cond::canceled);
+    }
+
+    void testCancelAt()
+    {
+        io_context ioc(Backend);
+        timer inner_timer(ioc);
+        timer timeout_timer(ioc);
+
+        bool completed = false;
+        std::error_code result_ec;
+
+        inner_timer.expires_after(std::chrono::seconds(60));
+        auto deadline =
+            timer::clock_type::now() + std::chrono::milliseconds(10);
+
+        auto task = [&]() -> capy::task<> {
+            auto [ec] = co_await cancel_at(
+                inner_timer.wait(), timeout_timer, deadline);
+            result_ec = ec;
+            completed = true;
+        };
+        capy::run_async(ioc.get_executor())(task());
+
+        ioc.run();
+        BOOST_TEST(completed);
+        BOOST_TEST(result_ec == capy::cond::canceled);
+    }
+
+    void testTimerReuse()
+    {
+        io_context ioc(Backend);
+        timer inner_timer(ioc);
+        timer timeout_timer(ioc);
+
+        int completed = 0;
+
+        auto task = [&]() -> capy::task<> {
+            // First: inner completes before timeout
+            inner_timer.expires_after(std::chrono::milliseconds(10));
+            auto [ec1] = co_await cancel_after(
+                inner_timer.wait(), timeout_timer,
+                std::chrono::seconds(1));
+            BOOST_TEST(!ec1);
+            ++completed;
+
+            // Second: timeout fires
+            inner_timer.expires_after(std::chrono::seconds(60));
+            auto [ec2] = co_await cancel_after(
+                inner_timer.wait(), timeout_timer,
+                std::chrono::milliseconds(10));
+            BOOST_TEST(ec2 == capy::cond::canceled);
+            ++completed;
+
+            // Third: inner completes again
+            inner_timer.expires_after(std::chrono::milliseconds(10));
+            auto [ec3] = co_await cancel_after(
+                inner_timer.wait(), timeout_timer,
+                std::chrono::seconds(1));
+            BOOST_TEST(!ec3);
+            ++completed;
+        };
+        capy::run_async(ioc.get_executor())(task());
+
+        ioc.run();
+        BOOST_TEST_EQ(completed, 3);
+    }
+
+    // -- Convenience overloads (no user-supplied timer) --
+
+    void testConvenienceTimeoutFires()
+    {
+        io_context ioc(Backend);
+        timer inner_timer(ioc);
+
+        bool completed = false;
+        std::error_code result_ec;
+
+        inner_timer.expires_after(std::chrono::seconds(60));
+
+        auto task = [&]() -> capy::task<> {
+            auto [ec] = co_await cancel_after(
+                inner_timer.wait(),
+                std::chrono::milliseconds(10));
+            result_ec = ec;
+            completed = true;
+        };
+        capy::run_async(ioc.get_executor())(task());
+
+        ioc.run();
+        BOOST_TEST(completed);
+        BOOST_TEST(result_ec == capy::cond::canceled);
+    }
+
+    void testConvenienceInnerCompletesFirst()
+    {
+        io_context ioc(Backend);
+        timer inner_timer(ioc);
+
+        bool completed = false;
+        std::error_code result_ec;
+
+        inner_timer.expires_after(std::chrono::milliseconds(10));
+
+        auto task = [&]() -> capy::task<> {
+            auto [ec] = co_await cancel_after(
+                inner_timer.wait(),
+                std::chrono::seconds(1));
+            result_ec = ec;
+            completed = true;
+        };
+        capy::run_async(ioc.get_executor())(task());
+
+        ioc.run();
+        BOOST_TEST(completed);
+        BOOST_TEST(!result_ec);
+    }
+
+    void testConvenienceCancelAt()
+    {
+        io_context ioc(Backend);
+        timer inner_timer(ioc);
+
+        bool completed = false;
+        std::error_code result_ec;
+
+        inner_timer.expires_after(std::chrono::seconds(60));
+        auto deadline =
+            timer::clock_type::now() + std::chrono::milliseconds(10);
+
+        auto task = [&]() -> capy::task<> {
+            auto [ec] = co_await cancel_at(
+                inner_timer.wait(), deadline);
+            result_ec = ec;
+            completed = true;
+        };
+        capy::run_async(ioc.get_executor())(task());
+
+        ioc.run();
+        BOOST_TEST(completed);
+        BOOST_TEST(result_ec == capy::cond::canceled);
+    }
+
+    void run()
+    {
+        testTimeoutFires();
+        testInnerCompletesFirst();
+        testZeroTimeout();
+        testParentCancellation();
+        testAlreadyExpiredDeadline();
+        testCancelAt();
+        testTimerReuse();
+        testConvenienceTimeoutFires();
+        testConvenienceInnerCompletesFirst();
+        testConvenienceCancelAt();
+    }
+};
+
+COROSIO_BACKEND_TESTS(cancel_test, "boost.corosio.cancel")
+
+} // namespace boost::corosio

--- a/test/unit/native/native_cancel.cpp
+++ b/test/unit/native/native_cancel.cpp
@@ -1,0 +1,111 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+// Test that header file is self-contained.
+#include <boost/corosio/native/native_cancel.hpp>
+
+#include <boost/corosio/timer.hpp>
+#include <boost/capy/cond.hpp>
+#include <boost/capy/ex/run_async.hpp>
+#include <boost/capy/task.hpp>
+
+#include <chrono>
+
+#include "context.hpp"
+#include "test_suite.hpp"
+
+namespace boost::corosio {
+
+template<auto Backend>
+struct native_cancel_test
+{
+    void testConvenienceTimeoutFires()
+    {
+        io_context ioc(Backend);
+        timer inner_timer(ioc);
+
+        bool completed = false;
+        std::error_code result_ec;
+
+        inner_timer.expires_after(std::chrono::seconds(60));
+
+        auto task = [&]() -> capy::task<> {
+            auto [ec] = co_await cancel_after<Backend>(
+                inner_timer.wait(),
+                std::chrono::milliseconds(10));
+            result_ec = ec;
+            completed = true;
+        };
+        capy::run_async(ioc.get_executor())(task());
+
+        ioc.run();
+        BOOST_TEST(completed);
+        BOOST_TEST(result_ec == capy::cond::canceled);
+    }
+
+    void testConvenienceInnerCompletesFirst()
+    {
+        io_context ioc(Backend);
+        timer inner_timer(ioc);
+
+        bool completed = false;
+        std::error_code result_ec;
+
+        inner_timer.expires_after(std::chrono::milliseconds(10));
+
+        auto task = [&]() -> capy::task<> {
+            auto [ec] = co_await cancel_after<Backend>(
+                inner_timer.wait(),
+                std::chrono::seconds(1));
+            result_ec = ec;
+            completed = true;
+        };
+        capy::run_async(ioc.get_executor())(task());
+
+        ioc.run();
+        BOOST_TEST(completed);
+        BOOST_TEST(!result_ec);
+    }
+
+    void testConvenienceCancelAt()
+    {
+        io_context ioc(Backend);
+        timer inner_timer(ioc);
+
+        bool completed = false;
+        std::error_code result_ec;
+
+        inner_timer.expires_after(std::chrono::seconds(60));
+        auto deadline =
+            timer::clock_type::now() + std::chrono::milliseconds(10);
+
+        auto task = [&]() -> capy::task<> {
+            auto [ec] = co_await cancel_at<Backend>(
+                inner_timer.wait(), deadline);
+            result_ec = ec;
+            completed = true;
+        };
+        capy::run_async(ioc.get_executor())(task());
+
+        ioc.run();
+        BOOST_TEST(completed);
+        BOOST_TEST(result_ec == capy::cond::canceled);
+    }
+
+    void run()
+    {
+        testConvenienceTimeoutFires();
+        testConvenienceInnerCompletesFirst();
+        testConvenienceCancelAt();
+    }
+};
+
+COROSIO_BACKEND_TESTS(native_cancel_test, "boost.corosio.native_cancel")
+
+} // namespace boost::corosio


### PR DESCRIPTION
Lightweight free functions that race an IoAwaitable against a timer. A bidirectional std::stop_source ties the inner op and timeout together — whichever completes first cancels the other. Uses a fire-and-forget coroutine for the timer side, avoiding any timer_service modifications.

Resolves #119.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deadline-based cancellation for I/O via cancel_at().
  * Timeout-based cancellation for I/O via cancel_after().
  * Support for native timer backends so cancellations integrate with platform timers.
  * Lightweight fire-and-forget timeout coroutine to drive cancellations.
  * Parent cancellation is propagated; operations auto-cancel on timeout.
  * Public headers exposing cancellation and socket-option support added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->