### PR TITLE
Fix compilation errors from upstream capy io_result API change

### DIFF
--- a/include/boost/corosio/io/io_signal_set.hpp
+++ b/include/boost/corosio/io/io_signal_set.hpp
@@ -54,7 +54,7 @@ class BOOST_COROSIO_DECL io_signal_set : public io_object
         capy::io_result<int> await_resume() const noexcept
         {
             if (token_.stop_requested())
-                return {capy::error::canceled};
+                return {capy::error::canceled, 0};
             return {ec_, signal_number_};
         }
 

--- a/include/boost/corosio/native/native_signal_set.hpp
+++ b/include/boost/corosio/native/native_signal_set.hpp
@@ -77,7 +77,7 @@ class native_signal_set : public signal_set
         capy::io_result<int> await_resume() const noexcept
         {
             if (token_.stop_requested())
-                return {capy::error::canceled};
+                return {capy::error::canceled, 0};
             return {ec_, signal_number_};
         }
 

--- a/test/unit/io_context.cpp
+++ b/test/unit/io_context.cpp
@@ -543,16 +543,19 @@ struct io_context_test
         }
     }
 
-    static capy::task<void> set_event_task(capy::async_event& evt)
+    static capy::task<capy::io_result<>> set_event_task(capy::async_event& evt)
     {
         evt.set();
-        co_return;
+        co_return capy::io_result<>{{}};
     }
 
     static capy::task<void> when_all_set_event_main(bool& finished)
     {
         capy::async_event evt;
-        co_await capy::when_all(evt.wait(), set_event_task(evt));
+        auto [ec, a, b] = co_await capy::when_all(evt.wait(), set_event_task(evt));
+        (void)a;
+        (void)b;
+        BOOST_TEST(!ec);
         finished = true;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed signal set cancellation handling to return proper result values instead of incomplete error states, ensuring consistent behavior across signal wait operations when cancellation is requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->