### PR TITLE
Replace per-operation thread spawning with shared thread pool

### DIFF
--- a/include/boost/corosio/detail/thread_pool.hpp
+++ b/include/boost/corosio/detail/thread_pool.hpp
@@ -1,0 +1,213 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_DETAIL_THREAD_POOL_HPP
+#define BOOST_COROSIO_DETAIL_THREAD_POOL_HPP
+
+#include <boost/corosio/detail/config.hpp>
+#include <boost/corosio/detail/intrusive.hpp>
+#include <boost/capy/ex/execution_context.hpp>
+
+#include <condition_variable>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+namespace boost::corosio::detail {
+
+/** Base class for thread pool work items.
+
+    Derive from this to create work that can be posted to a
+    @ref thread_pool. Uses static function pointer dispatch,
+    consistent with the IOCP `op` pattern.
+
+    @par Example
+    @code
+    struct my_work : pool_work_item
+    {
+        int* result;
+        static void execute( pool_work_item* w ) noexcept
+        {
+            auto* self = static_cast<my_work*>( w );
+            *self->result = 42;
+        }
+    };
+
+    my_work w;
+    w.func_ = &my_work::execute;
+    w.result = &r;
+    pool.post( &w );
+    @endcode
+*/
+struct pool_work_item : intrusive_queue<pool_work_item>::node
+{
+    /// Static dispatch function signature.
+    using func_type = void (*)(pool_work_item*) noexcept;
+
+    /// Completion handler invoked by the worker thread.
+    func_type func_ = nullptr;
+};
+
+/** Shared thread pool for dispatching blocking operations.
+
+    Provides a fixed pool of reusable worker threads for operations
+    that cannot be integrated with async I/O (e.g. blocking DNS
+    calls). Registered as an `execution_context::service` so it
+    is a singleton per io_context.
+
+    Threads are created eagerly in the constructor. The default
+    thread count is 1.
+
+    @par Thread Safety
+    All public member functions are thread-safe.
+
+    @par Shutdown
+    Sets a shutdown flag, notifies all threads, and joins them.
+    In-flight blocking calls complete naturally before the thread
+    exits.
+*/
+class thread_pool final
+    : public capy::execution_context::service
+{
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    intrusive_queue<pool_work_item> work_queue_;
+    std::vector<std::thread> threads_;
+    bool shutdown_ = false;
+
+    void worker_loop();
+
+public:
+    using key_type = thread_pool;
+
+    /** Construct the thread pool service.
+
+        Eagerly creates all worker threads.
+
+        @par Exception Safety
+        Strong guarantee. If thread creation fails, all
+        already-created threads are shut down and joined
+        before the exception propagates.
+
+        @param ctx Reference to the owning execution_context.
+        @param num_threads Number of worker threads. Must be
+               at least 1.
+
+        @throws std::logic_error If `num_threads` is 0.
+    */
+    explicit thread_pool(
+        capy::execution_context& ctx,
+        unsigned num_threads = 1)
+    {
+        (void)ctx;
+        if (!num_threads)
+            throw std::logic_error(
+                "thread_pool requires at least 1 thread");
+        threads_.reserve(num_threads);
+        try
+        {
+            for (unsigned i = 0; i < num_threads; ++i)
+                threads_.emplace_back([this] { worker_loop(); });
+        }
+        catch (...)
+        {
+            shutdown();
+            throw;
+        }
+    }
+
+    ~thread_pool() override = default;
+
+    thread_pool(thread_pool const&) = delete;
+    thread_pool& operator=(thread_pool const&) = delete;
+
+    /** Enqueue a work item for execution on the thread pool.
+
+        Zero-allocation: the caller owns the work item's storage.
+
+        @param w The work item to execute. Must remain valid until
+                 its `func_` has been called.
+
+        @return `true` if the item was enqueued, `false` if the
+                pool has already shut down.
+    */
+    bool post(pool_work_item* w) noexcept;
+
+    /** Shut down the thread pool.
+
+        Signals all threads to exit after draining any
+        remaining queued work, then joins them.
+    */
+    void shutdown() override;
+};
+
+inline void
+thread_pool::worker_loop()
+{
+    for (;;)
+    {
+        pool_work_item* w;
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            cv_.wait(lock, [this] {
+                return shutdown_ || !work_queue_.empty();
+            });
+
+            w = work_queue_.pop();
+            if (!w)
+            {
+                if (shutdown_)
+                    return;
+                continue;
+            }
+        }
+        w->func_(w);
+    }
+}
+
+inline bool
+thread_pool::post(pool_work_item* w) noexcept
+{
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (shutdown_)
+            return false;
+        work_queue_.push(w);
+    }
+    cv_.notify_one();
+    return true;
+}
+
+inline void
+thread_pool::shutdown()
+{
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        shutdown_ = true;
+    }
+    cv_.notify_all();
+
+    for (auto& t : threads_)
+    {
+        if (t.joinable())
+            t.join();
+    }
+    threads_.clear();
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        while (work_queue_.pop())
+            ;
+    }
+}
+
+} // namespace boost::corosio::detail
+
+#endif // BOOST_COROSIO_DETAIL_THREAD_POOL_HPP

