### PR TITLE
Use recv/send single-buffer syscalls when iovec_count == 1

### DIFF
--- a/include/boost/corosio/native/detail/epoll/epoll_traits.hpp
+++ b/include/boost/corosio/native/detail/epoll/epoll_traits.hpp
@@ -74,6 +74,18 @@ struct epoll_traits
             while (n < 0 && errno == EINTR);
             return n;
         }
+
+        static ssize_t write_one(
+            int fd, void const* data, std::size_t size) noexcept
+        {
+            ssize_t n;
+            do
+            {
+                n = ::send(fd, data, size, MSG_NOSIGNAL);
+            }
+            while (n < 0 && errno == EINTR);
+            return n;
+        }
     };
 
     struct accept_policy

--- a/include/boost/corosio/native/detail/kqueue/kqueue_traits.hpp
+++ b/include/boost/corosio/native/detail/kqueue/kqueue_traits.hpp
@@ -110,6 +110,21 @@ struct kqueue_traits
             while (n < 0 && errno == EINTR);
             return n;
         }
+
+        // Single-buffer fast path. macOS lacks MSG_NOSIGNAL; SIGPIPE is
+        // suppressed by the mandatory SO_NOSIGPIPE set in accept_policy
+        // and set_fd_options, so plain write() is safe here.
+        static ssize_t write_one(
+            int fd, void const* data, std::size_t size) noexcept
+        {
+            ssize_t n;
+            do
+            {
+                n = ::write(fd, data, size);
+            }
+            while (n < 0 && errno == EINTR);
+            return n;
+        }
     };
 
     struct accept_policy

--- a/include/boost/corosio/native/detail/reactor/reactor_stream_socket.hpp
+++ b/include/boost/corosio/native/detail/reactor/reactor_stream_socket.hpp
@@ -394,13 +394,25 @@ reactor_stream_socket<Derived, Service, ConnOp, ReadOp, WriteOp, DescState, Impl
         op.iovecs[i].iov_len  = bufs[i].size();
     }
 
-    // Speculative read
+    // Speculative read; for the single-buffer case use recv() so the
+    // kernel skips the readv iov_iter setup.
     ssize_t n;
-    do
+    if (op.iovec_count == 1)
     {
-        n = ::readv(this->fd_, op.iovecs, op.iovec_count);
+        do
+        {
+            n = ::recv(this->fd_, bufs[0].data(), bufs[0].size(), 0);
+        }
+        while (n < 0 && errno == EINTR);
     }
-    while (n < 0 && errno == EINTR);
+    else
+    {
+        do
+        {
+            n = ::readv(this->fd_, op.iovecs, op.iovec_count);
+        }
+        while (n < 0 && errno == EINTR);
+    }
 
     if (n >= 0 || (errno != EAGAIN && errno != EWOULDBLOCK))
     {
@@ -490,9 +502,20 @@ reactor_stream_socket<Derived, Service, ConnOp, ReadOp, WriteOp, DescState, Impl
         op.iovecs[i].iov_len  = bufs[i].size();
     }
 
-    // Speculative write via backend-specific write policy
-    ssize_t n =
-        WriteOp::write_policy::write(this->fd_, op.iovecs, op.iovec_count);
+    // Speculative write; the single-buffer case dispatches to a
+    // backend-specific fast path so the kernel skips msghdr/iov_iter
+    // setup (and so each backend can pick the right SIGPIPE strategy).
+    ssize_t n;
+    if (op.iovec_count == 1)
+    {
+        n = WriteOp::write_policy::write_one(
+            this->fd_, bufs[0].data(), bufs[0].size());
+    }
+    else
+    {
+        n = WriteOp::write_policy::write(
+            this->fd_, op.iovecs, op.iovec_count);
+    }
 
     if (n >= 0 || (errno != EAGAIN && errno != EWOULDBLOCK))
     {

--- a/include/boost/corosio/native/detail/select/select_traits.hpp
+++ b/include/boost/corosio/native/detail/select/select_traits.hpp
@@ -84,6 +84,26 @@ struct select_traits
             while (n < 0 && errno == EINTR);
             return n;
         }
