### PR TITLE
ci: pin latest MSVC matrix entry to windows-2022 (14.44)

### DIFF
--- a/.github/compilers.json
+++ b/.github/compilers.json
@@ -101,10 +101,10 @@
       "is_earliest": true
     },
     {
-      "version": "14.42",
+      "version": "14.44",
       "cxxstd": "20",
       "latest_cxxstd": "20",
-      "runs_on": "windows-2025",
+      "runs_on": "windows-2022",
       "b2_toolset": "msvc-14.4",
       "generator": "Visual Studio 17 2022",
       "is_latest": true


### PR DESCRIPTION
The windows-2025 runner label transiently resolved to a windows-2025-vs2026 image (Visual Studio 18 preview, MSVC 14.50) instead of the documented VS 2022 image, breaking the configure step because the hardcoded "Visual Studio 17 2022" generator can't match a VS 18 install.

Pin the latest MSVC entry to windows-2022, which has VS 2022 stable, until VS 18 reaches RTM and CMake ships the corresponding generator. Also bump the matrix version label from 14.42 to 14.44 so the job name matches the toolset actually shipped on windows-2022 (14.44.35207).