### PR TITLE
Remove capy auto-fetch so FetchContent consumers provide it themselves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -586,6 +586,28 @@ jobs:
           toolchain: ${{ env.CMAKE_TOOLCHAIN_FILE }}
           ref-source-dir: boost-root/libs/corosio/test/cmake_test
 
+      # Standalone root-project builds (build-cmake, coverage, clang-tidy)
+      # need the consumer to provide Boost::capy. Inject it via
+      # CMAKE_PROJECT_boost_corosio_INCLUDE so the already-cloned capy-root
+      # is added as a subdirectory at configure time.
+      - name: Create capy provider for standalone builds
+        if: ${{ matrix.build-cmake || matrix.coverage || matrix.clang-tidy }}
+        shell: bash
+        run: |
+          workspace_root=$(echo "$GITHUB_WORKSPACE" | sed 's/\\/\//g')
+          cat > "${workspace_root}/provide-capy.cmake" << 'EOF'
+          set(BOOST_CAPY_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+          set(BOOST_CAPY_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+          # Co-locate DLLs with executables so post-build test discovery works
+          if(BUILD_SHARED_LIBS)
+              set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+          endif()
+          add_subdirectory("${COROSIO_CI_CAPY_SOURCE_DIR}"
+              "${CMAKE_BINARY_DIR}/_deps/capy-build" EXCLUDE_FROM_ALL)
+          EOF
+          echo "COROSIO_CI_PROVIDE_CAPY=${workspace_root}/provide-capy.cmake" >> $GITHUB_ENV
+          echo "COROSIO_CI_CAPY_DIR=${workspace_root}/capy-root" >> $GITHUB_ENV
+
       - name: Root Project CMake Workflow
         uses: alandefreitas/cpp-actions/cmake-workflow@v1.9.0
         if: ${{ matrix.build-cmake || matrix.coverage }}
@@ -606,6 +628,8 @@ jobs:
           cmake-version: '>=3.20'
           extra-args: |
             -D Boost_VERBOSE=ON
+            -D CMAKE_PROJECT_boost_corosio_INCLUDE=${{ env.COROSIO_CI_PROVIDE_CAPY }}
+            -D COROSIO_CI_CAPY_SOURCE_DIR=${{ env.COROSIO_CI_CAPY_DIR }}
             ${{ matrix.compiler == 'mingw' && '-D CMAKE_VERBOSE_MAKEFILE=ON' || '' }}
             ${{ contains(matrix.generator || '', 'Visual Studio') && format('-D CMAKE_CONFIGURATION_TYPES={0}', matrix.build-type) || '' }}
             ${{ env.CMAKE_WOLFSSL_INCLUDE && format('-D WolfSSL_INCLUDE_DIR={0}', env.CMAKE_WOLFSSL_INCLUDE) || '' }}
@@ -630,6 +654,8 @@ jobs:
           cmake-version: '>=3.20'
           extra-args: |
             -D CMAKE_EXPORT_COMPILE_COMMANDS=ON
+            -D CMAKE_PROJECT_boost_corosio_INCLUDE=${{ env.COROSIO_CI_PROVIDE_CAPY }}
+            -D COROSIO_CI_CAPY_SOURCE_DIR=${{ env.COROSIO_CI_CAPY_DIR }}
             ${{ env.CMAKE_WOLFSSL_INCLUDE && format('-D WolfSSL_INCLUDE_DIR={0}', env.CMAKE_WOLFSSL_INCLUDE) || '' }}
             ${{ env.CMAKE_WOLFSSL_LIBRARY && format('-D WolfSSL_LIBRARY={0}', env.CMAKE_WOLFSSL_LIBRARY) || '' }}
             ${{ env.CMAKE_OPENSSL_ROOT && format('-D OPENSSL_ROOT_DIR="{0}"', env.CMAKE_OPENSSL_ROOT) || '' }}

--- a/README.md
+++ b/README.md
@@ -9,27 +9,25 @@ Boost.Corosio is a coroutine-only I/O library for C++20 that provides asynchrono
 
 ## Quick Start
 
-### Standalone build
-
-```bash
-git clone https://github.com/cppalliance/corosio.git
-cd corosio
-cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
-cmake --build build
-```
-
 ### Consume via CMake
 
-Use `FetchContent` or `add_subdirectory` to add corosio to your project,
-then link against `Boost::corosio`:
+Corosio depends on [Capy](https://github.com/cppalliance/capy). Both must
+be made available before linking. Use `FetchContent`, `add_subdirectory`,
+or `find_package` — declaration order does not matter:
 
 ```cmake
 include(FetchContent)
+
+FetchContent_Declare(capy
+    GIT_REPOSITORY https://github.com/cppalliance/capy.git
+    GIT_TAG develop
+    GIT_SHALLOW TRUE)
 FetchContent_Declare(corosio
     GIT_REPOSITORY https://github.com/cppalliance/corosio.git
     GIT_TAG develop
     GIT_SHALLOW TRUE)
-FetchContent_MakeAvailable(corosio)
+
+FetchContent_MakeAvailable(capy corosio)
 
 target_link_libraries(my_app Boost::corosio)
 ```

--- a/cmake/CorosioBuild.cmake
+++ b/cmake/CorosioBuild.cmake
@@ -9,8 +9,10 @@
 
 # corosio_resolve_deps()
 #
-# Resolve all build dependencies: sibling Boost libraries when inside a
-# boost tree, Capy via find_package / FetchContent, and Threads.
+# Resolve build dependencies: sibling Boost libraries when inside a
+# boost tree, and Threads. Capy (Boost::capy) must be provided by
+# the consumer — CMake resolves the target reference at generation
+# time, so declaration order does not matter.
 #
 # Must be a macro so find_package results propagate to the caller's scope.
 macro(corosio_resolve_deps)
@@ -27,55 +29,6 @@ macro(corosio_resolve_deps)
         set(CMAKE_FOLDER _deps)
         add_subdirectory(../.. ${CMAKE_CURRENT_BINARY_DIR}/deps/boost EXCLUDE_FROM_ALL)
         unset(CMAKE_FOLDER)
-    endif()
-
-    # Capy: prefer already-available target, then find_package, then FetchContent
-    if(NOT TARGET Boost::capy)
-        find_package(boost_capy QUIET)
-    endif()
-
-    if(NOT TARGET Boost::capy)
-        include(FetchContent)
-
-        # Match capy branch to corosio's current branch when possible
-        if(NOT DEFINED CACHE{BOOST_COROSIO_CAPY_TAG})
-            execute_process(
-                COMMAND git rev-parse --abbrev-ref HEAD
-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                OUTPUT_VARIABLE _corosio_branch
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-                ERROR_QUIET
-                RESULT_VARIABLE _git_result)
-            if(_git_result EQUAL 0 AND _corosio_branch)
-                execute_process(
-                    COMMAND git ls-remote --heads
-                        https://github.com/cppalliance/capy.git
-                        ${_corosio_branch}
-                    OUTPUT_VARIABLE _capy_has_branch
-                    OUTPUT_STRIP_TRAILING_WHITESPACE
-                    ERROR_QUIET
-                    TIMEOUT 30)
-                if(_capy_has_branch)
-                    set(_default_capy_tag "${_corosio_branch}")
-                endif()
-            endif()
-            if(NOT DEFINED _default_capy_tag)
-                set(_default_capy_tag "develop")
-            endif()
-        endif()
-        set(BOOST_COROSIO_CAPY_TAG "${_default_capy_tag}" CACHE STRING
-            "Git tag/branch for capy when fetching via FetchContent")
-
-        message(STATUS "Fetching capy...")
-        set(BOOST_CAPY_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-        set(BOOST_CAPY_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-        FetchContent_Declare(
-            capy
-            GIT_REPOSITORY https://github.com/cppalliance/capy.git
-            GIT_TAG ${BOOST_COROSIO_CAPY_TAG}
-            GIT_SHALLOW TRUE
-        )
-        FetchContent_MakeAvailable(capy)
     endif()
 
     find_package(Threads REQUIRED)
@@ -196,9 +149,11 @@ function(corosio_install)
                 $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
         endforeach()
 
-        if(boost_capy_FOUND)
-            # Capy from find_package (imported target): full install with
-            # CMake package config and export sets.
+        get_target_property(_capy_imported boost_capy IMPORTED)
+
+        if(_capy_imported)
+            # Capy is an imported target (find_package, vcpkg, conan):
+            # full install with export sets and package config.
             include(CMakePackageConfigHelpers)
 
             set(BOOST_COROSIO_INSTALL_CMAKEDIR
@@ -233,9 +188,9 @@ function(corosio_install)
             install(FILES ${_corosio_config_files}
                 DESTINATION ${BOOST_COROSIO_INSTALL_CMAKEDIR})
         else()
-            # Capy from source tree (boost root or FetchContent): export sets
-            # can't work because capy isn't an imported target. Install the
-            # library and headers only.
+            # Capy from source tree (boost root, FetchContent,
+            # add_subdirectory): export sets can't reference a
+            # non-exported dependency.
             install(TARGETS ${_corosio_install_targets}
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
The three-tier capy resolution (target check, find_package, FetchContent) introduced order dependence and network non-determinism at configure time. Consumers now provide Boost::capy via their own mechanism; CMake resolves the target reference at generation time regardless of declaration order.

Resolves #217.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CMake consumption instructions to require providing Capy and added an example showing both projects made available before linking.

* **Build Changes**
  * Simplified dependency resolution so Corosio no longer fetches Capy automatically; installer now treats missing provided Capy as a library+headers-only install path.

* **CI/CD Updates**
  * CI workflows updated to generate and consume a provider for consistent Capy configuration across build, coverage, and static-analysis matrix entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->