+
+        // Single-buffer fast path. Where MSG_NOSIGNAL exists we use
+        // send() to suppress SIGPIPE inline; otherwise fall back to
+        // write() and rely on the SO_NOSIGPIPE set in accept_policy
+        // and set_fd_options.
+        static ssize_t write_one(
+            int fd, void const* data, std::size_t size) noexcept
+        {
+            ssize_t n;
+            do
+            {
+#ifdef MSG_NOSIGNAL
+                n = ::send(fd, data, size, MSG_NOSIGNAL);
+#else
+                n = ::write(fd, data, size);
+#endif
+            }
+            while (n < 0 && errno == EINTR);
+            return n;
+        }
     };
 
     struct accept_policy


### PR DESCRIPTION
When the speculative read/write only has one buffer, dispatch to recv()/ send() instead of readv()/writev()/sendmsg() so the kernel can skip the iov_iter setup. The single-buffer path is the common case in HTTP and streaming workloads.

The single-buffer write goes through a new write_policy::write_one backend hook so each reactor backend picks the right SIGPIPE strategy:

  - epoll:  send(MSG_NOSIGNAL)
  - kqueue: write() -- macOS lacks MSG_NOSIGNAL; SIGPIPE is suppressed by the mandatory SO_NOSIGPIPE set in accept_policy and set_fd_options
  - select: send(MSG_NOSIGNAL) where defined, else write() with SO_NOSIGPIPE as the SIGPIPE fallback

The single-buffer read uses recv() inline -- flag=0 is portable across all reactor platforms, so no read_policy is needed.

# Benchmark Comparison

5 iterations, 3s per benchmark, Release build (LTO), epoll backend.
Baseline: **develop**

Values shown as **mean ± relative stddev (%)**.

## socket_throughput (GB/s)

| Benchmark | develop (GB/s) | recv-send (GB/s) |
|-----------|---|---|
| bidirectional/1024 | 0.26 ± 1.1% | **0.28 ± 0.2%** 🏆 |
| bidirectional/4096 | 1.01 ± 1.1% | **1.06 ± 0.3%** 🏆 |
| bidirectional/16384 | 3.54 ± 1.1% | **3.70 ± 0.4%** 🏆 |
| bidirectional/65536 | 8.64 ± 5.9% | **8.91 ± 5.1%** 🏆 |
| bidirectional/262144 | **10.31 ± 1.1%** 🏆 | 10.28 ± 1.6% |
| bidirectional/1048576 | 10.53 ± 1.1% | **10.55 ± 0.1%** 🏆 |
| bidirectional_lockless/1024 | 0.26 ± 0.9% | **0.28 ± 0.5%** 🏆 |
| bidirectional_lockless/4096 | 1.01 ± 0.8% | **1.06 ± 0.3%** 🏆 |
| bidirectional_lockless/16384 | 3.55 ± 0.8% | **3.71 ± 0.3%** 🏆 |
| bidirectional_lockless/65536 | 8.44 ± 7.5% | **8.95 ± 5.4%** 🏆 |
| bidirectional_lockless/262144 | 10.20 ± 1.9% | **10.40 ± 0.9%** 🏆 |
| bidirectional_lockless/1048576 | 10.53 ± 0.8% | **10.58 ± 0.6%** 🏆 |
| multithread/2 | 8.99 ± 0.9% | **9.01 ± 0.6%** 🏆 |
| multithread/4 | **13.29 ± 2.1%** 🏆 | 13.24 ± 1.7% |
| multithread/8 | 14.29 ± 2.6% | **14.31 ± 1.1%** 🏆 |
| unidirectional/1024 | 0.24 ± 0.7% | **0.25 ± 0.4%** 🏆 |
| unidirectional/4096 | 0.92 ± 0.9% | **0.97 ± 0.2%** 🏆 |
| unidirectional/16384 | 3.29 ± 0.9% | **3.45 ± 0.4%** 🏆 |
| unidirectional/65536 | 7.62 ± 2.8% | **7.94 ± 2.0%** 🏆 |
| unidirectional/262144 | 10.55 ± 1.3% | **10.76 ± 0.9%** 🏆 |
| unidirectional/1048576 | 10.67 ± 0.8% | **10.72 ± 0.3%** 🏆 |
| unidirectional_lockless/1024 | 0.24 ± 0.9% | **0.25 ± 0.5%** 🏆 |
| unidirectional_lockless/4096 | 0.93 ± 0.9% | **0.97 ± 0.4%** 🏆 |
| unidirectional_lockless/16384 | 3.28 ± 0.7% | **3.45 ± 0.3%** 🏆 |
| unidirectional_lockless/65536 | 7.58 ± 1.6% | **7.75 ± 7.4%** 🏆 |
| unidirectional_lockless/262144 | 10.59 ± 1.0% | **10.70 ± 0.5%** 🏆 |
| unidirectional_lockless/1048576 | 10.62 ± 1.4% | **10.80 ± 0.3%** 🏆 |

