### PR TITLE
fix(test): avoid AF_UNIX socket-file hang in temp_socket_dir teardown

### DIFF
--- a/include/boost/corosio/test/temp_path.hpp
+++ b/include/boost/corosio/test/temp_path.hpp
@@ -81,11 +81,17 @@ public:
 
     ~temp_socket_dir() noexcept
     {
-        if (!dir_.empty())
-        {
-            std::error_code ec;
-            std::filesystem::remove_all(dir_, ec);
-        }
+        if (dir_.empty())
+            return;
+
+        std::error_code ec;
+
+        // Unlink the socket file with C's std::remove from <cstdio>
+        // (deletes by name, no open) before remove_all, whose
+        // symlink_status opens AF_UNIX socket files via CreateFileW and
+        // hangs on Windows.
+        std::remove(path().c_str());
+        std::filesystem::remove_all(dir_, ec);
     }
 
     temp_socket_dir(temp_socket_dir const&)            = delete;


### PR DESCRIPTION
temp_socket_dir's destructor used std::filesystem::remove_all() on a directory holding a bound AF_UNIX socket file. remove_all() stats each entry via symlink_status(), which on Windows libstdc++ opens the file with CreateFileW; opening an AF_UNIX socket file hangs in ZwCreateFile, deadlocking teardown. This timed out the MinGW gcov coverage build (1500s) in local_stream_socket.iocp, native.local_stream_socket.iocp and wait.iocp -- the only suites that bind AF_UNIX paths. MSVC STL stats without opening the file, so the regular CI and non-coverage builds were unaffected; the wait-reactor WSAPoll change in ca33581 addressed an unrelated subsystem (the hang is in test teardown).

Unlink the socket file with std::remove (deletes by name without opening it) before remove_all walks the now-empty directory. Portable, no platform branch.