### PR TITLE
feat(io_context): concurrency_hint heuristic and single_threaded tie-up

### DIFF
--- a/doc/modules/ROOT/pages/4.guide/4c2.configuration.adoc
+++ b/doc/modules/ROOT/pages/4.guide/4c2.configuration.adoc
@@ -110,6 +110,19 @@ a re-queue through the scheduler.
 * *Single-threaded contexts*:
   `unassisted_budget` caps the budget when only one thread is
   running the event loop, preserving fairness.
+* *Disable the fast path entirely*: set all three options to 0 to
+  force a re-queue on every completion (useful as a baseline or
+  when a workload is dominated by cross-thread work-stealing).
+
+[NOTE]
+====
+When `io_context` is constructed with `concurrency_hint > 1` and all
+three budget fields are at their defaults `(2, 16, 4)`, the
+constructor overrides them to `(0, 0, 0)`.  Multi-thread workloads
+benefit from cross-thread work-stealing, which "post-everything"
+mode enables.  Setting any budget field to a non-default value
+disables the override.
+====
 
 === IOCP Timeout (`gqcs_timeout_ms`)
 

--- a/include/boost/corosio/io_context.hpp
+++ b/include/boost/corosio/io_context.hpp
@@ -64,6 +64,13 @@ struct io_context_options
         After a posted handler executes, the reactor grants this
         many speculative inline completions before forcing a
         re-queue. Applies to reactor backends only.
+
+        @note Constructing an `io_context` with `concurrency_hint > 1`
+            and all three budget fields at their defaults overrides
+            them to disable inline completion (post-everything mode),
+            since multi-thread workloads benefit from cross-thread
+            work-stealing. Setting any budget field to a non-default
+            value disables the override.
     */
     unsigned inline_budget_initial = 2;
 
@@ -112,6 +119,11 @@ struct io_context_options
         - DNS resolution returns `operation_not_supported`.
         - POSIX file I/O returns `operation_not_supported`.
         - Signal sets should not be shared across contexts.
+
+        @note Constructing an `io_context` with `concurrency_hint == 1`
+            automatically enables single-threaded mode regardless of
+            this field's value, matching asio's convention. To opt out,
+            pass `concurrency_hint > 1`.
     */
     bool single_threaded = false;
 };
@@ -158,7 +170,12 @@ class BOOST_COROSIO_DECL io_context : public capy::execution_context
     void apply_options_pre_(io_context_options const& opts);
 
     /// Apply runtime tuning to the scheduler (after construct).
-    void apply_options_post_(io_context_options const& opts);
+    void apply_options_post_(
+        io_context_options const& opts,
+        unsigned concurrency_hint);
+
+    /// Switch the scheduler to single-threaded (lockless) mode.
+    void configure_single_threaded_();
 
 protected:
     detail::timer_service* timer_svc_ = nullptr;
@@ -168,7 +185,14 @@ public:
     /** The executor type for this context. */
     class executor_type;
 