## local_socket_throughput (GB/s)

| Benchmark | develop (GB/s) | recv-send (GB/s) |
|-----------|---|---|
| bidirectional/1024 | 0.60 ± 0.8% | **0.67 ± 0.7%** 🏆 |
| bidirectional/4096 | 2.00 ± 1.2% | **2.22 ± 0.8%** 🏆 |
| bidirectional/16384 | 6.50 ± 1.6% | **7.14 ± 0.6%** 🏆 |
| bidirectional/65536 | 9.45 ± 1.2% | **9.66 ± 3.4%** 🏆 |
| bidirectional/262144 | 10.90 ± 1.5% | **11.08 ± 1.2%** 🏆 |
| bidirectional/1048576 | 10.91 ± 2.0% | **11.05 ± 0.6%** 🏆 |
| bidirectional_lockless/1024 | 0.61 ± 1.3% | **0.67 ± 0.3%** 🏆 |
| bidirectional_lockless/4096 | 2.00 ± 1.2% | **2.21 ± 0.7%** 🏆 |
| bidirectional_lockless/16384 | 6.51 ± 1.2% | **7.15 ± 1.1%** 🏆 |
| bidirectional_lockless/65536 | 9.52 ± 1.6% | **9.73 ± 1.2%** 🏆 |
| bidirectional_lockless/262144 | 11.02 ± 1.6% | **11.11 ± 1.4%** 🏆 |
| bidirectional_lockless/1048576 | 10.92 ± 2.2% | **11.06 ± 1.1%** 🏆 |
| unidirectional/1024 | 0.58 ± 1.4% | **0.65 ± 0.6%** 🏆 |
| unidirectional/4096 | 1.94 ± 1.0% | **2.15 ± 0.7%** 🏆 |
| unidirectional/16384 | 6.36 ± 1.9% | **6.97 ± 1.2%** 🏆 |
| unidirectional/65536 | 9.45 ± 1.5% | **9.82 ± 2.0%** 🏆 |
| unidirectional/262144 | 11.38 ± 2.8% | **11.72 ± 2.5%** 🏆 |
| unidirectional/1048576 | 11.59 ± 1.7% | **11.79 ± 2.0%** 🏆 |
| unidirectional_lockless/1024 | 0.59 ± 0.8% | **0.66 ± 0.8%** 🏆 |
| unidirectional_lockless/4096 | 1.95 ± 1.0% | **2.15 ± 0.4%** 🏆 |
| unidirectional_lockless/16384 | 6.37 ± 1.0% | **6.98 ± 0.7%** 🏆 |
| unidirectional_lockless/65536 | 9.52 ± 2.8% | **9.90 ± 2.1%** 🏆 |
| unidirectional_lockless/262144 | **11.69 ± 1.1%** 🏆 | 11.55 ± 3.8% |
| unidirectional_lockless/1048576 | 11.09 ± 7.7% | **11.41 ± 3.3%** 🏆 |

## socket_latency — ops/sec

| Benchmark | develop (ops/s) | recv-send (ops/s) |
|-----------|---|---|
| concurrent/1 | 128.00K ± 1.2% | **135.40K ± 0.4%** 🏆 |
| concurrent/4 | 132.74K ± 1.0% | **140.30K ± 0.3%** 🏆 |
| concurrent/16 | 133.64K ± 1.0% | **141.55K ± 0.2%** 🏆 |
| concurrent_lockless/1 | 128.59K ± 0.8% | **135.77K ± 0.4%** 🏆 |
| concurrent_lockless/4 | 133.09K ± 0.8% | **141.02K ± 0.3%** 🏆 |
| concurrent_lockless/16 | 134.14K ± 0.8% | **142.00K ± 0.3%** 🏆 |
| pingpong/1 | 128.04K ± 1.0% | **135.26K ± 0.2%** 🏆 |
| pingpong/64 | 128.22K ± 1.1% | **134.98K ± 0.5%** 🏆 |
| pingpong/1024 | 126.96K ± 1.0% | **134.01K ± 0.3%** 🏆 |
| pingpong_lockless/1 | 128.80K ± 0.9% | **136.07K ± 0.3%** 🏆 |
| pingpong_lockless/64 | 128.66K ± 0.9% | **135.94K ± 0.3%** 🏆 |
| pingpong_lockless/1024 | 127.46K ± 1.1% | **134.52K ± 0.1%** 🏆 |

