### PR TITLE
Migrate to capy post-#262 buffer API

### DIFF
--- a/include/boost/corosio/openssl_stream.hpp
+++ b/include/boost/corosio/openssl_stream.hpp
@@ -13,7 +13,7 @@
 #include <boost/corosio/detail/config.hpp>
 #include <boost/corosio/tls_context.hpp>
 #include <boost/corosio/tls_stream.hpp>
-#include <boost/capy/buffers/buffer_array.hpp>
+#include <boost/capy/detail/buffer_array.hpp>
 #include <boost/capy/concept/stream.hpp>
 #include <boost/capy/io/any_stream.hpp>
 #include <boost/capy/io_task.hpp>
@@ -188,10 +188,10 @@ public:
 
 protected:
     capy::io_task<std::size_t> do_read_some(
-        capy::mutable_buffer_array<capy::detail::max_iovec_> buffers) override;
+        capy::detail::mutable_buffer_array<capy::detail::max_iovec_> buffers) override;
 
     capy::io_task<std::size_t> do_write_some(
-        capy::const_buffer_array<capy::detail::max_iovec_> buffers) override;
+        capy::detail::const_buffer_array<capy::detail::max_iovec_> buffers) override;
 
 private:
     static impl* make_impl(capy::any_stream& stream, tls_context const& ctx);

--- a/include/boost/corosio/tls_stream.hpp
+++ b/include/boost/corosio/tls_stream.hpp
@@ -12,7 +12,7 @@
 
 #include <boost/corosio/detail/config.hpp>
 #include <boost/capy/buffers.hpp>
-#include <boost/capy/buffers/buffer_array.hpp>
+#include <boost/capy/detail/buffer_array.hpp>
 #include <boost/capy/io/any_stream.hpp>
 #include <boost/capy/io_task.hpp>
 
@@ -184,7 +184,7 @@ protected:
         @return An awaitable yielding `(error_code,std::size_t)`.
     */
     virtual capy::io_task<std::size_t> do_read_some(
-        capy::mutable_buffer_array<capy::detail::max_iovec_> buffers) = 0;
+        capy::detail::mutable_buffer_array<capy::detail::max_iovec_> buffers) = 0;
 
     /** Virtual write implementation.
 
@@ -196,7 +196,7 @@ protected:
         @return An awaitable yielding `(error_code,std::size_t)`.
     */
     virtual capy::io_task<std::size_t> do_write_some(
-        capy::const_buffer_array<capy::detail::max_iovec_> buffers) = 0;
+        capy::detail::const_buffer_array<capy::detail::max_iovec_> buffers) = 0;
 };
 
 } // namespace boost::corosio

--- a/include/boost/corosio/wolfssl_stream.hpp
+++ b/include/boost/corosio/wolfssl_stream.hpp
@@ -13,7 +13,7 @@
 #include <boost/corosio/detail/config.hpp>
 #include <boost/corosio/tls_context.hpp>
 #include <boost/corosio/tls_stream.hpp>
-#include <boost/capy/buffers/buffer_array.hpp>
+#include <boost/capy/detail/buffer_array.hpp>
 #include <boost/capy/concept/stream.hpp>
 #include <boost/capy/io/any_stream.hpp>
 #include <boost/capy/io_task.hpp>
@@ -188,10 +188,10 @@ public:
 
 protected:
     capy::io_task<std::size_t> do_read_some(
-        capy::mutable_buffer_array<capy::detail::max_iovec_> buffers) override;
+        capy::detail::mutable_buffer_array<capy::detail::max_iovec_> buffers) override;
 
     capy::io_task<std::size_t> do_write_some(
-        capy::const_buffer_array<capy::detail::max_iovec_> buffers) override;
+        capy::detail::const_buffer_array<capy::detail::max_iovec_> buffers) override;
 
 private:
     static impl* make_impl(capy::any_stream& stream, tls_context const& ctx);

--- a/src/openssl/src/openssl_stream.cpp
+++ b/src/openssl/src/openssl_stream.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/corosio/openssl_stream.hpp>
 #include <boost/corosio/detail/config.hpp>
-#include <boost/capy/buffers/buffer_array.hpp>
+#include <boost/capy/detail/buffer_array.hpp>
 #include <boost/capy/ex/async_mutex.hpp>
 #include <boost/capy/error.hpp>
 #include <boost/capy/write.hpp>
@@ -408,7 +408,7 @@ struct openssl_stream::impl
     }
 
     capy::io_task<std::size_t>
-    do_read_some(capy::mutable_buffer_array<capy::detail::max_iovec_> buffers)
+    do_read_some(capy::detail::mutable_buffer_array<capy::detail::max_iovec_> buffers)
     {
         std::error_code ec;
         std::size_t total_read = 0;
@@ -494,7 +494,7 @@ struct openssl_stream::impl
     }
 
     capy::io_task<std::size_t>
-    do_write_some(capy::const_buffer_array<capy::detail::max_iovec_> buffers)
+    do_write_some(capy::detail::const_buffer_array<capy::detail::max_iovec_> buffers)
     {
         std::error_code ec;
         std::size_t total_written = 0;
@@ -755,14 +755,14 @@ openssl_stream::operator=(openssl_stream&& other) noexcept
 
 capy::io_task<std::size_t>
 openssl_stream::do_read_some(
-    capy::mutable_buffer_array<capy::detail::max_iovec_> buffers)
+    capy::detail::mutable_buffer_array<capy::detail::max_iovec_> buffers)
 {
     co_return co_await impl_->do_read_some(buffers);
 }
 
 capy::io_task<std::size_t>
 openssl_stream::do_write_some(
-    capy::const_buffer_array<capy::detail::max_iovec_> buffers)
+    capy::detail::const_buffer_array<capy::detail::max_iovec_> buffers)
 {
     co_return co_await impl_->do_write_some(buffers);
 }