-    /** Construct with default concurrency and platform backend. */
+    /** Construct with default concurrency and platform backend.
+
+        Uses `std::thread::hardware_concurrency()` clamped to a minimum
+        of 2 as the concurrency hint, so the default constructor never
+        silently engages single-threaded mode (see
+        @ref io_context_options::single_threaded). Pass an explicit
+        `concurrency_hint == 1` to opt into single-threaded mode.
+    */
     io_context();
 
     /** Construct with a concurrency hint and platform backend.
@@ -206,6 +230,8 @@ public:
     {
         (void)backend;
         sched_ = &Backend::construct(*this, concurrency_hint);
+        if (concurrency_hint == 1)
+            configure_single_threaded_();
     }
 
     /** Construct with an explicit backend tag and runtime options.
@@ -229,7 +255,7 @@ public:
         (void)backend;
         apply_options_pre_(opts);
         sched_ = &Backend::construct(*this, concurrency_hint);
-        apply_options_post_(opts);
+        apply_options_post_(opts, concurrency_hint);
     }
 
     ~io_context();

--- a/include/boost/corosio/native/detail/reactor/reactor_scheduler.hpp
+++ b/include/boost/corosio/native/detail/reactor/reactor_scheduler.hpp
@@ -413,10 +413,9 @@ reactor_scheduler::configure_reactor(
         max_events > static_cast<unsigned>(std::numeric_limits<int>::max()))
         throw std::out_of_range(
             "max_events_per_poll must be in [1, INT_MAX]");
-    if (budget_max < 1 ||
-        budget_max > static_cast<unsigned>(std::numeric_limits<int>::max()))
+    if (budget_max > static_cast<unsigned>(std::numeric_limits<int>::max()))
         throw std::out_of_range(
-            "inline_budget_max must be in [1, INT_MAX]");
+            "inline_budget_max must be in [0, INT_MAX]");
 
     // Clamp initial and unassisted to budget_max.
     if (budget_init > budget_max)
@@ -433,6 +432,10 @@ reactor_scheduler::configure_reactor(
 inline void
 reactor_scheduler::reset_inline_budget() const noexcept
 {
+    // When budget is disabled (max==0), all paths below would no-op
+    // (inline_budget stays 0). Skip the TLS lookup entirely.
+    if (inline_budget_max_ == 0)
+        return;
     if (auto* ctx = reactor_find_context(this))
     {
         // Cap when no other thread absorbed queued work
@@ -444,10 +447,11 @@ reactor_scheduler::reset_inline_budget() const noexcept
                 static_cast<int>(unassisted_budget_);
             return;
         }
-        // Ramp up when previous cycle fully consumed budget
+        // Ramp up when previous cycle fully consumed budget.
+        // max(1, ...) ensures the doubling escapes zero.
         if (ctx->inline_budget == 0)
             ctx->inline_budget_max = (std::min)(
-                ctx->inline_budget_max * 2,
+                (std::max)(1, ctx->inline_budget_max) * 2,
                 static_cast<int>(inline_budget_max_));
         else if (ctx->inline_budget < ctx->inline_budget_max)
             ctx->inline_budget_max =
@@ -459,6 +463,8 @@ reactor_scheduler::reset_inline_budget() const noexcept
 inline bool
 reactor_scheduler::try_consume_inline_budget() const noexcept
 {
+    if (inline_budget_max_ == 0)
+        return false;
     if (auto* ctx = reactor_find_context(this))
     {
         if (ctx->inline_budget > 0)

--- a/perf/bench/corosio/accept_churn_bench.cpp
+++ b/perf/bench/corosio/accept_churn_bench.cpp
@@ -133,7 +133,7 @@ bench_sequential_churn_lockless(bench::state& state)
 
     corosio::io_context_options opts;
     opts.single_threaded = true;
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
     acceptor_type acc(ioc);
     acc.open();
     acc.set_option(corosio::native_socket_option::reuse_address(true));
@@ -398,7 +398,7 @@ bench_burst_churn_lockless(bench::state& state)
 
     corosio::io_context_options opts;
     opts.single_threaded = true;
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
     acceptor_type acc(ioc);
     acc.open();
     acc.set_option(corosio::native_socket_option::reuse_address(true));

--- a/perf/bench/corosio/fan_out_bench.cpp
+++ b/perf/bench/corosio/fan_out_bench.cpp
@@ -337,7 +337,7 @@ bench_fork_join_lockless(bench::state& state)
 
     corosio::io_context_options opts;
     opts.single_threaded = true;
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
 
     std::vector<socket_type> clients;
     std::vector<socket_type> servers;
@@ -414,7 +414,7 @@ bench_nested_lockless(bench::state& state)
 
     corosio::io_context_options opts;
     opts.single_threaded = true;
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
 
     std::vector<socket_type> clients;
     std::vector<socket_type> servers;
@@ -509,7 +509,7 @@ bench_concurrent_parents_lockless(bench::state& state)
 
     corosio::io_context_options opts;
     opts.single_threaded = true;
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
 
     std::vector<socket_type> clients;
     std::vector<socket_type> servers;

--- a/perf/bench/corosio/http_server_bench.cpp
+++ b/perf/bench/corosio/http_server_bench.cpp
@@ -156,7 +156,7 @@ bench_single_connection_lockless(bench::state& state)
 
     corosio::io_context_options opts;
     opts.single_threaded = true;
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
     auto [client, server] = corosio::test::make_socket_pair<
         socket_type, corosio::native_tcp_acceptor<Backend>>(ioc);
 

--- a/perf/bench/corosio/io_context_bench.cpp
+++ b/perf/bench/corosio/io_context_bench.cpp
@@ -265,7 +265,7 @@ bench_single_threaded_lockless(bench::state& state)
     corosio::io_context_options opts;
     opts.single_threaded = true;
 
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
     auto ex                  = ioc.get_executor();
     int64_t counter          = 0;
     int constexpr batch_size = 1000;
@@ -299,7 +299,7 @@ bench_interleaved_lockless(bench::state& state)
 
     int handlers_per_iteration = 100;
 
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
     auto ex         = ioc.get_executor();
     int64_t counter = 0;
 

--- a/perf/bench/corosio/local_socket_latency_bench.cpp
+++ b/perf/bench/corosio/local_socket_latency_bench.cpp
@@ -155,7 +155,7 @@ bench_unix_pingpong_latency_lockless(bench::state& state)
 
     corosio::io_context_options opts;
     opts.single_threaded = true;
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
     auto [client, server] = corosio::make_local_stream_pair(ioc);
 
     capy::run_async(ioc.get_executor())(
@@ -185,7 +185,7 @@ bench_unix_concurrent_latency_lockless(bench::state& state)
 
     corosio::io_context_options opts;
     opts.single_threaded = true;
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
 
     std::vector<corosio::local_stream_socket> clients;
     std::vector<corosio::local_stream_socket> servers;

--- a/perf/bench/corosio/local_socket_throughput_bench.cpp
+++ b/perf/bench/corosio/local_socket_throughput_bench.cpp
@@ -183,7 +183,7 @@ bench_unix_throughput_lockless(bench::state& state)
 
     corosio::io_context_options opts;
     opts.single_threaded = true;
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
     auto [writer, reader] = corosio::make_local_stream_pair(ioc);
 
     std::vector<char> write_buf(chunk_size, 'x');
@@ -243,7 +243,7 @@ bench_unix_bidirectional_throughput_lockless(bench::state& state)
 
     corosio::io_context_options opts;
     opts.single_threaded = true;
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
     auto [sock1, sock2] = corosio::make_local_stream_pair(ioc);
 
     std::vector<char> buf1(chunk_size, 'a');

--- a/perf/bench/corosio/socket_latency_bench.cpp
+++ b/perf/bench/corosio/socket_latency_bench.cpp
@@ -168,7 +168,7 @@ bench_pingpong_latency_lockless(bench::state& state)
 
     corosio::io_context_options opts;
     opts.single_threaded = true;
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
     auto [client, server] = corosio::test::make_socket_pair<
         socket_type, corosio::native_tcp_acceptor<Backend>>(ioc);
 
@@ -204,7 +204,7 @@ bench_concurrent_latency_lockless(bench::state& state)
 
     corosio::io_context_options opts;
     opts.single_threaded = true;
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
 
     std::vector<socket_type> clients;
     std::vector<socket_type> servers;

--- a/perf/bench/corosio/socket_throughput_bench.cpp
+++ b/perf/bench/corosio/socket_throughput_bench.cpp
@@ -255,7 +255,7 @@ bench_throughput_lockless(bench::state& state)
 
     corosio::io_context_options opts;
     opts.single_threaded = true;
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
     auto [writer, reader] = corosio::test::make_socket_pair<
         socket_type, corosio::native_tcp_acceptor<Backend>>(ioc);
 
@@ -321,7 +321,7 @@ bench_bidirectional_throughput_lockless(bench::state& state)
 
     corosio::io_context_options opts;
     opts.single_threaded = true;
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
     auto [sock1, sock2] = corosio::test::make_socket_pair<
         socket_type, corosio::native_tcp_acceptor<Backend>>(ioc);
 

--- a/perf/bench/corosio/timer_bench.cpp
+++ b/perf/bench/corosio/timer_bench.cpp
@@ -112,7 +112,7 @@ bench_schedule_cancel_lockless(bench::state& state)
 
     corosio::io_context_options opts;
     opts.single_threaded = true;
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
     int64_t counter          = 0;
     int constexpr batch_size = 1000;
 
@@ -148,7 +148,7 @@ bench_fire_rate_lockless(bench::state& state)
 
     corosio::io_context_options opts;
     opts.single_threaded = true;
-    corosio::native_io_context<Backend> ioc(opts);
+    corosio::native_io_context<Backend> ioc(opts, 1);
     std::atomic<bool> running{true};
     int64_t counter = 0;
 

--- a/src/corosio/src/io_context.cpp
+++ b/src/corosio/src/io_context.cpp
@@ -12,6 +12,7 @@
 #include <boost/corosio/backend.hpp>
 #include <boost/corosio/detail/thread_pool.hpp>
 
+#include <algorithm>
 #include <stdexcept>
 #include <thread>
 
@@ -141,19 +142,48 @@ pre_create_services(
 }
 
 // Apply runtime tuning to the scheduler after construction.
+//
+// Concurrency-hint heuristic for budget defaults: when the io_context is
+// constructed with concurrency_hint > 1 AND the user has not customized
+// the budget settings (i.e. they remain at the struct defaults), we
+// disable the inline-completion fast path. Multi-thread workloads
+// benefit from "always-post" because cross-thread work-stealing wins
+// over chained dispatch on the originating thread. Single-thread (or
+// any custom budget) keeps the user/library setting unchanged.
 void
 apply_scheduler_options(
     detail::scheduler& sched,
-    io_context_options const& opts)
+    io_context_options const& opts,
+    unsigned concurrency_hint)
 {
 #if BOOST_COROSIO_HAS_EPOLL || BOOST_COROSIO_HAS_KQUEUE || BOOST_COROSIO_HAS_SELECT
+    // Detect "user kept the defaults" by comparing all three to the
+    // io_context_options-defined struct defaults.
+    io_context_options defaults;
+    bool budget_at_defaults =
+        opts.inline_budget_initial == defaults.inline_budget_initial &&
+        opts.inline_budget_max == defaults.inline_budget_max &&
+        opts.unassisted_budget == defaults.unassisted_budget;
+
+    unsigned init = opts.inline_budget_initial;
+    unsigned max  = opts.inline_budget_max;
+    unsigned ua   = opts.unassisted_budget;
+
+    if (budget_at_defaults && concurrency_hint > 1)
+    {
+        // Multi-thread default: disable budget (post-everything).
+        init = 0;
+        max  = 0;
+        ua   = 0;
+    }
+
     auto& reactor =
         static_cast<detail::reactor_scheduler&>(sched);
     reactor.configure_reactor(
         opts.max_events_per_poll,
-        opts.inline_budget_initial,
-        opts.inline_budget_max,
-        opts.unassisted_budget);
+        init,
+        max,
+        ua);
     if (opts.single_threaded)
         reactor.configure_single_threaded(true);
 #endif
@@ -183,25 +213,40 @@ construct_default(capy::execution_context& ctx, unsigned concurrency_hint)
 #endif
 }
 
+// Tie concurrency_hint == 1 to single_threaded (asio precedent).
+io_context_options
+normalize_options(io_context_options opts, unsigned concurrency_hint)
+{
+    if (concurrency_hint == 1)
+        opts.single_threaded = true;
+    return opts;
+}
+
 } // anonymous namespace
 
-io_context::io_context() : io_context(std::thread::hardware_concurrency()) {}
+io_context::io_context()
+    : io_context(std::max(2u, std::thread::hardware_concurrency()))
+{
+}
 
 io_context::io_context(unsigned concurrency_hint)
     : capy::execution_context(this)
     , sched_(&construct_default(*this, concurrency_hint))
 {
+    if (concurrency_hint == 1)
+        configure_single_threaded_();
 }
 
 io_context::io_context(
-    io_context_options const& opts,
+    io_context_options const& opts_in,
     unsigned concurrency_hint)
     : capy::execution_context(this)
     , sched_(nullptr)
 {
+    auto opts = normalize_options(opts_in, concurrency_hint);
     pre_create_services(*this, opts);
     sched_ = &construct_default(*this, concurrency_hint);
-    apply_scheduler_options(*sched_, opts);
+    apply_scheduler_options(*sched_, opts, concurrency_hint);
 }
 
 void
@@ -211,9 +256,25 @@ io_context::apply_options_pre_(io_context_options const& opts)
 }
 
 void
-io_context::apply_options_post_(io_context_options const& opts)
+io_context::apply_options_post_(
+    io_context_options const& opts_in,
+    unsigned concurrency_hint)
 {
-    apply_scheduler_options(*sched_, opts);
+    auto opts = normalize_options(opts_in, concurrency_hint);
+    apply_scheduler_options(*sched_, opts, concurrency_hint);
+}
+
+void
+io_context::configure_single_threaded_()
+{
+#if BOOST_COROSIO_HAS_EPOLL || BOOST_COROSIO_HAS_KQUEUE || BOOST_COROSIO_HAS_SELECT
+    static_cast<detail::reactor_scheduler&>(*sched_)
+        .configure_single_threaded(true);
+#endif
+#if BOOST_COROSIO_HAS_IOCP
+    static_cast<detail::win_scheduler&>(*sched_)
+        .configure_single_threaded(true);
+#endif
 }
 
 io_context::~io_context()


### PR DESCRIPTION
Two related improvements to io_context construction:

1. Static heuristic for inline budget defaults: when concurrency_hint
   > 1 and the user has not customized budget options, override
   (init, max, unassisted) to (0, 0, 0). Multi-thread workloads benefit from cross-thread work-stealing, which "post everything" enables; single-thread keeps the (2, 16, 4) chaining defaults.

2. Tie concurrency_hint == 1 to single_threaded mode (asio precedent): constructing an io_context with concurrency_hint == 1 now forces opts.single_threaded = true, eliminating scheduler locking on the hot path. Matches asio's one_thread_ behavior. To opt out, pass concurrency_hint > 1.

Supporting changes:
  - reactor_scheduler: short-circuit try_consume_inline_budget and reset_inline_budget when inline_budget_max_ == 0 so post-everything mode skips TLS-list walks; relax configure_reactor validation to allow budget_max == 0; fix max(1, x) * 2 in ramp-up to escape zero.
  - io_context: apply_options_pre_/post_ now take concurrency_hint; new private configure_single_threaded_() helper used by the bare-hint and template no-opts constructors.
  - docs: update 4c2.configuration.adoc and io_context_options field docs to describe the queue-empty gating and new defaults.
  
  # Benchmark Results
  
  Results are statistically neutral for corosio_bench.
  
  ## evpp
  
| config           | develop  | HEAD     | delta      |
|------------------|---------:|---------:|-----------:|
|  1024 /   10 /  1 |  141.42 |   **144.32** 🏆 |  +2.1%     |
|  1024 /   10 /  4 |  438.69 |   **471.50** 🏆 |  +7.5%     |
|  1024 /  100 /  1 |  147.36 |   148.65 |  +0.9%     |
|  1024 /  100 /  4 |  474.55 |   **505.09** 🏆 |  +6.4%     |
|  4096 /   10 /  1 |  526.14 |   529.84 |  +0.7%     |
|  4096 /   10 /  4 | 1569.06 |  **1663.34** 🏆 |  +6.0%     |
|  4096 /  100 /  1 |  519.29 |   **527.87** 🏆 |  +1.7%     |
|  4096 /  100 /  4 | 1716.81 |  **1831.97** 🏆 |  +6.7%     |
| 16384 /   10 /  1 | 1683.25 |  1681.38 |  −0.1%     |
| 16384 /   10 /  4 | 4613.24 |  **4675.90** 🏆 |  +1.4%     |
| 16384 /  100 /  1 | 1654.33 |  **1681.86** 🏆 |  +1.7%     |
| 16384 /  100 /  4 | 5039.05 |  **5191.18** 🏆 |  +3.0%     |
|  1024 /  100 / 16 |  711.83 |   **837.31** 🏆 | +17.6% |
|  1024 / 1000 / 16 |  745.45 |   **837.28** 🏆 | +12.3% |
|  4096 /  100 / 16 | 2549.42 |  **2905.38** 🏆 | +14.0% |
|  4096 / 1000 / 16 | 2729.30 |  **2872.61** 🏆 |  +5.3%     |
| 16384 /  100 / 16 | 6601.52 |  **6868.91** 🏆 |  +4.1%     |
| 16384 / 1000 / 16 | 6059.62 |  6014.67 |  −0.7%     |
|  1024 / 1000 /  1 |  148.58 |   148.15 |  −0.3%     |
|  1024 / 1000 /  4 |  494.45 |   **527.01** 🏆 |  +6.6%     |
|  4096 / 1000 /  1 |  496.57 |   **502.11** 🏆 |  +1.1%     |
|  4096 / 1000 /  4 | 1773.26 |  **1873.82** 🏆 |  +5.7%     |
| 16384 / 1000 /  1 | 1595.20 |  **1620.16** 🏆 |  +1.6%     |
| 16384 / 1000 /  4 | 4698.05 |  **4775.52** 🏆 |  +1.6%     |

**Summary: 19 wins, 5 ties, 0 losses** (±1% threshold).