## socket_latency — p50

| Benchmark | develop (p50) | recv-send (p50) |
|-----------|---|---|
| concurrent/1 | 7.82 µs ± 1.4% | **7.37 µs ± 0.4%** 🏆 |
| concurrent/4 | 34.41 µs ± 1.2% | **32.67 µs ± 0.5%** 🏆 |
| concurrent/16 | 143.28 µs ± 1.0% | **134.85 µs ± 0.2%** 🏆 |
| concurrent_lockless/1 | 7.79 µs ± 1.2% | **7.34 µs ± 0.4%** 🏆 |
| concurrent_lockless/4 | 34.35 µs ± 1.1% | **32.42 µs ± 0.7%** 🏆 |
| concurrent_lockless/16 | 142.56 µs ± 0.8% | **134.37 µs ± 0.3%** 🏆 |
| pingpong/1 | 7.83 µs ± 1.3% | **7.40 µs ± 0.6%** 🏆 |
| pingpong/64 | 7.82 µs ± 1.2% | **7.41 µs ± 0.8%** 🏆 |
| pingpong/1024 | 7.87 µs ± 1.3% | **7.44 µs ± 0.6%** 🏆 |
| pingpong_lockless/1 | 7.78 µs ± 1.1% | **7.34 µs ± 0.4%** 🏆 |
| pingpong_lockless/64 | 7.78 µs ± 1.2% | **7.33 µs ± 0.4%** 🏆 |
| pingpong_lockless/1024 | 7.83 µs ± 1.3% | **7.40 µs ± 0.2%** 🏆 |

## socket_latency — p99

| Benchmark | develop (p99) | recv-send (p99) |
|-----------|---|---|
| concurrent/1 | 10.10 µs ± 2.0% | **9.51 µs ± 1.7%** 🏆 |
| concurrent/4 | 42.57 µs ± 1.1% | **40.55 µs ± 1.0%** 🏆 |
| concurrent/16 | 168.33 µs ± 1.1% | **160.94 µs ± 0.3%** 🏆 |
| concurrent_lockless/1 | 9.94 µs ± 4.3% | **9.51 µs ± 2.5%** 🏆 |
| concurrent_lockless/4 | 42.07 µs ± 0.9% | **40.30 µs ± 0.8%** 🏆 |
| concurrent_lockless/16 | 169.46 µs ± 1.1% | **161.31 µs ± 0.7%** 🏆 |
| pingpong/1 | 9.91 µs ± 0.6% | **9.34 µs ± 3.8%** 🏆 |
| pingpong/64 | 10.00 µs ± 3.6% | **9.49 µs ± 2.1%** 🏆 |
| pingpong/1024 | 10.15 µs ± 2.0% | **9.62 µs ± 2.0%** 🏆 |
| pingpong_lockless/1 | 9.87 µs ± 1.6% | **9.35 µs ± 1.3%** 🏆 |
| pingpong_lockless/64 | 10.01 µs ± 1.0% | **9.53 µs ± 0.6%** 🏆 |
| pingpong_lockless/1024 | 9.98 µs ± 0.5% | **9.48 µs ± 1.4%** 🏆 |

## local_socket_latency — ops/sec