--- a/src/wolfssl/src/wolfssl_stream.cpp
+++ b/src/wolfssl/src/wolfssl_stream.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/corosio/wolfssl_stream.hpp>
 #include <boost/corosio/detail/config.hpp>
-#include <boost/capy/buffers/buffer_array.hpp>
+#include <boost/capy/detail/buffer_array.hpp>
 #include <boost/capy/ex/async_mutex.hpp>
 #include <boost/capy/error.hpp>
 #include <boost/capy/write.hpp>
@@ -442,7 +442,7 @@ struct wolfssl_stream::impl
     // Inner coroutines for TLS read/write operations
 
     capy::io_task<std::size_t>
-    do_read_some(capy::mutable_buffer_array<capy::detail::max_iovec_> buffers)
+    do_read_some(capy::detail::mutable_buffer_array<capy::detail::max_iovec_> buffers)
     {
         std::error_code ec;
         std::size_t total_read = 0;
@@ -570,7 +570,7 @@ struct wolfssl_stream::impl
     }
 
     capy::io_task<std::size_t>
-    do_write_some(capy::const_buffer_array<capy::detail::max_iovec_> buffers)
+    do_write_some(capy::detail::const_buffer_array<capy::detail::max_iovec_> buffers)
     {
         std::error_code ec;
         std::size_t total_written = 0;
@@ -1046,14 +1046,14 @@ wolfssl_stream::operator=(wolfssl_stream&& other) noexcept
 
 capy::io_task<std::size_t>
 wolfssl_stream::do_read_some(
-    capy::mutable_buffer_array<capy::detail::max_iovec_> buffers)
+    capy::detail::mutable_buffer_array<capy::detail::max_iovec_> buffers)
 {
     co_return co_await impl_->do_read_some(buffers);
 }
 
 capy::io_task<std::size_t>
 wolfssl_stream::do_write_some(
-    capy::const_buffer_array<capy::detail::max_iovec_> buffers)
+    capy::detail::const_buffer_array<capy::detail::max_iovec_> buffers)
 {
     co_return co_await impl_->do_write_some(buffers);
 }

--- a/test/unit/buffer_param.cpp
+++ b/test/unit/buffer_param.cpp
@@ -10,7 +10,7 @@
 // Test that header file is self-contained.
 #include <boost/corosio/detail/buffer_param.hpp>
 
-#include <boost/capy/buffers/buffer_pair.hpp>
+
 #include <span>
 #include <array>
 
@@ -62,7 +62,7 @@ struct buffer_param_test
     {
         char const data1[] = "Hello";
         char const data2[] = "World";
-        capy::const_buffer_pair cbp{
+        std::array<capy::const_buffer, 2> cbp{
             {capy::const_buffer(data1, 5), capy::const_buffer(data2, 5)}};
         check_copy(cbp, {{data1, 5}, {data2, 5}});
     }
@@ -71,7 +71,7 @@ struct buffer_param_test
     {
         char data1[] = "Hello";
         char data2[] = "World";
-        capy::mutable_buffer_pair mbp{
+        std::array<capy::mutable_buffer, 2> mbp{
             {capy::mutable_buffer(data1, 5), capy::mutable_buffer(data2, 5)}};
         check_copy(mbp, {{data1, 5}, {data2, 5}});
     }
@@ -162,7 +162,7 @@ struct buffer_param_test
         // Buffer pair with both zero-byte buffers
         char const data1[] = "Hello";
         char const data2[] = "World";
-        capy::const_buffer_pair cbp{
+        std::array<capy::const_buffer, 2> cbp{
             {capy::const_buffer(data1, 0), capy::const_buffer(data2, 0)}};
         check_empty(cbp);
     }
@@ -185,7 +185,7 @@ struct buffer_param_test
         // Zero-size buffer is skipped
         char const data1[] = "Hello";
         char const data2[] = "World";
-        capy::const_buffer_pair cbp{
+        std::array<capy::const_buffer, 2> cbp{
             {capy::const_buffer(data1, 0), capy::const_buffer(data2, 5)}};
         check_copy(cbp, {{data2, 5}});
     }
@@ -203,7 +203,7 @@ struct buffer_param_test
         // Mutable buffer pair with zero-byte buffers
         char data1[] = "Hello";
         char data2[] = "World";
-        capy::mutable_buffer_pair mbp{
+        std::array<capy::mutable_buffer, 2> mbp{
             {capy::mutable_buffer(data1, 0), capy::mutable_buffer(data2, 0)}};
         check_empty(mbp);
     }


### PR DESCRIPTION
cppalliance/capy#262 removes the `const_buffer_pair` / `mutable_buffer_pair` aliases and demotes `buffer_array<N, IsConst>` from `capy::` to `capy::detail::`. corosio migrates:

- `test/unit/buffer_param.cpp`: replace `capy::const_buffer_pair` / `capy::mutable_buffer_pair` with `std::array<capy::const_buffer, 2>` / `std::array<capy::mutable_buffer, 2>`. Drop the `buffers/buffer_pair.hpp` include.

- tls_stream.hpp / wolfssl_stream.{hpp,cpp} / openssl_stream.{hpp,cpp}: replace `capy::mutable_buffer_array<N>` / `capy::const_buffer_array<N>` with `capy::detail::mutable_buffer_array<N>` / `capy::detail::const_buffer_array<N>` and update include paths to `boost/capy/detail/buffer_array.hpp`. corosio's TLS stream interface acknowledges that this scatter/gather fixed-capacity helper is now capy-internal; using `detail::` from corosio is the explicit choice made when buffer_array became internal machinery.

Coordinated with capy PR cppalliance/capy#262.