### PR TITLE
Defer write-filter registration to first write/connect op

### DIFF
--- a/include/boost/corosio/native/detail/epoll/epoll_op.hpp
+++ b/include/boost/corosio/native/detail/epoll/epoll_op.hpp
@@ -38,6 +38,7 @@
 #include <stop_token>
 
 #include <netinet/in.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
 
@@ -129,7 +130,7 @@ struct descriptor_state final : scheduler_op
     bool write_cancel_pending   = false;
     bool connect_cancel_pending = false;
 
-    // Set during registration only (no mutex needed)
+    // Protected by mutex (written by register_descriptor and ensure_write_events)
     std::uint32_t registered_events = 0;
     int fd                          = -1;
 
@@ -265,7 +266,17 @@ struct epoll_connect_op final : epoll_op
 
     void perform_io() noexcept override
     {
-        // connect() completion status is retrieved via SO_ERROR, not return value
+        // Guard against spurious write-ready events: a zero-timeout
+        // poll confirms the fd is actually writable (connect finished).
+        pollfd pfd{};
+        pfd.fd     = fd;
+        pfd.events = POLLOUT;
+        if (::poll(&pfd, 1, 0) == 0)
+        {
+            complete(EAGAIN, 0);
+            return;
+        }
+
         int err       = 0;
         socklen_t len = sizeof(err);
         if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &len) < 0)

--- a/include/boost/corosio/native/detail/epoll/epoll_scheduler.hpp
+++ b/include/boost/corosio/native/detail/epoll/epoll_scheduler.hpp
@@ -145,6 +145,18 @@ public:
     */
     void register_descriptor(int fd, descriptor_state* desc) const;
 
