### PR TITLE
Pr/capy update

### DIFF
--- a/.github/compilers.json
+++ b/.github/compilers.json
@@ -130,20 +130,11 @@
       "version": "*",
       "cxxstd": "20,23",
       "latest_cxxstd": "23",
-      "runs_on": "macos-14",
+      "runs_on": "macos-15",
       "cxx": "clang++",
       "cc": "clang",
       "b2_toolset": "clang",
       "is_earliest": true
-    },
-    {
-      "version": "*",
-      "cxxstd": "20,23",
-      "latest_cxxstd": "23",
-      "runs_on": "macos-15",
-      "cxx": "clang++",
-      "cc": "clang",
-      "b2_toolset": "clang"
     },
     {
       "version": "*",

--- a/include/boost/corosio/io/io_signal_set.hpp
+++ b/include/boost/corosio/io/io_signal_set.hpp
@@ -54,7 +54,7 @@ class BOOST_COROSIO_DECL io_signal_set : public io_object
         capy::io_result<int> await_resume() const noexcept
         {
             if (token_.stop_requested())
-                return {capy::error::canceled};
+                return {capy::error::canceled, 0};
             return {ec_, signal_number_};
         }
 

--- a/include/boost/corosio/native/native_signal_set.hpp
+++ b/include/boost/corosio/native/native_signal_set.hpp
@@ -77,7 +77,7 @@ class native_signal_set : public signal_set
         capy::io_result<int> await_resume() const noexcept
         {
             if (token_.stop_requested())
-                return {capy::error::canceled};
+                return {capy::error::canceled, 0};
             return {ec_, signal_number_};
         }
 

--- a/src/openssl/src/openssl_stream.cpp
+++ b/src/openssl/src/openssl_stream.cpp
@@ -374,9 +374,10 @@ struct openssl_stream::impl
                 break;
 
             {
-                auto [lec, guard] = co_await io_cm_.scoped_lock();
+                auto [lec] = co_await io_cm_.lock();
                 if (lec)
                     co_return lec;
+                capy::async_mutex::lock_guard io_guard(&io_cm_);
                 auto [ec, n] = co_await capy::write(
                     s_, capy::const_buffer(out_buf_.data(), got));
                 if (ec)
@@ -388,9 +389,10 @@ struct openssl_stream::impl
 
     capy::task<std::error_code> read_input()
     {
-        auto [lec, guard] = co_await io_cm_.scoped_lock();
+        auto [lec] = co_await io_cm_.lock();
         if (lec)
             co_return lec;
+        capy::async_mutex::lock_guard io_guard(&io_cm_);
         auto [ec, n] = co_await s_.read_some(
             capy::mutable_buffer(in_buf_.data(), in_buf_.size()));
         if (ec)

--- a/src/wolfssl/src/wolfssl_stream.cpp
+++ b/src/wolfssl/src/wolfssl_stream.cpp
@@ -494,12 +494,13 @@ struct wolfssl_stream::impl
                             read_in_buf_.data() + read_in_len_,
                             read_in_buf_.size() - read_in_len_);
 
-                        auto [lec, guard] = co_await io_cm_.scoped_lock();
+                        auto [lec] = co_await io_cm_.lock();
                         if (lec)
                         {
                             current_op_ = nullptr;
                             co_return {lec, total_read};
                         }
+                        capy::async_mutex::lock_guard io_guard(&io_cm_);
                         auto [rec, rn] = co_await s_.read_some(rbuf);
                         if (rec)
                         {
@@ -526,12 +527,13 @@ struct wolfssl_stream::impl
                         // Renegotiation
                         if (read_out_len_ > 0)
                         {
-                            auto [lec, guard] = co_await io_cm_.scoped_lock();
+                            auto [lec] = co_await io_cm_.lock();
                             if (lec)
                             {
                                 current_op_ = nullptr;
                                 co_return {lec, total_read};
                             }
+                            capy::async_mutex::lock_guard io_guard(&io_cm_);
                             auto [wec, wn] = co_await capy::write(
                                 s_,
                                 capy::const_buffer(
@@ -604,12 +606,13 @@ struct wolfssl_stream::impl
                         // Flush any pending output
                         if (write_out_len_ > 0)
                         {
-                            auto [lec, guard] = co_await io_cm_.scoped_lock();
+                            auto [lec] = co_await io_cm_.lock();
                             if (lec)
                             {
                                 current_op_ = nullptr;
                                 co_return {lec, total_written};
                             }
+                            capy::async_mutex::lock_guard io_guard(&io_cm_);
                             auto [wec, wn] = co_await capy::write(
                                 s_,
                                 capy::const_buffer(
@@ -633,12 +636,13 @@ struct wolfssl_stream::impl
                     {
                         if (write_out_len_ > 0)
                         {
-                            auto [lec, guard] = co_await io_cm_.scoped_lock();
+                            auto [lec] = co_await io_cm_.lock();
                             if (lec)
                             {
                                 current_op_ = nullptr;
                                 co_return {lec, total_written};
                             }
+                            capy::async_mutex::lock_guard io_guard(&io_cm_);
                             auto [wec, wn] = co_await capy::write(
                                 s_,
                                 capy::const_buffer(
@@ -662,12 +666,13 @@ struct wolfssl_stream::impl
                         capy::mutable_buffer rbuf(
                             write_in_buf_.data() + write_in_len_,
                             write_in_buf_.size() - write_in_len_);
-                        auto [lec, guard] = co_await io_cm_.scoped_lock();
+                        auto [lec] = co_await io_cm_.lock();
                         if (lec)
                         {
                             current_op_ = nullptr;
                             co_return {lec, total_written};
                         }
+                        capy::async_mutex::lock_guard io_guard(&io_cm_);
                         auto [rec, rn] = co_await s_.read_some(rbuf);
                         if (rec)
                         {
@@ -729,12 +734,13 @@ struct wolfssl_stream::impl
                 // Flush any remaining output
                 if (read_out_len_ > 0)
                 {
-                    auto [lec, guard] = co_await io_cm_.scoped_lock();
+                    auto [lec] = co_await io_cm_.lock();
                     if (lec)
                     {
                         ec = lec;
                         break;
                     }
+                    capy::async_mutex::lock_guard io_guard(&io_cm_);
                     auto [wec, wn] = co_await capy::write(
                         s_,
                         capy::const_buffer(
@@ -754,12 +760,13 @@ struct wolfssl_stream::impl
                     // Must flush (e.g. ClientHello) before reading ServerHello
                     if (read_out_len_ > 0)
                     {
-                        auto [lec, guard] = co_await io_cm_.scoped_lock();
+                        auto [lec] = co_await io_cm_.lock();
                         if (lec)
                         {
                             ec = lec;
                             break;
                         }
+                        capy::async_mutex::lock_guard io_guard(&io_cm_);
                         auto [wec, wn] = co_await capy::write(
                             s_,
                             capy::const_buffer(
@@ -780,12 +787,13 @@ struct wolfssl_stream::impl
                     capy::mutable_buffer rbuf(
                         read_in_buf_.data() + read_in_len_,
                         read_in_buf_.size() - read_in_len_);
-                    auto [lec, guard] = co_await io_cm_.scoped_lock();
+                    auto [lec] = co_await io_cm_.lock();
                     if (lec)
                     {
                         ec = lec;
                         break;
                     }
+                    capy::async_mutex::lock_guard io_guard(&io_cm_);
                     auto [rec, rn] = co_await s_.read_some(rbuf);
                     if (rec)
                     {
@@ -798,12 +806,13 @@ struct wolfssl_stream::impl
                 {
                     if (read_out_len_ > 0)
                     {
-                        auto [lec, guard] = co_await io_cm_.scoped_lock();
+                        auto [lec] = co_await io_cm_.lock();
                         if (lec)
                         {
                             ec = lec;
                             break;
                         }
+                        capy::async_mutex::lock_guard io_guard(&io_cm_);
                         auto [wec, wn] = co_await capy::write(
                             s_,
                             capy::const_buffer(
@@ -853,12 +862,13 @@ struct wolfssl_stream::impl
                 // Bidirectional shutdown complete - flush any remaining output
                 if (read_out_len_ > 0)
                 {
-                    auto [lec, guard] = co_await io_cm_.scoped_lock();
+                    auto [lec] = co_await io_cm_.lock();
                     if (lec)
                     {
                         ec = lec;
                         break;
                     }
+                    capy::async_mutex::lock_guard io_guard(&io_cm_);
                     auto [wec, wn] = co_await capy::write(
                         s_,
                         capy::const_buffer(
@@ -874,9 +884,13 @@ struct wolfssl_stream::impl
                 // First, flush any pending output (sends our close_notify)
                 if (read_out_len_ > 0)
                 {
-                    auto [lec, guard] = co_await io_cm_.scoped_lock();
+                    auto [lec] = co_await io_cm_.lock();
                     if (lec)
+                    {
+                        ec = lec;
                         break;
+                    }
+                    capy::async_mutex::lock_guard io_guard(&io_cm_);
                     auto [wec, wn] = co_await capy::write(
                         s_,
                         capy::const_buffer(
@@ -897,9 +911,13 @@ struct wolfssl_stream::impl
                     capy::mutable_buffer rbuf(
                         read_in_buf_.data() + read_in_len_,
                         read_in_buf_.size() - read_in_len_);
-                    auto [lec, guard] = co_await io_cm_.scoped_lock();
+                    auto [lec] = co_await io_cm_.lock();
                     if (lec)
+                    {
+                        ec = lec;
                         break;
+                    }
+                    capy::async_mutex::lock_guard io_guard(&io_cm_);
                     auto [rec, rn] = co_await s_.read_some(rbuf);
                     if (rec)
                         break; // EOF or socket error during shutdown read - acceptable

--- a/test/unit/io_context.cpp
+++ b/test/unit/io_context.cpp
@@ -543,16 +543,19 @@ struct io_context_test
         }
     }
 
-    static capy::task<void> set_event_task(capy::async_event& evt)
+    static capy::task<capy::io_result<>> set_event_task(capy::async_event& evt)
     {
         evt.set();
-        co_return;
+        co_return capy::io_result<>{{}};
     }
 
     static capy::task<void> when_all_set_event_main(bool& finished)
     {
         capy::async_event evt;
-        co_await capy::when_all(evt.wait(), set_event_task(evt));
+        auto [ec, a, b] = co_await capy::when_all(evt.wait(), set_event_task(evt));
+        (void)a;
+        (void)b;
+        BOOST_TEST(!ec);
         finished = true;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Apple Clang compiler configuration to target macOS 15 and removed duplicate build matrix entries.

* **Bug Fixes**
  * Fixed signal handler cancellation behavior to return properly structured result values.
  * Enhanced mutex lock management in TLS stream implementations (OpenSSL and WolfSSL) to improve thread-safe I/O operation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->