### PR TITLE
Add Apple-clang tsan to CI

### DIFF
--- a/.github/generate-matrix.py
+++ b/.github/generate-matrix.py
@@ -160,6 +160,7 @@ def generate_sanitizer_variant(compiler_family, spec):
         "asan": True,
         "build-type": "RelWithDebInfo",
         "shared": True,
+        "build-cmake": False,
     }
 
     if compiler_family not in ("msvc", "clang-cl"):
@@ -172,14 +173,15 @@ def generate_sanitizer_variant(compiler_family, spec):
 
 
 def generate_tsan_variant(compiler_family, spec):
-    """Generate TSan variant for the latest compiler in a family (Linux only)."""
+    """Generate TSan variant for the latest compiler in a family."""
     overrides = {
         "tsan": True,
         "build-type": "RelWithDebInfo",
         "shared": True,
+        "build-cmake": False,
     }
 
-    if compiler_family == "clang":
+    if compiler_family in ("clang", "apple-clang"):
         overrides["shared"] = False
 
     return make_entry(compiler_family, spec, **overrides)
@@ -261,8 +263,8 @@ def main():
                 if family != "mingw":
                     matrix.append(generate_sanitizer_variant(family, spec))
 
-                # TSan is incompatible with ASan; separate variant for Linux
-                if family in ("gcc", "clang"):
+                # TSan is incompatible with ASan; separate variant for GCC, Clang, and Apple-Clang
+                if family in ("gcc", "clang", "apple-clang"):
                     matrix.append(generate_tsan_variant(family, spec))
 
                 if family == "clang":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration and testing infrastructure support for Apple Clang compiler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->