+    /** Ensure EPOLLOUT is registered for a descriptor.
+
+        No-op if the write interest is already registered. Called lazily
+        before the first write or connect operation that needs async
+        notification. Uses EPOLL_CTL_MOD to add EPOLLOUT to the
+        existing registration.
+
+        @param fd The file descriptor.
+        @param desc The descriptor_state that owns the fd.
+    */
+    void ensure_write_events(int fd, descriptor_state* desc) const;
+
     /** Deregister a persistently registered descriptor.
 
         @param fd The file descriptor to deregister.
@@ -547,8 +559,16 @@ descriptor_state::operator()()
                     cn->complete(err, 0);
                 else
                     cn->perform_io();
-                connect_op = nullptr;
-                local_ops.push(cn);
+
+                if (cn->errn == EAGAIN || cn->errn == EWOULDBLOCK)
+                {
+                    cn->errn = 0;
+                }
+                else
+                {
+                    connect_op = nullptr;
+                    local_ops.push(cn);
+                }
             }
             if (write_op)
             {
@@ -906,8 +926,11 @@ epoll_scheduler::poll_one()
 inline void
 epoll_scheduler::register_descriptor(int fd, descriptor_state* desc) const
 {
+    // Only register read interest upfront. EPOLLOUT is deferred until
+    // the first write/connect op to avoid a spurious write-ready event
+    // on freshly opened (always-writable) sockets.
     epoll_event ev{};
-    ev.events   = EPOLLIN | EPOLLOUT | EPOLLET | EPOLLERR | EPOLLHUP;
+    ev.events   = EPOLLIN | EPOLLET | EPOLLERR | EPOLLHUP;
     ev.data.ptr = desc;
 
     if (::epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, fd, &ev) < 0)
@@ -920,6 +943,20 @@ epoll_scheduler::register_descriptor(int fd, descriptor_state* desc) const
     std::lock_guard lock(desc->mutex);
     desc->read_ready  = false;
     desc->write_ready = false;
+}
+
+inline void
+epoll_scheduler::ensure_write_events(int fd, descriptor_state* desc) const
+{
+    std::lock_guard lock(desc->mutex);
+    if (desc->registered_events & EPOLLOUT)
+        return;
+
+    epoll_event ev{};
+    ev.events   = desc->registered_events | EPOLLOUT;
+    ev.data.ptr = desc;
+    if (::epoll_ctl(epoll_fd_, EPOLL_CTL_MOD, fd, &ev) == 0)
+        desc->registered_events = ev.events;
 }
 
 inline void

--- a/include/boost/corosio/native/detail/epoll/epoll_socket_service.hpp
+++ b/include/boost/corosio/native/detail/epoll/epoll_socket_service.hpp
@@ -341,6 +341,8 @@ epoll_socket::connect(
     }
 
     // EINPROGRESS — register with reactor
+    svc_.scheduler().ensure_write_events(fd_, &desc_state_);
+
     op.reset();
     op.h               = h;
     op.ex              = ex;
@@ -512,6 +514,8 @@ epoll_socket::write_some(
     }
 
     // EAGAIN — register with reactor
+    svc_.scheduler().ensure_write_events(fd_, &desc_state_);
+
     op.h         = h;
     op.ex        = ex;
     op.ec_out    = ec;

--- a/include/boost/corosio/native/detail/kqueue/kqueue_op.hpp
+++ b/include/boost/corosio/native/detail/kqueue/kqueue_op.hpp
@@ -37,6 +37,7 @@
 #include <stop_token>
 
 #include <netinet/in.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
 
@@ -138,7 +139,7 @@ struct descriptor_state final : scheduler_op
     bool write_cancel_pending   = false;
     bool connect_cancel_pending = false;
 
-    // Set during registration only (no mutex needed)
+    // Protected by mutex (written by register_descriptor and ensure_write_filter)
     std::uint32_t registered_events = 0;
     int fd                          = -1;
 
@@ -277,7 +278,17 @@ struct kqueue_connect_op final : kqueue_op
 
     void perform_io() noexcept override
     {
-        // connect() completion status is retrieved via SO_ERROR, not return value
+        // Guard against spurious write-ready events: a zero-timeout
+        // poll confirms the fd is actually writable (connect finished).
+        pollfd pfd{};
+        pfd.fd     = fd;
+        pfd.events = POLLOUT;
+        if (::poll(&pfd, 1, 0) == 0)
+        {
+            complete(EAGAIN, 0);
+            return;
+        }
+
         int err       = 0;
         socklen_t len = sizeof(err);
         if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &len) < 0)

--- a/include/boost/corosio/native/detail/kqueue/kqueue_scheduler.hpp
+++ b/include/boost/corosio/native/detail/kqueue/kqueue_scheduler.hpp
@@ -196,9 +196,12 @@ public:
 
     /** Register a descriptor for persistent monitoring.
 
-        Adds EVFILT_READ and EVFILT_WRITE (both EV_CLEAR) for @a fd
-        and stores @a desc in the kevent udata field so that the
-        reactor can dispatch events to the correct descriptor_state.
+        Adds EVFILT_READ (EV_CLEAR) for @a fd and stores @a desc in
+        the kevent udata field so that the reactor can dispatch events
+        to the correct descriptor_state. EVFILT_WRITE is deferred
+        until the first write or connect operation needs it (see
+        @ref ensure_write_filter) to avoid spurious write-ready events
+        on freshly opened sockets.
 
         The caller retains ownership of @a desc. It must remain valid
         until deregister_descriptor() is called and all pending
@@ -212,6 +215,17 @@ public:
         @throws std::system_error if kevent(EV_ADD) fails.
     */
     void register_descriptor(int fd, descriptor_state* desc) const;
