### PR TITLE
Align CI with CMake standards: dedicated build modes and matrix fixes

### DIFF
--- a/.github/compilers.json
+++ b/.github/compilers.json
@@ -8,7 +8,8 @@
       "container": "ubuntu:22.04",
       "cxx": "g++-12",
       "cc": "gcc-12",
-      "b2_toolset": "gcc"
+      "b2_toolset": "gcc",
+      "is_earliest": true
     },
     {
       "version": "13",
@@ -52,7 +53,8 @@
       "cxx": "clang++-17",
       "cc": "clang-17",
       "b2_toolset": "clang",
-      "arm": true
+      "arm": true,
+      "is_earliest": true
     },
     {
       "version": "18",
@@ -95,7 +97,8 @@
       "latest_cxxstd": "20",
       "runs_on": "windows-2022",
       "b2_toolset": "msvc-14.3",
-      "generator": "Visual Studio 17 2022"
+      "generator": "Visual Studio 17 2022",
+      "is_earliest": true
     },
     {
       "version": "14.42",
@@ -130,7 +133,8 @@
       "runs_on": "macos-14",
       "cxx": "clang++",
       "cc": "clang",
-      "b2_toolset": "clang"
+      "b2_toolset": "clang",
+      "is_earliest": true
     },
     {
       "version": "*",

--- a/.github/generate-matrix.py
+++ b/.github/generate-matrix.py
@@ -32,7 +32,7 @@ def load_compilers(path=None):
 
 
 def platform_for_family(compiler_family):
-    """Return the platform boolean name for a compiler family."""
+    """Return the platform name for a compiler family."""
     if compiler_family in ("msvc", "clang-cl", "mingw"):
         return "windows"
     elif compiler_family == "apple-clang":
@@ -51,11 +51,8 @@ def make_entry(compiler_family, spec, **overrides):
         "b2-toolset": spec["b2_toolset"],
         "shared": True,
         "build-type": "Release",
-        "build-cmake": True,
+        platform_for_family(compiler_family): True,
     }
-
-    # Platform boolean
-    entry[platform_for_family(compiler_family)] = True
 
     if spec.get("container"):
         entry["container"] = spec["container"]
@@ -71,30 +68,23 @@ def make_entry(compiler_family, spec, **overrides):
         entry["is-latest"] = True
     if spec.get("is_earliest"):
         entry["is-earliest"] = True
-    if spec.get("build_cmake") is False:
-        entry["build-cmake"] = False
-    if spec.get("cmake_cxxstd"):
-        entry["cmake-cxxstd"] = spec["cmake_cxxstd"]
-    if spec.get("cxxflags"):
-        entry["cxxflags"] = spec["cxxflags"]
     if "shared" in spec:
         entry["shared"] = spec["shared"]
     if spec.get("vcpkg_triplet"):
         entry["vcpkg-triplet"] = spec["vcpkg_triplet"]
 
+    # CMake builds only on earliest/latest compilers, unless explicitly disabled
+    if spec.get("build_cmake") is False:
+        entry["build-cmake"] = False
+    elif spec.get("is_latest") or spec.get("is_earliest"):
+        entry["build-cmake"] = True
+    if spec.get("cmake_cxxstd"):
+        entry["cmake-cxxstd"] = spec["cmake_cxxstd"]
+    if spec.get("cxxflags"):
+        entry["cxxflags"] = spec["cxxflags"]
+
     entry.update(overrides)
     entry["name"] = generate_name(compiler_family, entry)
-    return entry
-
-
-def apply_clang_tidy(entry, spec):
-    """Add clang-tidy flag and install package to an entry (base entries only)."""
-    entry["clang-tidy"] = True
-    version = spec["version"]
-    existing_install = entry.get("install", "")
-    tidy_pkg = f"clang-tidy-{version}"
-    entry["install"] = f"{existing_install} {tidy_pkg}".strip()
-    entry["name"] = generate_name(entry["compiler"], entry)
     return entry
 
 
@@ -104,7 +94,7 @@ def generate_name(compiler_family, entry):
         "gcc": "GCC",
         "clang": "Clang",
         "msvc": "MSVC",
