### PR TITLE
Inline budget now has a symmetric ramp down

### DIFF
--- a/include/boost/corosio/native/detail/reactor/reactor_scheduler.hpp
+++ b/include/boost/corosio/native/detail/reactor/reactor_scheduler.hpp
@@ -450,8 +450,9 @@ reactor_scheduler::reset_inline_budget() const noexcept
                 ctx->inline_budget_max * 2,
                 static_cast<int>(inline_budget_max_));
         else if (ctx->inline_budget < ctx->inline_budget_max)
-            ctx->inline_budget_max =
-                static_cast<int>(inline_budget_initial_);
+            ctx->inline_budget_max = (std::max)(
+                ctx->inline_budget_max / 2,
+                static_cast<int>(inline_budget_initial_));
         ctx->inline_budget = ctx->inline_budget_max;
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the adaptive inline-budget scaling behavior in the reactor scheduler to reduce budget more gradually instead of completely resetting. This ensures better system stability and responsiveness during high-load conditions while preventing excessive performance drops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->