+
+    /** Ensure EVFILT_WRITE is registered for a descriptor.
+
+        No-op if the write filter is already registered. Called lazily
+        before the first write or connect operation that needs async
+        notification.
+
+        @param fd The file descriptor.
+        @param desc The descriptor_state that owns the fd.
+    */
+    void ensure_write_filter(int fd, descriptor_state* desc) const;
 
     /** Deregister a persistently registered descriptor.
 
@@ -604,8 +618,16 @@ descriptor_state::operator()()
             cn->complete(err, 0);
         else
             cn->perform_io();
-        local_ops.push(cn);
-        cn = nullptr;
+
+        if (cn->errn == EAGAIN || cn->errn == EWOULDBLOCK)
+        {
+            cn->errn = 0;
+        }
+        else
+        {
+            local_ops.push(cn);
+            cn = nullptr;
+        }
     }
 
     if (wr)
@@ -630,7 +652,7 @@ descriptor_state::operator()()
     // have set read_ready/write_ready while we held the op (no read_op
     // was registered, so it cached the edge event). Check the flags
     // under the same lock as re-registration so no edge is lost.
-    while (rd || wr)
+    while (rd || wr || cn)
     {
         bool retry = false;
         {
@@ -661,6 +683,19 @@ descriptor_state::operator()()
                     wr       = nullptr;
                 }
             }
+            if (cn)
+            {
+                if (write_ready)
+                {
+                    write_ready = false;
+                    retry       = true;
+                }
+                else
+                {
+                    connect_op = cn;
+                    cn         = nullptr;
+                }
+            }
         }
 
         if (!retry)
@@ -675,6 +710,17 @@ descriptor_state::operator()()
             {
                 local_ops.push(rd);
                 rd = nullptr;
+            }
+        }
+        if (cn)
+        {
+            cn->perform_io();
+            if (cn->errn == EAGAIN || cn->errn == EWOULDBLOCK)
+                cn->errn = 0;
+            else
+            {
+                local_ops.push(cn);
+                cn = nullptr;
             }
         }
         if (wr)
@@ -977,24 +1023,39 @@ kqueue_scheduler::poll_one()
 inline void
 kqueue_scheduler::register_descriptor(int fd, descriptor_state* desc) const
 {
-    struct kevent changes[2];
+    // Only register EVFILT_READ upfront. EVFILT_WRITE is deferred
+    // until the first write/connect op to avoid a spurious write-ready
+    // event on freshly opened (always-writable) sockets.
+    struct kevent change;
     EV_SET(
-        &changes[0], static_cast<uintptr_t>(fd), EVFILT_READ, EV_ADD | EV_CLEAR,
+        &change, static_cast<uintptr_t>(fd), EVFILT_READ, EV_ADD | EV_CLEAR,
         0, 0, desc);
-    EV_SET(
-        &changes[1], static_cast<uintptr_t>(fd), EVFILT_WRITE,
-        EV_ADD | EV_CLEAR, 0, 0, desc);
 
-    if (::kevent(kq_fd_, changes, 2, nullptr, 0, nullptr) < 0)
+    if (::kevent(kq_fd_, &change, 1, nullptr, 0, nullptr) < 0)
         detail::throw_system_error(make_err(errno), "kevent (register)");
 
-    desc->registered_events = kqueue_event_read | kqueue_event_write;
+    desc->registered_events = kqueue_event_read;
     desc->fd                = fd;
     desc->scheduler_        = this;
 
     std::lock_guard lock(desc->mutex);
     desc->read_ready  = false;
     desc->write_ready = false;
+}
+
+inline void
+kqueue_scheduler::ensure_write_filter(int fd, descriptor_state* desc) const
+{
+    std::lock_guard lock(desc->mutex);
+    if (desc->registered_events & kqueue_event_write)
+        return;
+
+    struct kevent change;
+    EV_SET(
+        &change, static_cast<uintptr_t>(fd), EVFILT_WRITE, EV_ADD | EV_CLEAR,
+        0, 0, desc);
+    if (::kevent(kq_fd_, &change, 1, nullptr, 0, nullptr) == 0)
+        desc->registered_events |= kqueue_event_write;
 }
 
 inline void

--- a/include/boost/corosio/native/detail/kqueue/kqueue_socket_service.hpp
+++ b/include/boost/corosio/native/detail/kqueue/kqueue_socket_service.hpp
@@ -342,6 +342,8 @@ kqueue_socket::connect(
     }
 
     // EINPROGRESS — async path
+    svc_.scheduler().ensure_write_filter(fd_, &desc_state_);
+
     op.reset();
     op.h               = h;
     op.ex              = ex;
@@ -559,6 +561,8 @@ kqueue_socket::write_some(
     }
 
     // EAGAIN — register with reactor
+    svc_.scheduler().ensure_write_filter(fd_, &desc_state_);
+
     op.h         = h;
     op.ex        = ex;
     op.ec_out    = ec;


### PR DESCRIPTION
register_descriptor() previously registered both read and write filters (EVFILT_WRITE / EPOLLOUT) upfront when a socket was opened. A fresh socket is always writable, so this armed an immediate write-ready event. On FreeBSD (kqueue), if connect() returned EINPROGRESS, the stale event could be delivered before the connection completed, causing getsockopt(SO_ERROR) to return 0 and the connect to falsely report success.

Now only the read filter is registered at open time. The write filter is added lazily via ensure_write_filter() / ensure_write_events() on the first connect (EINPROGRESS) or write (EAGAIN) that actually needs async notification. This matches Boost.Asio's approach.

As defense-in-depth, connect_op::perform_io() now uses a zero-timeout poll(POLLOUT) to confirm the fd is actually writable before checking SO_ERROR, and returns EAGAIN on spurious events. The descriptor_state event loop handles connect EAGAIN by re-registering the op.

Applied symmetrically to both kqueue and epoll backends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added guards against spurious write-ready events in connect/write paths, improving reliability of non-blocking I/O.

* **Performance**
  * Deferred registration of write notifications until needed, reducing unnecessary event monitoring and lowering runtime overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->