| Benchmark | develop (ops/s) | recv-send (ops/s) |
|-----------|---|---|
| concurrent/1 | 263.50K ± 1.2% | **297.86K ± 0.4%** 🏆 |
| concurrent/4 | 280.92K ± 1.0% | **317.39K ± 1.0%** 🏆 |
| concurrent/16 | 288.71K ± 1.1% | **325.14K ± 0.4%** 🏆 |
| concurrent_lockless/1 | 265.40K ± 1.9% | **294.06K ± 2.6%** 🏆 |
| concurrent_lockless/4 | 283.43K ± 1.6% | **322.63K ± 1.1%** 🏆 |
| concurrent_lockless/16 | 289.05K ± 0.9% | **327.32K ± 0.5%** 🏆 |
| pingpong/1 | 263.57K ± 1.6% | **298.07K ± 0.4%** 🏆 |
| pingpong/64 | 258.07K ± 3.7% | **290.86K ± 2.8%** 🏆 |
| pingpong/1024 | 254.26K ± 3.7% | **279.52K ± 3.2%** 🏆 |
| pingpong_lockless/1 | 266.42K ± 0.9% | **294.22K ± 3.2%** 🏆 |
| pingpong_lockless/64 | 261.83K ± 2.4% | **295.67K ± 1.7%** 🏆 |
| pingpong_lockless/1024 | 255.53K ± 3.6% | **283.83K ± 3.5%** 🏆 |

## local_socket_latency — p50

| Benchmark | develop (p50) | recv-send (p50) |
|-----------|---|---|
| concurrent/1 | 3.84 µs ± 1.2% | **3.40 µs ± 0.7%** 🏆 |
| concurrent/4 | 16.72 µs ± 1.0% | **14.81 µs ± 1.0%** 🏆 |
| concurrent/16 | 67.86 µs ± 1.3% | **60.09 µs ± 0.5%** 🏆 |
| concurrent_lockless/1 | 3.81 µs ± 1.3% | **3.43 µs ± 2.4%** 🏆 |
| concurrent_lockless/4 | 16.60 µs ± 1.5% | **14.56 µs ± 1.2%** 🏆 |
| concurrent_lockless/16 | 67.66 µs ± 0.9% | **59.56 µs ± 0.7%** 🏆 |
| pingpong/1 | 3.85 µs ± 1.5% | **3.40 µs ± 0.4%** 🏆 |
| pingpong/64 | 3.95 µs ± 4.3% | **3.46 µs ± 3.2%** 🏆 |
| pingpong/1024 | 4.00 µs ± 4.2% | **3.62 µs ± 3.4%** 🏆 |
| pingpong_lockless/1 | 3.81 µs ± 1.1% | **3.44 µs ± 3.5%** 🏆 |
| pingpong_lockless/64 | 3.86 µs ± 2.6% | **3.40 µs ± 1.2%** 🏆 |
| pingpong_lockless/1024 | 3.96 µs ± 3.6% | **3.57 µs ± 3.7%** 🏆 |

## local_socket_latency — p99

| Benchmark | develop (p99) | recv-send (p99) |
|-----------|---|---|
| concurrent/1 | 4.24 µs ± 6.0% | **3.78 µs ± 8.6%** 🏆 |
| concurrent/4 | 20.33 µs ± 0.5% | **18.16 µs ± 0.1%** 🏆 |
| concurrent/16 | 73.04 µs ± 0.6% | **65.47 µs ± 0.4%** 🏆 |
| concurrent_lockless/1 | 4.06 µs ± 3.1% | **3.94 µs ± 13.7%** 🏆 |
| concurrent_lockless/4 | 20.22 µs ± 2.6% | **17.87 µs ± 1.5%** 🏆 |
| concurrent_lockless/16 | 73.72 µs ± 1.6% | **65.83 µs ± 1.2%** 🏆 |
| pingpong/1 | 4.24 µs ± 2.4% | **3.79 µs ± 1.7%** 🏆 |
| pingpong/64 | 4.22 µs ± 3.3% | **3.91 µs ± 9.1%** 🏆 |
| pingpong/1024 | 4.37 µs ± 7.2% | **4.09 µs ± 10.4%** 🏆 |
| pingpong_lockless/1 | 4.08 µs ± 2.7% | **3.79 µs ± 8.0%** 🏆 |
| pingpong_lockless/64 | 4.33 µs ± 5.9% | **3.83 µs ± 5.1%** 🏆 |
| pingpong_lockless/1024 | 4.32 µs ± 5.7% | **3.99 µs ± 5.2%** 🏆 |

## accept_churn (ops/s)