--- a/include/boost/corosio/native/detail/iocp/win_resolver.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_resolver.hpp
@@ -23,6 +23,7 @@
 #endif
 
 #include <boost/corosio/detail/scheduler.hpp>
+#include <boost/corosio/detail/thread_pool.hpp>
 #include <boost/corosio/endpoint.hpp>
 #include <boost/corosio/resolver.hpp>
 #include <boost/corosio/resolver_results.hpp>
@@ -42,12 +43,9 @@
 #include <WS2tcpip.h>
 
 #include <atomic>
-#include <condition_variable>
 #include <cstring>
 #include <memory>
 #include <string>
-#include <thread>
-#include <unordered_map>
 
 // MinGW may not have GetAddrInfoExCancel declared
 #if defined(__MINGW32__) || defined(__MINGW64__)
@@ -72,15 +70,14 @@ extern "C"
     Reverse Resolution (GetNameInfoW)
     ---------------------------------
     Unlike GetAddrInfoExW, GetNameInfoW has no async variant. Reverse
-    resolution spawns a detached worker thread that calls GetNameInfoW
-    and posts the result to the scheduler upon completion.
+    resolution dispatches the blocking call to the shared
+    resolver_thread_pool service.
 
     Class Hierarchy
     ---------------
     - win_resolver_service (execution_context::service)
         - Owns all win_resolver instances via shared_ptr
         - Coordinates with win_scheduler for work tracking
-        - Tracks active worker threads for safe shutdown
     - win_resolver (one per resolver object)
         - Contains embedded resolve_op and reverse_resolve_op
         - Inherits from enable_shared_from_this for thread safety
@@ -88,14 +85,13 @@ extern "C"
         - OVERLAPPED base enables IOCP integration
         - Static completion() callback invoked by Windows
     - reverse_resolve_op (overlapped_op subclass)
-        - Used by worker thread for reverse resolution
+        - Used by pool thread for reverse resolution
 
-    Shutdown Synchronization
-    ------------------------
-    The service uses condition_variable_any and win_mutex to track active
-    worker threads. During shutdown(), the service waits for all threads
-    to complete before destroying resources. Worker threads always post
-    their completions so the scheduler can properly drain them via destroy().
+    Shutdown
+    --------
+    The resolver service cancels all resolvers and clears the impl map.
+    The thread pool service shuts down separately via execution_context
+    service ordering, joining all worker threads.
 
     Cancellation
     ------------
@@ -128,16 +124,13 @@ extern "C"
 
     Reverse Resolution (GetNameInfoW)
     ---------------------------------
-    Unlike GetAddrInfoExW, GetNameInfoW has no async variant. We use a worker
-    thread approach similar to POSIX:
-    1. reverse_resolve() spawns a detached worker thread
-    2. Worker calls GetNameInfoW() (blocking)
-    3. Worker converts wide results to UTF-8 via WideCharToMultiByte
-    4. Worker posts completion to scheduler
+    Unlike GetAddrInfoExW, GetNameInfoW has no async variant. The blocking
+    call is dispatched to the shared resolver_thread_pool:
+    1. reverse_resolve() posts work to the thread pool
+    2. Pool thread calls GetNameInfoW() (blocking)
+    3. Pool thread converts wide results to UTF-8 via WideCharToMultiByte
+    4. Pool thread posts completion to scheduler
     5. op_() resumes the coroutine with results
-
-    Thread tracking (thread_started/thread_finished) ensures safe shutdown
-    by waiting for all worker threads before destroying the service.
 
     String Conversion
     -----------------
@@ -250,6 +243,16 @@ class win_resolver final
     friend struct resolve_op;
 
 public:
