### PR TITLE
fix(io_context): stop context when run_one_until deadline already ela…

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -26,6 +26,7 @@ on:
     paths:
       - 'src/**'
       - 'include/**'
+      - 'test/**'
       - '.github/workflows/code-coverage.yml'
   workflow_dispatch:
 

--- a/include/boost/corosio/io_context.hpp
+++ b/include/boost/corosio/io_context.hpp
@@ -414,10 +414,13 @@ public:
     run_one_until(std::chrono::time_point<Clock, Duration> const& abs_time)
     {
         typename Clock::time_point now = Clock::now();
-        while (now < abs_time)
+        for (;;)
         {
             auto rel_time = abs_time - now;
-            if (rel_time > std::chrono::seconds(1))
+            using rel_type = decltype(rel_time);
+            if (rel_time < rel_type::zero())
+                rel_time = rel_type::zero();
+            else if (rel_time > std::chrono::seconds(1))
                 rel_time = std::chrono::seconds(1);
 
             std::size_t s = sched_->wait_one(
@@ -430,8 +433,9 @@ public:
                 return s;
 
             now = Clock::now();
+            if (now >= abs_time)
+                return 0;
         }
-        return 0;
     }
 
     /** Process all ready work items without blocking.

--- a/include/boost/corosio/native/native_io_context.hpp
+++ b/include/boost/corosio/native/native_io_context.hpp
@@ -191,10 +191,13 @@ public:
     run_one_until(std::chrono::time_point<Clock, Duration> const& abs_time)
     {
         typename Clock::time_point now = Clock::now();
-        while (now < abs_time)
+        for (;;)
         {
             auto rel_time = abs_time - now;
-            if (rel_time > std::chrono::seconds(1))
+            using rel_type = decltype(rel_time);
+            if (rel_time < rel_type::zero())
+                rel_time = rel_type::zero();
+            else if (rel_time > std::chrono::seconds(1))
                 rel_time = std::chrono::seconds(1);
 
             std::size_t s = sched().wait_one(
@@ -207,8 +210,9 @@ public:
                 return s;
 
             now = Clock::now();
+            if (now >= abs_time)
+                return 0;
         }
-        return 0;
     }
 
     /** Process all ready work items without blocking.

--- a/test/unit/io_context.cpp
+++ b/test/unit/io_context.cpp
@@ -481,6 +481,28 @@ struct io_context_test
         BOOST_TEST(counter == 1);
     }
 
+    void testRunOneUntilExpiredDeadlineStops()
+    {
+        // An already-elapsed deadline with no work must still stop the
+        // context: run_one_until has to call wait_one at least once. This
+        // is the deterministic form of a valgrind/CI flake where the thread
+        // is preempted past the deadline before the first loop check, so
+        // wait_one (which holds the "no work -> stop" logic) was skipped.
+        io_context ioc;
+
+        auto past =
+            std::chrono::steady_clock::now() - std::chrono::milliseconds(1);
+        std::size_t n = ioc.run_one_until(past);
+        BOOST_TEST(n == 0);
+        BOOST_TEST(ioc.stopped());
+
+        // run_for with an already-elapsed deadline (run_until -> run_one_until)
+        ioc.restart();
+        n = ioc.run_for(std::chrono::milliseconds(-1));
+        BOOST_TEST(n == 0);
+        BOOST_TEST(ioc.stopped());
+    }
+
     void testRunFor()
     {
         io_context ioc;
@@ -784,6 +806,7 @@ struct io_context_test
         testStopAndRestart();
         testRunOneFor();
         testRunOneUntil();
+        testRunOneUntilExpiredDeadlineStops();
         testRunOneUntilLongDeadlineNoWork();
         testRunFor();
         testRunForWithOutstandingWork();

--- a/test/unit/native/native_io_context.cpp
+++ b/test/unit/native/native_io_context.cpp
@@ -151,6 +151,20 @@ struct native_io_context_test
         ex.on_work_finished();
     }
 
+    // An already-elapsed deadline with no work must still stop the context.
+    // run_one_until has to call wait_one (which holds the "no work -> stop"
+    // logic) at least once; the deterministic form of a valgrind/CI flake
+    // where preemption pushes now past the deadline before the first check.
+    void testIoContextRunOneUntilExpiredDeadlineStops()
+    {
+        native_io_context<Backend> ctx;
+        auto past =
+            std::chrono::steady_clock::now() - std::chrono::milliseconds(1);
+        auto n = ctx.run_one_until(past);
+        BOOST_TEST(n == 0u);
+        BOOST_TEST(ctx.stopped());
+    }
+
     void run()
     {
         testIoContextConstruct();
@@ -162,6 +176,7 @@ struct native_io_context_test
         testIoContextRun();
         testIoContextRunFor();
         testIoContextRunOneUntilLongDeadlineNoWork();
+        testIoContextRunOneUntilExpiredDeadlineStops();
         testIoContextRunForWithOutstandingWork();
     }
 };


### PR DESCRIPTION
…psed

run_one_until wrapped wait_one in a `while (now < abs_time)` loop, but the "no outstanding work -> stop" logic lives inside wait_one. When the deadline had already passed at the first loop check, the body was skipped, wait_one was never called, and the function returned 0 with stopped() == false, violating the documented contract.

Rewrite the loop to always issue at least one wait_one, clamping the relative timeout to [0, 1s] and rechecking the deadline at the bottom. This also prevents a negative timeout from mapping to an indefinite block when outstanding work is present.

Surfaced as a flaky testRunOneFor failure under valgrind, where the thread can be preempted past a 10ms deadline before the first check. Add deterministic regression tests using an already-elapsed deadline.