| Benchmark | develop (ops/s) | recv-send (ops/s) |
|-----------|---|---|
| burst/10 | 4.10K ± 0.5% | **4.12K ± 0.3%** 🏆 |
| burst/100 | 0.39K ± 0.4% | **0.40K ± 0.5%** 🏆 |
| burst_lockless/10 | 4.10K ± 0.6% | **4.11K ± 0.2%** 🏆 |
| burst_lockless/100 | 0.40K ± 0.6% | **0.40K ± 0.7%** 🏆 |
| concurrent/1 | 33.43K ± 1.0% | **33.87K ± 0.2%** 🏆 |
| concurrent/4 | 33.57K ± 0.7% | **33.93K ± 0.2%** 🏆 |
| concurrent/16 | 33.40K ± 0.8% | **33.58K ± 0.6%** 🏆 |
| sequential | 33.44K ± 0.9% | **33.86K ± 0.3%** 🏆 |
| sequential_lockless | 33.61K ± 0.8% | **33.88K ± 0.4%** 🏆 |

## fan_out (ops/s)

| Benchmark | develop (ops/s) | recv-send (ops/s) |
|-----------|---|---|
| concurrent_parents/1 | 7.40K ± 0.8% | **7.76K ± 0.1%** 🏆 |
| concurrent_parents/4 | 7.21K ± 1.1% | **7.57K ± 0.3%** 🏆 |
| concurrent_parents/16 | 7.10K ± 1.0% | **7.40K ± 0.4%** 🏆 |
| concurrent_parents_lockless/1 | 7.47K ± 0.9% | **7.80K ± 0.2%** 🏆 |
| concurrent_parents_lockless/4 | 7.27K ± 0.9% | **7.59K ± 0.2%** 🏆 |
| concurrent_parents_lockless/16 | 7.11K ± 0.7% | **7.45K ± 0.2%** 🏆 |
| fork_join/1 | 102.50K ± 0.9% | **106.39K ± 0.2%** 🏆 |
| fork_join/4 | 28.75K ± 0.9% | **30.10K ± 0.3%** 🏆 |
| fork_join/16 | 7.42K ± 1.0% | **7.74K ± 0.1%** 🏆 |
| fork_join/64 | 1.81K ± 1.1% | **1.89K ± 0.2%** 🏆 |
| fork_join_lockless/1 | 103.68K ± 0.9% | **107.71K ± 0.4%** 🏆 |
| fork_join_lockless/4 | 28.94K ± 1.1% | **30.19K ± 0.4%** 🏆 |
| fork_join_lockless/16 | 7.46K ± 0.9% | **7.79K ± 0.2%** 🏆 |
| fork_join_lockless/64 | 1.82K ± 0.8% | **1.90K ± 0.3%** 🏆 |
| nested/4 | 7.35K ± 1.1% | **7.70K ± 0.3%** 🏆 |
| nested/16 | 1.80K ± 1.0% | **1.88K ± 0.3%** 🏆 |
| nested_lockless/4 | 7.41K ± 1.0% | **7.75K ± 0.1%** 🏆 |
| nested_lockless/16 | 1.81K ± 1.0% | **1.89K ± 0.2%** 🏆 |

## http_server (ops/s)

| Benchmark | develop (ops/s) | recv-send (ops/s) |
|-----------|---|---|
| concurrent/1 | 106.42K ± 0.9% | **110.75K ± 0.4%** 🏆 |
| concurrent/4 | 114.05K ± 0.8% | **118.41K ± 0.6%** 🏆 |
| concurrent/16 | 115.90K ± 0.8% | **120.20K ± 0.3%** 🏆 |
| concurrent/32 | 114.77K ± 0.8% | **119.17K ± 0.2%** 🏆 |
| multithread/1 | 114.65K ± 0.7% | **119.37K ± 0.4%** 🏆 |
| multithread/2 | 215.15K ± 0.9% | **222.44K ± 0.7%** 🏆 |
| multithread/4 | 363.40K ± 1.2% | **375.39K ± 0.9%** 🏆 |
| multithread/8 | 549.83K ± 3.1% | **556.06K ± 4.7%** 🏆 |
| multithread/16 | 606.24K ± 8.2% | **609.25K ± 3.9%** 🏆 |
| single_conn | 106.42K ± 1.3% | **110.89K ± 0.3%** 🏆 |
| single_conn_lockless | 107.34K ± 1.0% | **111.80K ± 0.2%** 🏆 |