+    /// Embedded pool work item for thread pool dispatch.
+    struct pool_op : pool_work_item
+    {
+        /// Resolver that owns this work item.
+        win_resolver* resolver_ = nullptr;
+
+        /// Prevent impl destruction while work is in flight.
+        std::shared_ptr<win_resolver> ref_;
+    };
+
     explicit win_resolver(win_resolver_service& svc) noexcept;
 
     std::coroutine_handle<> resolve(
@@ -275,6 +278,12 @@ public:
 
     resolve_op op_;
     reverse_resolve_op reverse_op_;
+
+    /// Pool work item for reverse resolution.
+    pool_op reverse_pool_op_;
+
+    /// Execute blocking `GetNameInfoW()` on a pool thread.
+    static void do_reverse_resolve_work(pool_work_item*) noexcept;
 
 private:
     win_resolver_service& svc_;

--- a/include/boost/corosio/native/detail/iocp/win_resolver_service.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_resolver_service.hpp
@@ -16,6 +16,9 @@
 #if BOOST_COROSIO_HAS_IOCP
 
 #include <boost/corosio/native/detail/iocp/win_resolver.hpp>
+#include <boost/corosio/detail/thread_pool.hpp>
+
+#include <unordered_map>
 
 namespace boost::corosio::detail {
 
@@ -78,21 +81,13 @@ public:
     /** Notify scheduler that I/O work completed. */
     void work_finished() noexcept;
 
-    /** Track worker thread start for safe shutdown. */
-    void thread_started() noexcept;
-
-    /** Track worker thread completion for safe shutdown. */
-    void thread_finished() noexcept;
-
-    /** Check if service is shutting down. */
-    bool is_shutting_down() const noexcept;
+    /** Return the resolver thread pool. */
+    thread_pool& pool() noexcept { return pool_; }
 
 private:
     scheduler& sched_;
+    thread_pool& pool_;
     win_mutex mutex_;
-    std::condition_variable_any cv_;
-    std::atomic<bool> shutting_down_{false};
-    std::size_t active_threads_ = 0;
     intrusive_list<win_resolver> resolver_list_;
     std::unordered_map<win_resolver*, std::shared_ptr<win_resolver>>
         resolver_ptrs_;
@@ -413,74 +408,16 @@ win_resolver::reverse_resolve(
     // Keep io_context alive while resolution is pending
     svc_.work_started();
 
-    // Track thread for safe shutdown
-    svc_.thread_started();
-
-    try
+    // Prevent impl destruction while work is in flight
+    reverse_pool_op_.resolver_ = this;
+    reverse_pool_op_.ref_      = this->shared_from_this();
+    reverse_pool_op_.func_ = &win_resolver::do_reverse_resolve_work;
+    if (!svc_.pool().post(&reverse_pool_op_))
     {
-        // Prevent impl destruction while worker thread is running
-        auto self = this->shared_from_this();
-
-        // GetNameInfoW is synchronous, so we need to use a thread
-        std::thread worker([this, self = std::move(self)]() {
-            // Build sockaddr from endpoint
-            sockaddr_storage ss{};
-            int ss_len;
-
-            if (reverse_op_.ep.is_v4())
-            {
-                auto sa = to_sockaddr_in(reverse_op_.ep);
-                std::memcpy(&ss, &sa, sizeof(sa));
-                ss_len = sizeof(sockaddr_in);
-            }
-            else
-            {
-                auto sa = to_sockaddr_in6(reverse_op_.ep);
-                std::memcpy(&ss, &sa, sizeof(sa));
-                ss_len = sizeof(sockaddr_in6);
-            }
-
-            wchar_t host[NI_MAXHOST];
-            wchar_t service[NI_MAXSERV];
-
-            int result = ::GetNameInfoW(
-                reinterpret_cast<sockaddr*>(&ss), ss_len, host, NI_MAXHOST,
-                service, NI_MAXSERV,
-                resolver_detail::flags_to_ni_flags(reverse_op_.flags));
-
-            if (!reverse_op_.cancelled.load(std::memory_order_acquire))
-            {
-                if (result == 0)
-                {
-                    reverse_op_.stored_host = resolver_detail::from_wide(host);
-                    reverse_op_.stored_service =
-                        resolver_detail::from_wide(service);
-                    reverse_op_.gai_error = 0;
-                }
-                else
-                {
-                    reverse_op_.gai_error = result;
-                }
-            }
-
-            // Always post so the scheduler can properly drain the op
-            // during shutdown via destroy().
-            svc_.work_finished();
-            svc_.post(&reverse_op_);
-
-            // Signal thread completion for shutdown synchronization
-            svc_.thread_finished();
-        });
-        worker.detach();
-    }
-    catch (std::system_error const&)
-    {
-        // Thread creation failed - no thread was started
-        svc_.thread_finished();
-
-        // Set error and post completion to avoid hanging the coroutine
+        // Pool shut down — complete with cancellation
+        reverse_pool_op_.ref_.reset();
+        op.cancelled.store(true, std::memory_order_release);
         svc_.work_finished();
-        reverse_op_.gai_error = WSAENOBUFS; // Map to "not enough memory"
         svc_.post(&reverse_op_);
     }
     // completion is always posted to scheduler queue, never inline.
@@ -499,13 +436,67 @@ win_resolver::cancel() noexcept
     }
 }
 
+inline void
+win_resolver::do_reverse_resolve_work(pool_work_item* w) noexcept
+{
+    auto* pw   = static_cast<pool_op*>(w);
+    auto* self = pw->resolver_;
+
+    sockaddr_storage ss{};
+    int ss_len;
+
+    if (self->reverse_op_.ep.is_v4())
+    {
+        auto sa = to_sockaddr_in(self->reverse_op_.ep);
+        std::memcpy(&ss, &sa, sizeof(sa));
+        ss_len = sizeof(sockaddr_in);
+    }
+    else
+    {
+        auto sa = to_sockaddr_in6(self->reverse_op_.ep);
+        std::memcpy(&ss, &sa, sizeof(sa));
+        ss_len = sizeof(sockaddr_in6);
+    }
+
+    wchar_t host[NI_MAXHOST];
+    wchar_t service[NI_MAXSERV];
+
+    int result = ::GetNameInfoW(
+        reinterpret_cast<sockaddr*>(&ss), ss_len, host, NI_MAXHOST,
+        service, NI_MAXSERV,
+        resolver_detail::flags_to_ni_flags(self->reverse_op_.flags));
+
+    if (!self->reverse_op_.cancelled.load(std::memory_order_acquire))
+    {
+        if (result == 0)
+        {
+            self->reverse_op_.stored_host =
+                resolver_detail::from_wide(host);
+            self->reverse_op_.stored_service =
+                resolver_detail::from_wide(service);
+            self->reverse_op_.gai_error = 0;
+        }
+        else
+        {
+            self->reverse_op_.gai_error = result;
+        }
+    }
+
+    self->svc_.work_finished();
+
+    // Move ref to stack before post — post may trigger destroy_impl
+    // which erases the last shared_ptr, destroying *self (and *pw)
+    auto ref = std::move(pw->ref_);
+    self->svc_.post(&self->reverse_op_);
+}
+
 // win_resolver_service
 
 inline win_resolver_service::win_resolver_service(
     capy::execution_context& ctx, scheduler& sched)
     : sched_(sched)
+    , pool_(ctx.make_service<thread_pool>())
 {
-    (void)ctx;
 }
 
 inline win_resolver_service::~win_resolver_service() {}
@@ -513,29 +504,19 @@ inline win_resolver_service::~win_resolver_service() {}
 inline void
 win_resolver_service::shutdown()
 {
+    std::lock_guard<win_mutex> lock(mutex_);
+
+    // Cancel all resolvers (sets cancelled flag checked by pool threads)
+    for (auto* impl = resolver_list_.pop_front(); impl != nullptr;
+         impl       = resolver_list_.pop_front())
     {
-        std::lock_guard<win_mutex> lock(mutex_);
-
-        // Signal threads to not access service after GetNameInfoW returns
-        shutting_down_.store(true, std::memory_order_release);
-
-        // Cancel all resolvers (sets cancelled flag checked by threads)
-        for (auto* impl = resolver_list_.pop_front(); impl != nullptr;
-             impl       = resolver_list_.pop_front())
-        {
-            impl->cancel();
-        }
-
-        // Clear the map which releases shared_ptrs
-        // Note: impls may still be alive if worker threads hold references
-        resolver_ptrs_.clear();
+        impl->cancel();
     }
 
-    // Wait for all worker threads to finish before service is destroyed
-    {
-        std::unique_lock<win_mutex> lock(mutex_);
-        cv_.wait(lock, [this] { return active_threads_ == 0; });
-    }
+    // Clear the map which releases shared_ptrs.
+    // The thread pool service shuts down separately via
+    // execution_context service ordering.
+    resolver_ptrs_.clear();
 }
 
 inline io_object::implementation*
@@ -577,27 +558,6 @@ inline void
 win_resolver_service::work_finished() noexcept
 {
     sched_.work_finished();
-}
-
-inline void
-win_resolver_service::thread_started() noexcept
-{
-    std::lock_guard<win_mutex> lock(mutex_);
-    ++active_threads_;
-}
-
-inline void
-win_resolver_service::thread_finished() noexcept
-{
-    std::lock_guard<win_mutex> lock(mutex_);
-    --active_threads_;
-    cv_.notify_one();
-}
-
-inline bool
-win_resolver_service::is_shutting_down() const noexcept
-{
-    return shutting_down_.load(std::memory_order_acquire);
 }
 
 } // namespace boost::corosio::detail