-        "mingw": "MinGW",
+        "mingw": "MinGW Clang",
         "clang-cl": "Clang-CL",
         "apple-clang": "Apple-Clang",
     }
@@ -123,6 +113,7 @@ def generate_name(compiler_family, entry):
     if "arm" in runner:
         modifiers.append("arm64")
     elif compiler_family == "apple-clang":
+        # Extract macOS version from runner name
         macos_ver = runner.replace("macos-", "macOS ")
         modifiers.append(macos_ver)
 
@@ -138,11 +129,17 @@ def generate_name(compiler_family, entry):
     if entry.get("coverage"):
         modifiers.append("coverage")
 
+    if entry.get("x86"):
+        modifiers.append("x86")
+
     if entry.get("clang-tidy"):
         modifiers.append("clang-tidy")
 
-    if entry.get("x86"):
-        modifiers.append("x86")
+    if entry.get("time-trace"):
+        modifiers.append("time-trace")
+
+    if entry.get("superproject-cmake"):
+        modifiers.append("superproject CMake")
 
     if entry.get("shared") is False:
         modifiers.append("static")
@@ -154,7 +151,7 @@ def generate_name(compiler_family, entry):
 def generate_sanitizer_variant(compiler_family, spec):
     """Generate ASAN+UBSAN variant for the latest compiler in a family.
 
-    MSVC and Clang-CL only support ASAN, not UBSAN.
+    MSVC does not support UBSAN; only ASAN is enabled for MSVC.
     """
     overrides = {
         "asan": True,
@@ -163,6 +160,7 @@ def generate_sanitizer_variant(compiler_family, spec):
         "build-cmake": False,
     }
 
+    # MSVC and Clang-CL only support ASAN, not UBSAN
     if compiler_family not in ("msvc", "clang-cl"):
         overrides["ubsan"] = True
 
@@ -188,39 +186,35 @@ def generate_tsan_variant(compiler_family, spec):
 
 
 def generate_coverage_variant(compiler_family, spec):
-    """Generate coverage variant.
+    """Generate coverage variant with platform-specific flags.
 
