### PR TITLE
Remove -fcoroutines and -fexperimental-library flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,6 @@ jobs:
 
           # macOS (4 configurations)
           # kqueue is the default backend on macOS
-          # Global cxxflags needed until capy adds -fexperimental-library internally
 
           - compiler: "apple-clang"
             version: "*"
@@ -146,7 +145,6 @@ jobs:
             build-type: "RelWithDebInfo"
             asan: true
             ubsan: true
-            cxxflags: "-fexperimental-library"
 
           - compiler: "apple-clang"
             version: "*"
@@ -161,7 +159,6 @@ jobs:
             shared: true
             build-type: "Release"
             build-cmake: true
-            cxxflags: "-fexperimental-library"
 
           - compiler: "apple-clang"
             version: "*"
@@ -175,7 +172,6 @@ jobs:
             macos: true
             shared: true
             build-type: "Release"
-            cxxflags: "-fexperimental-library"
 
           - compiler: "apple-clang"
             version: "*"
@@ -191,7 +187,7 @@ jobs:
             coverage: true
             coverage-flag: "macos"
             build-type: "Debug"
-            cxxflags: "--coverage -fexperimental-library"
+            cxxflags: "--coverage"
             ccflags: "--coverage"
 
           # Linux GCC (5 configurations)
@@ -778,7 +774,6 @@ jobs:
               variant=release \
               link=shared \
               rtti=on \
-              cxxflags="-fexperimental-library" \
               -q \
               -j$(sysctl -n hw.ncpu)
 
@@ -795,7 +790,6 @@ jobs:
             cd boost-root
             cmake -S . -B build \
               -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_CXX_FLAGS="-fexperimental-library" \
               -DBOOST_INCLUDE_LIBRARIES="${{ steps.patch.outputs.module }}" \
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
             cmake --build build --target tests -j$(sysctl -n hw.ncpu)

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -208,7 +208,7 @@ jobs:
           cxxstd: '20'
           cc: ${{ steps.setup-cpp.outputs.cc || 'clang' }}
           cxx: ${{ steps.setup-cpp.outputs.cxx || 'clang++' }}
-          cxxflags: '--coverage -fexperimental-library'
+          cxxflags: '--coverage'
           ccflags: '--coverage'
           shared: false
           cmake-version: '>=3.20'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,9 +67,6 @@ target_compile_definitions(boost_corosio
         $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,BOOST_COROSIO_DYN_LINK,BOOST_COROSIO_STATIC_LINK>
     PRIVATE
         BOOST_COROSIO_SOURCE)
-target_compile_options(boost_corosio
-    PRIVATE
-        $<$<CXX_COMPILER_ID:GNU>:-fcoroutines>)
 set_target_properties(boost_corosio PROPERTIES EXPORT_NAME corosio)
 
 if (BOOST_COROSIO_MRDOCS_BUILD)

--- a/build/Jamfile
+++ b/build/Jamfile
@@ -20,7 +20,6 @@ project boost/corosio
   : requirements
     $(c20-requires)
     <define>BOOST_COROSIO_SOURCE
-    <toolset>gcc:<cxxflags>-fcoroutines
   : common-requirements
     <link>shared:<define>BOOST_COROSIO_DYN_LINK
     <link>static:<define>BOOST_COROSIO_STATIC_LINK

--- a/cmake/CorosioBuild.cmake
+++ b/cmake/CorosioBuild.cmake
@@ -165,9 +165,6 @@ function(corosio_add_tls_library name)
     target_include_directories(${_target} PRIVATE
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/corosio>)
     target_compile_definitions(${_target} PRIVATE BOOST_COROSIO_SOURCE)
-    target_compile_options(${_target}
-        PRIVATE
-            $<$<CXX_COMPILER_ID:GNU>:-fcoroutines>)
 endfunction()
 
 # corosio_install()

--- a/perf/bench/CMakeLists.txt
+++ b/perf/bench/CMakeLists.txt
@@ -32,7 +32,6 @@ target_link_libraries(corosio_bench
         Threads::Threads)
 
 target_compile_options(corosio_bench PRIVATE
-    $<$<CXX_COMPILER_ID:GNU>:-fcoroutines>
     $<$<CXX_COMPILER_ID:MSVC>:/EHsc>)
 
 set_property(TARGET corosio_bench PROPERTY FOLDER "perf/benchmarks")

--- a/test/unit/Jamfile
+++ b/test/unit/Jamfile
@@ -17,7 +17,6 @@ project boost/corosio/test/unit
       <include>../../../capy/extra/test_suite
       <include>.
       <include>../..
-      <toolset>gcc:<cxxflags>-fcoroutines
     ;
 
 # Non-TLS tests


### PR DESCRIPTION
Capy now propagates these as PUBLIC compile options, making local flag-setting redundant for downstream consumers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build configurations by removing unnecessary compiler flags from continuous integration workflows and CMake build scripts across macOS, Linux, and FreeBSD platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->