### PR TITLE
fix(umbrella): include connect.hpp and host_name.hpp

### DIFF
--- a/include/boost/corosio.hpp
+++ b/include/boost/corosio.hpp
@@ -12,8 +12,10 @@
 
 #include <boost/corosio/backend.hpp>
 #include <boost/corosio/cancel.hpp>
+#include <boost/corosio/connect.hpp>
 #include <boost/corosio/endpoint.hpp>
 #include <boost/corosio/file_base.hpp>
+#include <boost/corosio/host_name.hpp>
 #include <boost/corosio/io_context.hpp>
 #include <boost/corosio/ipv4_address.hpp>
 #include <boost/corosio/ipv6_address.hpp>


### PR DESCRIPTION
Both headers are standalone public APIs not reached transitively from anything else in the umbrella, so users who include only <boost/corosio.hpp> could not call corosio::connect or corosio::host_name without an extra include.