-    Corosio has three coverage builds:
-      - Linux (GCC): lcov with full profiling flags
-      - macOS (Apple-Clang): --coverage only, gcovr with llvm-cov
-      - Windows (MinGW): gcovr with full profiling flags
+    Linux/Windows: full gcov flags with atomic profile updates.
+    macOS: --coverage only (Apple-Clang uses llvm-cov).
     """
     platform = platform_for_family(compiler_family)
 
     if platform == "macos":
-        flags = "--coverage"
+        cov_flags = "--coverage"
     else:
-        flags = "--coverage -fprofile-arcs -ftest-coverage -fprofile-update=atomic"
+        cov_flags = ("--coverage -fprofile-arcs -ftest-coverage"
+                     " -fprofile-update=atomic")
 
     overrides = {
         "coverage": True,
         "coverage-flag": platform,
         "shared": False,
         "build-type": "Debug",
-        "cxxflags": flags,
-        "ccflags": flags,
+        "build-cmake": False,
+        "cxxflags": cov_flags,
+        "ccflags": cov_flags,
     }
 
     if platform == "linux":
         overrides["install"] = "lcov wget unzip"
 
     entry = make_entry(compiler_family, spec, **overrides)
-    # Coverage variants should not trigger integration tests; they get CMake
-    # through the matrix.coverage condition in ci.yml
     entry.pop("is-latest", None)
     entry.pop("is-earliest", None)
-    entry["build-cmake"] = False
-    entry["name"] = generate_name(compiler_family, entry)
     return entry
 
 
@@ -235,10 +229,42 @@ def generate_x86_variant(compiler_family, spec):
 def generate_arm_entry(compiler_family, spec):
     """Generate ARM64 variant for a compiler spec."""
     arm_runner = spec["runs_on"].replace("ubuntu-24.04", "ubuntu-24.04-arm")
-    # ARM runners don't support containers
+    # ARM runners don't support containers — build a spec copy without container
     arm_spec = {k: v for k, v in spec.items() if k != "container"}
     arm_spec["runs_on"] = arm_runner
     return make_entry(compiler_family, arm_spec)
+
+
+def generate_time_trace_variant(compiler_family, spec):
+    """Generate time-trace variant for compile-time profiling (Clang only)."""
+    return make_entry(compiler_family, spec, **{
+        "time-trace": True,
+        "build-cmake": True,
+        "cxxflags": "-ftime-trace",
+    })
+
+
+def generate_superproject_cmake_variant(compiler_family, spec):
+    """Generate a single superproject CMake build to verify integration."""
+    entry = make_entry(compiler_family, spec, **{
+        "superproject-cmake": True,
+        "build-cmake": False,
+    })
+    entry.pop("is-latest", None)
+    entry.pop("is-earliest", None)
+    return entry
+
+
+def apply_clang_tidy(entry, spec):
+    """Add clang-tidy flag and install package to an entry."""
+    entry["clang-tidy"] = True
+    entry["build-cmake"] = False
+    version = spec["version"]
+    existing_install = entry.get("install", "")
+    tidy_pkg = f"clang-tidy-{version}"
+    entry["install"] = f"{existing_install} {tidy_pkg}".strip()
+    entry["name"] = generate_name(entry["compiler"], entry)
+    return entry
 
 
 def main():
@@ -259,20 +285,23 @@ def main():
 
             # Variants for the latest compiler in each family
             if spec.get("is_latest"):
-                # MinGW has limited ASAN support; skip sanitizer variant
                 if family != "mingw":
                     matrix.append(generate_sanitizer_variant(family, spec))
 
-                # TSan is incompatible with ASan; separate variant for GCC, Clang, and Apple-Clang
+                # TSan is incompatible with ASan; separate variant for Linux
                 if family in ("gcc", "clang", "apple-clang"):
                     matrix.append(generate_tsan_variant(family, spec))
 
+                # GCC always gets coverage; other families opt in via spec flag
+                if family == "gcc" or spec.get("coverage"):
+                    matrix.append(generate_coverage_variant(family, spec))
+
+                if family == "gcc":
+                    matrix.append(generate_superproject_cmake_variant(family, spec))
+
                 if family == "clang":
                     matrix.append(generate_x86_variant(family, spec))
-
-            # Coverage variant (driven by spec flag, not is_latest)
-            if spec.get("coverage"):
-                matrix.append(generate_coverage_variant(family, spec))
+                    matrix.append(generate_time_trace_variant(family, spec))
 
     json.dump(matrix, sys.stdout)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,13 @@ jobs:
           ref: ${{ (github.ref_name == 'master' && github.ref_name) || 'develop' }}
           path: asio-root
 
+      - name: Setup MSYS2 (MinGW Clang)
+        if: matrix.compiler == 'mingw'
+        shell: bash
+        run: |
+          /c/msys64/usr/bin/pacman.exe -S --noconfirm mingw-w64-clang-x86_64-clang
+          echo "C:/msys64/clang64/bin" >> "$GITHUB_PATH"
+
       - name: Clone Boost
         uses: alandefreitas/cpp-actions/boost-clone@v1.9.0
         id: boost-clone
@@ -117,7 +124,7 @@ jobs:
           boost-dir: boost-source
           modules-exclude-paths: ''
           scan-modules-dir: corosio-root
-          scan-modules-ignore: corosio,capy
+          scan-modules-ignore: corosio, capy
 
       - name: ASLR Fix
         if: ${{ startsWith(matrix.runs-on, 'ubuntu') }}
@@ -142,17 +149,17 @@ jobs:
           rm -r "boost-source/libs/$module" || true
           rm -r "boost-source/libs/capy" || true
 
-          # boost-clone uses sparse checkout which excludes CMakeLists.txt files
-          # Disable sparse checkout to get full source trees for add_subdirectory in cmake_test
-          cd boost-source
-          if git sparse-checkout list > /dev/null 2>&1; then
-            echo "Disabling sparse checkout..."
-            git sparse-checkout disable
-            echo "Fetching any missing objects..."
-            git fetch origin --no-tags
-            git checkout
+          # Disable sparse checkout for superproject CMake builds
+          # (needed so CMakeLists.txt files in sibling boost libraries are available)
+          if [ "${{ matrix.superproject-cmake }}" = "true" ]; then
+            cd boost-source
+            if git sparse-checkout list > /dev/null 2>&1; then
+                git sparse-checkout disable
+                git fetch origin --no-tags
+                git checkout
+            fi
+            cd ..
           fi
-          cd ..
 
           # Copy cached boost-source to an isolated boost-root
           cp -rL boost-source boost-root
@@ -458,16 +465,16 @@ jobs:
 
       - name: Boost B2 Workflow
         uses: alandefreitas/cpp-actions/b2-workflow@v1.9.0
-        if: ${{ !matrix.coverage }}
+        if: ${{ !matrix.coverage && !matrix.time-trace && !matrix.superproject-cmake && !matrix.clang-tidy }}
         env:
-          ASAN_OPTIONS: ${{ ((matrix.compiler == 'apple-clang' || matrix.compiler == 'clang') && 'detect_invalid_pointer_pairs=0:strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1') || 'detect_invalid_pointer_pairs=2:strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1' }}
+          ASAN_OPTIONS: ${{ ((matrix.compiler == 'apple-clang' || matrix.compiler == 'clang' || matrix.compiler == 'mingw') && 'detect_invalid_pointer_pairs=0:strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1') || 'detect_invalid_pointer_pairs=2:strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1' }}
           TSAN_OPTIONS: ${{ matrix.tsan && 'halt_on_error=1:second_deadlock_stack=1' || '' }}
         with:
           source-dir: boost-root
           modules: corosio
           toolset: ${{ matrix.b2-toolset }}
           build-variant: ${{ (matrix.compiler == 'msvc' && 'debug,release') || matrix.build-type }}
-          cxx: ${{ steps.setup-cpp.outputs.cxx || matrix.cxx || '' }}
+          cxx: ${{ matrix.cxx || steps.setup-cpp.outputs.cxx || '' }}
           cxxstd: ${{ matrix.cxxstd }}
           address-model: ${{ (matrix.x86 && '32') || '64' }}
           asan: ${{ matrix.asan }}
@@ -475,33 +482,33 @@ jobs:
           tsan: ${{ matrix.tsan }}
           shared: ${{ matrix.shared }}
           rtti: on
-          cxxflags: ${{ matrix.cxxflags }} ${{ (matrix.asan && matrix.compiler != 'msvc' && matrix.compiler != 'clang-cl' && '-fsanitize-address-use-after-scope -fsanitize=pointer-subtract') || '' }}
+          cxxflags: ${{ (matrix.asan && matrix.compiler != 'msvc' && matrix.compiler != 'clang-cl' && '-fsanitize-address-use-after-scope -fsanitize=pointer-subtract') || '' }}
           stop-on-error: true
-          user-config: ${{ (matrix.windows || matrix.macos) && 'user-config.jam' || '' }}
+          extra-args: ${{ (matrix.valgrind && 'testing.launcher=valgrind' || '' )}}
 
       - name: Boost CMake Workflow
         uses: alandefreitas/cpp-actions/cmake-workflow@v1.9.0
-        if: ${{ matrix.coverage || matrix.build-cmake || matrix.is-earliest }}
+        if: ${{ matrix.superproject-cmake }}
         with:
           source-dir: boost-root
           build-dir: __build_cmake_test__
           generator: ${{ matrix.generator }}
           generator-toolset: ${{ matrix.generator-toolset }}
           build-type: ${{ matrix.build-type }}
-          build-target: tests
+          build-target: boost_corosio_tests
           run-tests: true
-          install-prefix: .local
-          cxxstd: ${{ matrix.latest-cxxstd }}
+          cxxstd: ${{ matrix.cmake-cxxstd || matrix.cxxstd }}
           cc:  ${{ steps.setup-cpp.outputs.cc || matrix.cc }}
           ccflags: ${{ matrix.ccflags }}
           cxx: ${{ steps.setup-cpp.outputs.cxx || matrix.cxx }}
           cxxflags: ${{ matrix.cxxflags }}
           shared: ${{ matrix.shared }}
           cmake-version: '>=3.20'
+          install: true
+          install-prefix: ${{ steps.patch.outputs.workspace_root }}/.local
           extra-args: |
             -D Boost_VERBOSE=ON
             -D BOOST_INCLUDE_LIBRARIES="${{ steps.patch.outputs.module }}"
-            -D CMAKE_EXPORT_COMPILE_COMMANDS=ON
             ${{ matrix.compiler == 'mingw' && '-D CMAKE_VERBOSE_MAKEFILE=ON' || '' }}
             ${{ contains(matrix.generator || '', 'Visual Studio') && format('-D CMAKE_CONFIGURATION_TYPES={0}', matrix.build-type) || '' }}
             ${{ env.CMAKE_WOLFSSL_INCLUDE && format('-D WolfSSL_INCLUDE_DIR={0}', env.CMAKE_WOLFSSL_INCLUDE) || '' }}
@@ -514,27 +521,18 @@ jobs:
           package-artifact: false
           ref-source-dir: boost-root/libs/corosio
 
-      - name: Run clang-tidy
-        if: ${{ matrix.clang-tidy }}
-        run: |
-          python3 -c "import json; [print(e['file']) for e in json.load(open('boost-root/__build_cmake_test__/compile_commands.json'))]" \
-            | grep '/libs/corosio/src/' \
-            | xargs -r clang-tidy-20 \
-                -p boost-root/__build_cmake_test__ \
-                --warnings-as-errors='*'
-
-      - name: Set Path
+      - name: Set Path (Windows Shared)
         if: ${{ matrix.windows && matrix.shared }}
         run: echo "$GITHUB_WORKSPACE/.local/bin" >> $GITHUB_PATH
 
-      - name: Set LD_LIBRARY_PATH
+      - name: Set LD_LIBRARY_PATH (Linux Shared)
         if: ${{ matrix.linux && matrix.shared }}
         run: |
           echo "LD_LIBRARY_PATH=$GITHUB_WORKSPACE/.local/lib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
-      - name: Find Package Integration Workflow
+      - name: Find Package Integration Test
         uses: alandefreitas/cpp-actions/cmake-workflow@v1.9.0
-        if: ${{ (matrix.is-latest || matrix.is-earliest) && matrix.build-cmake != false }}
+        if: ${{ matrix.superproject-cmake }}
         with:
           source-dir: boost-root/libs/${{ steps.patch.outputs.module }}/test/cmake_test
           build-dir: __build_cmake_install_test__
@@ -548,7 +546,7 @@ jobs:
           cxxflags: ${{ matrix.cxxflags }}
           shared: ${{ matrix.shared }}
           install: false
-          cmake-version: '>=3.15'
+          cmake-version: '>=3.20'
           extra-args: |
             -D BOOST_CI_INSTALL_TEST=ON
             -D CMAKE_PREFIX_PATH=${{ steps.patch.outputs.workspace_root }}/.local
@@ -561,9 +559,9 @@ jobs:
           ref-source-dir: boost-root/libs/corosio
           trace-commands: true
 
-      - name: Subdirectory Integration Workflow
+      - name: Subdirectory Integration Test
         uses: alandefreitas/cpp-actions/cmake-workflow@v1.9.0
-        if: ${{ (matrix.is-latest || matrix.is-earliest) && matrix.build-cmake != false }}
+        if: ${{ matrix.superproject-cmake }}
         with:
           source-dir: boost-root/libs/${{ steps.patch.outputs.module }}/test/cmake_test
           build-dir: __build_cmake_subdir_test__
@@ -590,15 +588,14 @@ jobs:
 
       - name: Root Project CMake Workflow
         uses: alandefreitas/cpp-actions/cmake-workflow@v1.9.0
-        if: ${{ (matrix.is-latest || matrix.is-earliest) && matrix.build-cmake != false }}
+        if: ${{ matrix.build-cmake || matrix.coverage }}
         with:
-          source-dir: boost-root/libs/${{ steps.patch.outputs.module }}
-          build-dir: __build_root_test__
-          build-target: tests
-          run-tests: true
+          source-dir: corosio-root
+          build-dir: __build__
           generator: ${{ matrix.generator }}
           generator-toolset: ${{ matrix.generator-toolset }}
           build-type: ${{ matrix.build-type }}
+          run-tests: true
           install: false
           cxxstd: ${{ matrix.latest-cxxstd }}
           cc: ${{ steps.setup-cpp.outputs.cc || matrix.cc }}
@@ -620,52 +617,84 @@ jobs:
           package-artifact: false
           ref-source-dir: boost-root
 
+      - name: Configure for clang-tidy
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.9.0
+        if: ${{ matrix.clang-tidy }}
+        with:
+          source-dir: corosio-root
+          build-dir: __build__
+          generator: ${{ matrix.generator }}
+          cxxstd: ${{ matrix.latest-cxxstd }}
+          cc: ${{ steps.setup-cpp.outputs.cc || matrix.cc }}
+          cxx: ${{ steps.setup-cpp.outputs.cxx || matrix.cxx }}
+          cmake-version: '>=3.20'
+          extra-args: |
+            -D CMAKE_EXPORT_COMPILE_COMMANDS=ON
+            ${{ env.CMAKE_WOLFSSL_INCLUDE && format('-D WolfSSL_INCLUDE_DIR={0}', env.CMAKE_WOLFSSL_INCLUDE) || '' }}
+            ${{ env.CMAKE_WOLFSSL_LIBRARY && format('-D WolfSSL_LIBRARY={0}', env.CMAKE_WOLFSSL_LIBRARY) || '' }}
+            ${{ env.CMAKE_OPENSSL_ROOT && format('-D OPENSSL_ROOT_DIR="{0}"', env.CMAKE_OPENSSL_ROOT) || '' }}
+          toolchain: ${{ env.CMAKE_TOOLCHAIN_FILE }}
+          build: false
+          run-tests: false
+          install: false
+          ref-source-dir: corosio-root
+
+      - name: Run clang-tidy
+        if: ${{ matrix.clang-tidy }}
+        run: |
+          python3 -c "import json; [print(e['file']) for e in json.load(open('corosio-root/__build__/compile_commands.json'))]" \
+            | grep '/corosio-root/\(src\|include\)/' \
+            | xargs -r clang-tidy-${{ matrix.version }} \
+                -p corosio-root/__build__ \
+                --warnings-as-errors='*'
+
+      - name: FlameGraph
+        uses: alandefreitas/cpp-actions/flamegraph@v1.9.0
+        if: matrix.time-trace
+        with:
+          source-dir: corosio-root
+          build-dir: corosio-root/__build__
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate Coverage Report
         if: ${{ matrix.coverage && matrix.linux }}
         run: |
           set -x
-
-          # Generate report
           gcov_tool="gcov"
-          if command -v "gcov-${{ steps.setup-cpp.outputs.version-major }}.${{ steps.setup-cpp.outputs.version-minor }}" &> /dev/null; then
-              gcov_tool="gcov"
-          elif command -v "gcov-${{ steps.setup-cpp.outputs.version-major }}" &> /dev/null; then
+          if command -v "gcov-${{ steps.setup-cpp.outputs.version-major }}" &> /dev/null; then
               gcov_tool="gcov-${{ steps.setup-cpp.outputs.version-major }}"
           fi
-          lcov -c -q -o "boost-root/__build_cmake_test__/coverage.info" \
-            -d "boost-root/__build_cmake_test__" \
-            --include "*/boost-root/libs/${{steps.patch.outputs.module}}/include/*" \
-            --include "*/boost-root/libs/${{steps.patch.outputs.module}}/src/*" \
+          lcov -c -q -o "corosio-root/__build__/coverage.info" -d "corosio-root/__build__" \
+            --include "$(pwd)/corosio-root/include/*" \
+            --include "$(pwd)/corosio-root/src/*" \
             --gcov-tool "$gcov_tool"
 
       - name: Generate Coverage Report (macOS)
         if: ${{ matrix.coverage && matrix.macos }}
         run: |
-          set -x
           pip3 install --break-system-packages gcovr
           gcovr \
             --gcov-executable "xcrun llvm-cov gcov" \
-            -r boost-root \
-            --filter ".*/libs/${{steps.patch.outputs.module}}/include/.*" \
-            --filter ".*/libs/${{steps.patch.outputs.module}}/src/.*" \
-            --lcov -o "boost-root/__build_cmake_test__/coverage.info"
+            -r corosio-root \
+            --filter ".*/corosio-root/include/.*" \
+            --filter ".*/corosio-root/src/.*" \
+            --lcov -o "corosio-root/__build__/coverage.info"
 
       - name: Generate Coverage Report (Windows)
         if: ${{ matrix.coverage && matrix.windows }}
         run: |
-          set -x
           pip3 install gcovr
           gcovr \
-            -r boost-root \
-            --filter ".*/libs/${{steps.patch.outputs.module}}/include/.*" \
-            --filter ".*/libs/${{steps.patch.outputs.module}}/src/.*" \
-            --lcov -o "boost-root/__build_cmake_test__/coverage.info"
+            -r corosio-root \
+            --filter ".*/corosio-root/include/.*" \
+            --filter ".*/corosio-root/src/.*" \
+            --lcov -o "corosio-root/__build__/coverage.info"
 
       - name: Upload to Codecov
         if: ${{ matrix.coverage }}
         uses: codecov/codecov-action@v5
         with:
-          files: boost-root/__build_cmake_test__/coverage.info
+          files: corosio-root/__build__/coverage.info
           flags: ${{ matrix.coverage-flag }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/perf/bench/CMakeLists.txt
+++ b/perf/bench/CMakeLists.txt
@@ -8,9 +8,14 @@
 #
 
 # Check LTO support for benchmarks
+# MinGW GCC LTO mishandles virtual thunks from multiple inheritance,
+# discarding COMDAT sections that contain needed thunk relocations.
 include(CheckIPOSupported)
 check_ipo_supported(RESULT COROSIO_BENCH_LTO_SUPPORTED OUTPUT COROSIO_BENCH_LTO_ERROR LANGUAGES CXX)
-if (COROSIO_BENCH_LTO_SUPPORTED)
+if (MINGW)
+    set(COROSIO_BENCH_LTO_SUPPORTED FALSE)
+    message(STATUS "LTO disabled for benchmarks: MinGW virtual thunk bug")
+elseif (COROSIO_BENCH_LTO_SUPPORTED)
     message(STATUS "LTO enabled for benchmarks")
 else ()
     message(STATUS "LTO not available for benchmarks: ${COROSIO_BENCH_LTO_ERROR}")

--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -5,7 +5,7 @@
 # https://www.boost.org/LICENSE_1_0.txt
 #
 
-cmake_minimum_required(VERSION 3.16...3.28)
+cmake_minimum_required(VERSION 3.13...3.31)
 
 project(cmake_subdir_test LANGUAGES CXX)
 set(__ignore__ ${CMAKE_C_COMPILER})


### PR DESCRIPTION
Closes #186

Key changes:
- Dedicate a single superproject-cmake matrix entry (GCC latest) for CMake superproject build and both integration tests, moving sparse checkout disable behind the superproject-cmake flag
- Run standalone CMake from library root (corosio-root) instead of boost-root, building all targets without a build-target filter
- Add clang-tidy as standalone configure-only step against corosio-root with version-parametric binary and include/src file filtering
- Add FlameGraph compile-time profiling for Clang time-trace variant
- Gate B2 on !coverage && !time-trace && !superproject-cmake && !clang-tidy
- Gate standalone CMake on build-cmake || coverage
- Add is_earliest to GCC 12, Clang 17, MSVC 14.34, Apple-Clang macos-14 so oldest compilers also run standalone CMake builds
- Fix generate-matrix.py to emit generator-toolset (hyphen) matching ci.yml references, and read shared/vcpkg_triplet from compiler specs
- Skip ASAN+UBSAN variant for MinGW (limited sanitizer support)
- Restore zip/unzip/tar packages needed by vcpkg in container builds
- Update cmake_test version range to 3.13...3.31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced compiler metadata to mark earliest toolchain entries.
  * Expanded CI matrix and workflows to support new build variants (time-trace, superproject-CMake) and improved cross-platform handling.
  * Integrated clang-tidy checks and FlameGraph generation into CI.
  * Updated coverage and test artifact collection paths and refined MinGW/Windows/Linux build/setup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->