### PR TITLE
Fix tcp_server test port race on Windows CI

### DIFF
--- a/include/boost/corosio/tcp_server.hpp
+++ b/include/boost/corosio/tcp_server.hpp
@@ -712,6 +712,15 @@ public:
     */
     void start();
 
+    /** Return the local endpoint for the i-th bound port.
+
+        @param index Zero-based index into the list of bound ports.
+
+        @return The local endpoint, or a default-constructed endpoint
+            if @p index is out of range or the acceptor is not open.
+    */
+    endpoint local_endpoint(std::size_t index = 0) const noexcept;
+
     /** Stop accepting connections.
 
         Signals all listening ports to stop accepting new connections

--- a/src/corosio/src/tcp_server.cpp
+++ b/src/corosio/src/tcp_server.cpp
@@ -105,6 +105,14 @@ tcp_server::bind(endpoint ep)
     }
 }
 
+endpoint
+tcp_server::local_endpoint(std::size_t index) const noexcept
+{
+    if (index >= impl_->ports.size())
+        return endpoint{};
+    return impl_->ports[index].local_endpoint();
+}
+
 void
 tcp_server::start()
 {

--- a/test/unit/tcp_server.cpp
+++ b/test/unit/tcp_server.cpp
@@ -116,26 +116,10 @@ struct tcp_server_test
     {
         io_context ioc;
 
-        // Find an available port
-        tcp_acceptor acc(ioc);
-        std::uint16_t port = 0;
-        for (int attempt = 0; attempt < 20; ++attempt)
-        {
-            port = static_cast<std::uint16_t>(49152 + (attempt * 7) % 16383);
-            acc.open();
-            acc.set_option(socket_option::reuse_address(true));
-            if (!acc.bind(endpoint(ipv4_address::loopback(), port)) &&
-                !acc.listen())
-                break;
-            acc.close();
-            acc = tcp_acceptor(ioc);
-        }
-        acc.close();
-
-        // Create server and bind to found port
         test_server srv(ioc);
-        auto ec = srv.bind(endpoint(ipv4_address::loopback(), port));
+        auto ec = srv.bind(endpoint(ipv4_address::loopback(), 0));
         BOOST_TEST(!ec);
+        auto port = srv.local_endpoint().port();
 
         std::atomic<bool> connection_handled{false};
         std::atomic<bool> stop_requested{false};
@@ -251,25 +235,10 @@ struct tcp_server_test
 
         io_context ioc;
 
-        // Find an available port
-        tcp_acceptor acc(ioc);
-        std::uint16_t port = 0;
-        for (int attempt = 0; attempt < 20; ++attempt)
-        {
-            port = static_cast<std::uint16_t>(49152 + (attempt * 7) % 16383);
-            acc.open();
-            acc.set_option(socket_option::reuse_address(true));
-            if (!acc.bind(endpoint(ipv4_address::loopback(), port)) &&
-                !acc.listen())
-                break;
-            acc.close();
-            acc = tcp_acceptor(ioc);
-        }
-        acc.close();
-
         test_server srv(ioc);
-        auto ec = srv.bind(endpoint(ipv4_address::loopback(), port));
+        auto ec = srv.bind(endpoint(ipv4_address::loopback(), 0));
         BOOST_TEST(!ec);
+        auto port = srv.local_endpoint().port();
 
         int connections_handled = 0;
 


### PR DESCRIPTION
Add tcp_server::local_endpoint() and use ephemeral port binding (port 0) instead of TOCTOU port-probing in testStopWithActiveConnection and testRestart.