--- a/include/boost/corosio/native/detail/posix/posix_resolver.hpp
+++ b/include/boost/corosio/native/detail/posix/posix_resolver.hpp
@@ -22,6 +22,7 @@
 #include <boost/corosio/detail/intrusive.hpp>
 #include <boost/corosio/detail/dispatch_coro.hpp>
 #include <boost/corosio/detail/scheduler_op.hpp>
+#include <boost/corosio/detail/thread_pool.hpp>
 
 #include <boost/corosio/detail/scheduler.hpp>
 #include <boost/corosio/resolver_results.hpp>
@@ -34,32 +35,18 @@
 #include <sys/socket.h>
 
 #include <atomic>
-#include <cassert>
-#include <condition_variable>
-#include <cstring>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <stop_token>
 #include <string>
-#include <thread>
-#include <unordered_map>
-#include <vector>
 
 /*
     POSIX Resolver Service
     ======================
 
     POSIX getaddrinfo() is a blocking call that cannot be monitored with
-    epoll/kqueue/io_uring. We use a worker thread approach: each resolution
-    spawns a dedicated thread that runs the blocking call and posts completion
-    back to the scheduler.
-
-    Thread-per-resolution Design
-    ----------------------------
-    Simple, no thread pool complexity. DNS lookups are infrequent enough that
-    thread creation overhead is acceptable. Detached threads self-manage;
-    shared_ptr capture keeps impl alive until completion.
+    epoll/kqueue/io_uring. Blocking calls are dispatched to a shared
+    resolver_thread_pool service which reuses threads across operations.
 
     Cancellation
     ------------
@@ -80,19 +67,13 @@
     - reverse_resolve_op (reverse resolution state)
         - Uses getnameinfo() to resolve endpoint to host/service
 
-    Worker Thread Lifetime
-    ----------------------
-    Each resolve() spawns a detached thread. The thread captures a shared_ptr
-    to posix_resolver, ensuring the impl (and its embedded op_) stays
-    alive until the thread completes, even if the resolver is destroyed.
-
     Completion Flow
     ---------------
     Forward resolution:
-    1. resolve() sets up op_, spawns worker thread
-    2. Worker runs getaddrinfo() (blocking)
-    3. Worker stores results in op_.stored_results
-    4. Worker calls svc_.post(&op_) to queue completion
+    1. resolve() sets up op_, posts work to the thread pool
+    2. Pool thread runs getaddrinfo() (blocking)
+    3. Pool thread stores results in op_.stored_results
+    4. Pool thread calls svc_.post(&op_) to queue completion
     5. Scheduler invokes op_() which resumes the coroutine
 
     Reverse resolution follows the same pattern using getnameinfo().
@@ -103,11 +84,11 @@
     reverse resolution. Concurrent operations of the same type on the same
     resolver would corrupt state. Users must serialize operations per-resolver.
 
-    Shutdown Synchronization
-    ------------------------
-    The service tracks active worker threads via thread_started()/thread_finished().
-    During shutdown(), the service sets shutting_down_ flag and waits for all
-    threads to complete before destroying resources.
+    Shutdown
+    --------
+    The resolver service cancels all resolvers and clears the impl map.
+    The thread pool service shuts down separately via execution_context
+    service ordering, joining all worker threads.
 */
 
 namespace boost::corosio::detail {
@@ -268,6 +249,16 @@ public:
         void start(std::stop_token const& token);
     };
 
+    /// Embedded pool work item for thread pool dispatch.
+    struct pool_op : pool_work_item
+    {
+        /// Resolver that owns this work item.
+        posix_resolver* resolver_ = nullptr;
+
+        /// Prevent impl destruction while work is in flight.
+        std::shared_ptr<posix_resolver> ref_;
+    };
+
     explicit posix_resolver(posix_resolver_service& svc) noexcept;
 
     std::coroutine_handle<> resolve(
@@ -293,6 +284,18 @@ public:
 
     resolve_op op_;
     reverse_resolve_op reverse_op_;
+
+    /// Pool work item for forward resolution.
+    pool_op resolve_pool_op_;
+
+    /// Pool work item for reverse resolution.
+    pool_op reverse_pool_op_;
+
+    /// Execute blocking `getaddrinfo()` on a pool thread.
+    static void do_resolve_work(pool_work_item*) noexcept;
+
+    /// Execute blocking `getnameinfo()` on a pool thread.
+    static void do_reverse_resolve_work(pool_work_item*) noexcept;
 
 private:
     posix_resolver_service& svc_;

--- a/include/boost/corosio/native/detail/posix/posix_resolver_service.hpp
+++ b/include/boost/corosio/native/detail/posix/posix_resolver_service.hpp
@@ -15,13 +15,16 @@
 #if BOOST_COROSIO_POSIX
 
 #include <boost/corosio/native/detail/posix/posix_resolver.hpp>
+#include <boost/corosio/detail/thread_pool.hpp>
+
+#include <unordered_map>
 
 namespace boost::corosio::detail {
 
 /** Resolver service for POSIX backends.
 
-    Owns all posix_resolver instances and tracks active worker
-    threads for safe shutdown synchronization.
+    Owns all posix_resolver instances. Thread lifecycle is managed
+    by the thread_pool service.
 */
 class BOOST_COROSIO_DECL posix_resolver_service final
     : public capy::execution_context::service
@@ -30,8 +33,9 @@ class BOOST_COROSIO_DECL posix_resolver_service final
 public:
     using key_type = posix_resolver_service;
 
-    posix_resolver_service(capy::execution_context&, scheduler& sched)
+    posix_resolver_service(capy::execution_context& ctx, scheduler& sched)
         : sched_(&sched)
+        , pool_(ctx.make_service<thread_pool>())
     {
     }
 
@@ -56,16 +60,13 @@ public:
     void work_started() noexcept;
     void work_finished() noexcept;
 
-    void thread_started() noexcept;
-    void thread_finished() noexcept;
-    bool is_shutting_down() const noexcept;
+    /** Return the resolver thread pool. */
+    thread_pool& pool() noexcept { return pool_; }
 
 private:
     scheduler* sched_;
+    thread_pool& pool_;
     std::mutex mutex_;
-    std::condition_variable cv_;
-    std::atomic<bool> shutting_down_{false};
-    std::size_t active_threads_ = 0;
     intrusive_list<posix_resolver> resolver_list_;
     std::unordered_map<posix_resolver*, std::shared_ptr<posix_resolver>>
         resolver_ptrs_;
@@ -379,58 +380,15 @@ posix_resolver::resolve(
     // Keep io_context alive while resolution is pending
     op.ex.on_work_started();
 
-    // Track thread for safe shutdown
-    svc_.thread_started();
-
-    try
+    // Prevent impl destruction while work is in flight
+    resolve_pool_op_.resolver_ = this;
+    resolve_pool_op_.ref_      = this->shared_from_this();
+    resolve_pool_op_.func_     = &posix_resolver::do_resolve_work;
+    if (!svc_.pool().post(&resolve_pool_op_))
     {
-        // Prevent impl destruction while worker thread is running
-        auto self = this->shared_from_this();
-        std::thread worker([this, self = std::move(self)]() {
-            struct addrinfo hints{};
-            hints.ai_family   = AF_UNSPEC;
-            hints.ai_socktype = SOCK_STREAM;
-            hints.ai_flags = posix_resolver_detail::flags_to_hints(op_.flags);
-
-            struct addrinfo* ai = nullptr;
-            int result          = ::getaddrinfo(
-                op_.host.empty() ? nullptr : op_.host.c_str(),
-                op_.service.empty() ? nullptr : op_.service.c_str(), &hints,
-                &ai);
-
-            if (!op_.cancelled.load(std::memory_order_acquire))
-            {
-                if (result == 0 && ai)
-                {
-                    op_.stored_results = posix_resolver_detail::convert_results(
-                        ai, op_.host, op_.service);
-                    op_.gai_error = 0;
-                }
-                else
-                {
-                    op_.gai_error = result;
-                }
-            }
-
-            if (ai)
-                ::freeaddrinfo(ai);
-
-            // Always post so the scheduler can properly drain the op
-            // during shutdown via destroy().
-            svc_.post(&op_);
-
-            // Signal thread completion for shutdown synchronization
-            svc_.thread_finished();
-        });
-        worker.detach();
-    }
-    catch (std::system_error const&)
-    {
-        // Thread creation failed - no thread was started
-        svc_.thread_finished();
-
-        // Set error and post completion to avoid hanging the coroutine
-        op_.gai_error = EAI_MEMORY; // Map to "not enough memory"
+        // Pool shut down — complete with cancellation
+        resolve_pool_op_.ref_.reset();
+        op.cancelled.store(true, std::memory_order_release);
         svc_.post(&op_);
     }
     return std::noop_coroutine();
@@ -460,69 +418,15 @@ posix_resolver::reverse_resolve(
     // Keep io_context alive while resolution is pending
     op.ex.on_work_started();
 
-    // Track thread for safe shutdown
-    svc_.thread_started();
-
-    try
+    // Prevent impl destruction while work is in flight
+    reverse_pool_op_.resolver_ = this;
+    reverse_pool_op_.ref_      = this->shared_from_this();
+    reverse_pool_op_.func_ = &posix_resolver::do_reverse_resolve_work;
+    if (!svc_.pool().post(&reverse_pool_op_))
     {
-        // Prevent impl destruction while worker thread is running
-        auto self = this->shared_from_this();
-        std::thread worker([this, self = std::move(self)]() {
-            // Build sockaddr from endpoint
-            sockaddr_storage ss{};
-            socklen_t ss_len;
-
-            if (reverse_op_.ep.is_v4())
-            {
-                auto sa = to_sockaddr_in(reverse_op_.ep);
-                std::memcpy(&ss, &sa, sizeof(sa));
-                ss_len = sizeof(sockaddr_in);
-            }
-            else
-            {
-                auto sa = to_sockaddr_in6(reverse_op_.ep);
-                std::memcpy(&ss, &sa, sizeof(sa));
-                ss_len = sizeof(sockaddr_in6);
-            }
-
-            char host[NI_MAXHOST];
-            char service[NI_MAXSERV];
-
-            int result = ::getnameinfo(
-                reinterpret_cast<sockaddr*>(&ss), ss_len, host, sizeof(host),
-                service, sizeof(service),
-                posix_resolver_detail::flags_to_ni_flags(reverse_op_.flags));
-
-            if (!reverse_op_.cancelled.load(std::memory_order_acquire))
-            {
-                if (result == 0)
-                {
-                    reverse_op_.stored_host    = host;
-                    reverse_op_.stored_service = service;
-                    reverse_op_.gai_error      = 0;
-                }
-                else
-                {
-                    reverse_op_.gai_error = result;
-                }
-            }
-
-            // Always post so the scheduler can properly drain the op
-            // during shutdown via destroy().
-            svc_.post(&reverse_op_);
-
-            // Signal thread completion for shutdown synchronization
-            svc_.thread_finished();
-        });
-        worker.detach();
-    }
-    catch (std::system_error const&)
-    {
-        // Thread creation failed - no thread was started
-        svc_.thread_finished();
-
-        // Set error and post completion to avoid hanging the coroutine
-        reverse_op_.gai_error = EAI_MEMORY;
+        // Pool shut down — complete with cancellation
+        reverse_pool_op_.ref_.reset();
+        op.cancelled.store(true, std::memory_order_release);
         svc_.post(&reverse_op_);
     }
     return std::noop_coroutine();
@@ -535,33 +439,115 @@ posix_resolver::cancel() noexcept
     reverse_op_.request_cancel();
 }
 
+inline void
+posix_resolver::do_resolve_work(pool_work_item* w) noexcept
+{
+    auto* pw   = static_cast<pool_op*>(w);
+    auto* self = pw->resolver_;
+
+    struct addrinfo hints{};
+    hints.ai_family   = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = posix_resolver_detail::flags_to_hints(self->op_.flags);
+
+    struct addrinfo* ai = nullptr;
+    int result          = ::getaddrinfo(
+        self->op_.host.empty() ? nullptr : self->op_.host.c_str(),
+        self->op_.service.empty() ? nullptr : self->op_.service.c_str(),
+        &hints, &ai);
+
+    if (!self->op_.cancelled.load(std::memory_order_acquire))
+    {
+        if (result == 0 && ai)
+        {
+            self->op_.stored_results =
+                posix_resolver_detail::convert_results(
+                    ai, self->op_.host, self->op_.service);
+            self->op_.gai_error = 0;
+        }
+        else
+        {
+            self->op_.gai_error = result;
+        }
+    }
+
+    if (ai)
+        ::freeaddrinfo(ai);
+
+    // Move ref to stack before post — post may trigger destroy_impl
+    // which erases the last shared_ptr, destroying *self (and *pw)
+    auto ref = std::move(pw->ref_);
+    self->svc_.post(&self->op_);
+}
+
+inline void
+posix_resolver::do_reverse_resolve_work(pool_work_item* w) noexcept
+{
+    auto* pw   = static_cast<pool_op*>(w);
+    auto* self = pw->resolver_;
+
+    sockaddr_storage ss{};
+    socklen_t ss_len;
+
+    if (self->reverse_op_.ep.is_v4())
+    {
+        auto sa = to_sockaddr_in(self->reverse_op_.ep);
+        std::memcpy(&ss, &sa, sizeof(sa));
+        ss_len = sizeof(sockaddr_in);
+    }
+    else
+    {
+        auto sa = to_sockaddr_in6(self->reverse_op_.ep);
+        std::memcpy(&ss, &sa, sizeof(sa));
+        ss_len = sizeof(sockaddr_in6);
+    }
+
+    char host[NI_MAXHOST];
+    char service[NI_MAXSERV];
+
+    int result = ::getnameinfo(
+        reinterpret_cast<sockaddr*>(&ss), ss_len, host, sizeof(host),
+        service, sizeof(service),
+        posix_resolver_detail::flags_to_ni_flags(self->reverse_op_.flags));
+
+    if (!self->reverse_op_.cancelled.load(std::memory_order_acquire))
+    {
+        if (result == 0)
+        {
+            self->reverse_op_.stored_host    = host;
+            self->reverse_op_.stored_service = service;
+            self->reverse_op_.gai_error      = 0;
+        }
+        else
+        {
+            self->reverse_op_.gai_error = result;
+        }
+    }
+
+    // Move ref to stack before post — post may trigger destroy_impl
+    // which erases the last shared_ptr, destroying *self (and *pw)
+    auto ref = std::move(pw->ref_);
+    self->svc_.post(&self->reverse_op_);
+}
+
 // posix_resolver_service implementation
 
 inline void
 posix_resolver_service::shutdown()
 {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // Cancel all resolvers (sets cancelled flag checked by pool threads)
+    for (auto* impl = resolver_list_.pop_front(); impl != nullptr;
+         impl       = resolver_list_.pop_front())
     {
-        std::lock_guard<std::mutex> lock(mutex_);
-
-        // Signal threads to not access service after getaddrinfo returns
-        shutting_down_.store(true, std::memory_order_release);
-
-        // Cancel all resolvers (sets cancelled flag checked by threads)
-        for (auto* impl = resolver_list_.pop_front(); impl != nullptr;
-             impl       = resolver_list_.pop_front())
-        {
-            impl->cancel();
-        }
-
-        // Clear the map which releases shared_ptrs
-        resolver_ptrs_.clear();
+        impl->cancel();
     }
 
-    // Wait for all worker threads to finish before service is destroyed
-    {
-        std::unique_lock<std::mutex> lock(mutex_);
-        cv_.wait(lock, [this] { return active_threads_ == 0; });
-    }
+    // Clear the map which releases shared_ptrs.
+    // The thread pool service shuts down separately via
+    // execution_context service ordering.
+    resolver_ptrs_.clear();
 }
 
 inline io_object::implementation*
@@ -603,27 +589,6 @@ inline void
 posix_resolver_service::work_finished() noexcept
 {
     sched_->work_finished();
-}
-
-inline void
-posix_resolver_service::thread_started() noexcept
-{
-    std::lock_guard<std::mutex> lock(mutex_);
-    ++active_threads_;
-}
-
-inline void
-posix_resolver_service::thread_finished() noexcept
-{
-    std::lock_guard<std::mutex> lock(mutex_);
-    --active_threads_;
-    cv_.notify_one();
-}
-
-inline bool
-posix_resolver_service::is_shutting_down() const noexcept
-{
-    return shutting_down_.load(std::memory_order_acquire);
 }
 
 // Free function to get/create the resolver service

--- a/test/unit/thread_pool.cpp
+++ b/test/unit/thread_pool.cpp
@@ -1,0 +1,170 @@
+//
+// Copyright (c) 2026 Steve Gerbino
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+// Test that header file is self-contained.
+#include <boost/corosio/detail/thread_pool.hpp>
+
+#include <boost/corosio/io_context.hpp>
+
+#include <atomic>
+#include <thread>
+
+#include "test_suite.hpp"
+
+namespace boost::corosio {
+
+struct test_work : detail::pool_work_item
+{
+    std::atomic<int>* counter = nullptr;
+
+    static void execute(detail::pool_work_item* w) noexcept
+    {
+        static_cast<test_work*>(w)->counter->fetch_add(1);
+    }
+};
+
+struct thread_pool_test
+{
+    void testDrainOnShutdown()
+    {
+        io_context ioc;
+        auto& pool = ioc.use_service<detail::thread_pool>();
+
+        std::atomic<int> counter{0};
+
+        // Post several tasks before any can run
+        constexpr int n = 10;
+        test_work items[n];
+        for (int i = 0; i < n; ++i)
+        {
+            items[i].counter = &counter;
+            items[i].func_   = &test_work::execute;
+            BOOST_TEST(pool.post(&items[i]));
+        }
+
+        // Shutdown should drain all queued tasks
+        pool.shutdown();
+
+        BOOST_TEST(counter.load() == n);
+    }
+
+    void testShutdownWithNoWork()
+    {
+        io_context ioc;
+        auto& pool = ioc.use_service<detail::thread_pool>();
+
+        struct flag_work : detail::pool_work_item
+        {
+            std::atomic<bool>* flag = nullptr;
+
+            static void execute(detail::pool_work_item* p) noexcept
+            {
+                static_cast<flag_work*>(p)->flag->store(true);
+            }
+        };
+
+        std::atomic<bool> ran{false};
+        flag_work fw;
+        fw.flag  = &ran;
+        fw.func_ = &flag_work::execute;
+        pool.post(&fw);
+
+        // Give it a moment to process
+        while (!ran.load())
+            std::this_thread::yield();
+
+        // Shutdown with empty queue should not hang
+        pool.shutdown();
+    }
+
+    void testPostAfterShutdown()
+    {
+        io_context ioc;
+        auto& pool = ioc.use_service<detail::thread_pool>();
+
+        pool.shutdown();
+
+        // post() must return false after shutdown
+        test_work tw;
+        std::atomic<int> counter{0};
+        tw.counter = &counter;
+        tw.func_   = &test_work::execute;
+        BOOST_TEST(!pool.post(&tw));
+        BOOST_TEST(counter.load() == 0);
+
+        // Second shutdown must not hang
+        pool.shutdown();
+    }
+
+    void testZeroThreads()
+    {
+        io_context ioc;
+
+        // Creating a pool with 0 threads must throw
+        BOOST_TEST_THROWS(
+            detail::thread_pool(ioc, 0),
+            std::logic_error);
+    }
+
+    void testMultipleThreads()
+    {
+        io_context ioc;
+        constexpr unsigned num_threads = 4;
+        detail::thread_pool pool(ioc, num_threads);
+
+        // Each work item blocks on a shared counter until all
+        // num_threads items are running, proving true concurrency.
+        struct barrier_work : detail::pool_work_item
+        {
+            std::atomic<unsigned>* arrived;
+            unsigned expected;
+            std::atomic<int>* done;
+
+            static void execute(detail::pool_work_item* p) noexcept
+            {
+                auto* self = static_cast<barrier_work*>(p);
+                self->arrived->fetch_add(1);
+                // Spin until all threads have arrived
+                while (self->arrived->load() < self->expected)
+                    std::this_thread::yield();
+                self->done->fetch_add(1);
+            }
+        };
+
+        std::atomic<unsigned> arrived{0};
+        std::atomic<int> done{0};
+        barrier_work items[num_threads];
+        for (unsigned i = 0; i < num_threads; ++i)
+        {
+            items[i].arrived  = &arrived;
+            items[i].expected = num_threads;
+            items[i].done     = &done;
+            items[i].func_    = &barrier_work::execute;
+            pool.post(&items[i]);
+        }
+
+        pool.shutdown();
+
+        // All items completed — proves all 4 threads ran concurrently
+        BOOST_TEST(done.load() == static_cast<int>(num_threads));
+    }
+
+    void run()
+    {
+        testDrainOnShutdown();
+        testShutdownWithNoWork();
+        testPostAfterShutdown();
+        testZeroThreads();
+        testMultipleThreads();
+    }
+};
+
+TEST_SUITE(thread_pool_test, "boost.corosio.thread_pool");
+
+} // namespace boost::corosio


### PR DESCRIPTION
Resolver operations previously created and detached a new std::thread for every blocking getaddrinfo()/getnameinfo() call. Add a generic detail::thread_pool execution_context service that reuses threads across operations, and wire both POSIX and Windows resolver services to dispatch blocking work through it.

Resolves #118.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized thread-pool service added to run blocking resolver work.

* **Improvements**
  * Forward and reverse DNS lookups now use the shared pool instead of per-call detached threads, improving resource reuse.
  * Shutdown and cancellation flows simplified; background task cleanup coordinated via execution-context sequencing.

* **Public API**
  * Resolver services expose a pool() accessor; legacy per-thread lifecycle hooks removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->