### PR TITLE
refactor: share the native op envelope, decode, socket accessors, and…

### DIFF
--- a/include/boost/corosio/native/detail/coro_op.hpp
+++ b/include/boost/corosio/native/detail/coro_op.hpp
@@ -1,0 +1,134 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_NATIVE_DETAIL_CORO_OP_HPP
+#define BOOST_COROSIO_NATIVE_DETAIL_CORO_OP_HPP
+
+#include <boost/corosio/detail/config.hpp>
+#include <boost/corosio/detail/continuation_op.hpp>
+#include <boost/corosio/detail/scheduler_op.hpp>
+#include <boost/capy/ex/executor_ref.hpp>
+
+#include <atomic>
+#include <coroutine>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <stop_token>
+#include <system_error>
+
+/*
+    Shared, non-template op envelope for every native backend — the readiness
+    reactors (epoll/kqueue/select), io_uring, and IOCP. It captures the part of
+    an async operation that is identical regardless of how completion is
+    reported: the coroutine to resume, the executor it dispatches on, the
+    output pointers, the stop_token wiring, the cancelled flag, and the
+    keepalive that holds the owning impl alive while the op is in flight.
+
+    What is deliberately NOT here (it differs by backend and stays in the
+    derived op layer):
+      - the result model: the reactors re-run the syscall and record
+        `errn`/`bytes_transferred` (reactor_op_base); io_uring stores the raw
+        `res`/`cqe_flags`; IOCP stores `dwError`/`bytes_transferred`. Each
+        decodes its own result.
+      - the submission + the kernel cancel action. Cancellation is unified only
+        at the call site via the virtual `on_cancel()` hook: the stop_callback
+        always targets `coro_op`, and each backend overrides `on_cancel()` —
+        the reactors route to the owning impl's cancel(), io_uring submits an
+        ASYNC_CANCEL SQE, IOCP calls the stored cancel_func_/CancelIoEx.
+
+    See tasks/proactor-dedup-decisions.md and coro-op-unification-scope.md.
+*/
+
+namespace boost::corosio::detail {
+
+/** Non-template op envelope shared by every native backend's operations.
+
+    `reactor_op_base`, `io_uring_op`, and `overlapped_op` all derive from this.
+    Derives from scheduler_op so ops queue intrusively and dispatch through the
+    function-pointer (io_uring/IOCP) or virtual (reactors) completion path —
+    hence both a default and a func_type constructor.
+
+    @note For IOCP, the concrete op multiply-inherits `OVERLAPPED` as its
+    first base (so `static_cast<OVERLAPPED*>` round-trips); `coro_op`
+    follows it.
+*/
+struct coro_op : scheduler_op
+{
+    /** Stop-callback handler: routes a stop_token firing to `on_cancel()`.
+
+        A single canceller type for both backends keeps `stop_cb` (and thus
+        `start()`) in this shared base; the backend-specific action lives
+        behind the `on_cancel()` virtual.
+    */
+    struct canceller
+    {
+        coro_op* op;
+        void operator()() const noexcept { op->on_cancel(); }
+    };
+
+    std::coroutine_handle<>  h;
+    detail::continuation_op  cont_op;
+    capy::executor_ref       ex;
+    std::error_code*         ec_out    = nullptr;
+    std::size_t*             bytes_out = nullptr;
+
+    /// True for receive/read ops (drives the zero-byte == EOF decision).
+    bool                     is_read      = false;
+    /// True when the submitted buffer was zero-length (suppresses EOF).
+    bool                     empty_buffer = false;
+
+    std::atomic<bool>                            cancelled{false};
+    std::optional<std::stop_callback<canceller>> stop_cb;
+
+    /// Keeps the owning impl alive while the op is in flight (the kernel
+    /// owns user buffers until completion). Dropped in the handler's resume
+    /// tail (see coro_op_complete.hpp).
+    std::shared_ptr<void>    impl_ptr;
+
+    /// Default-construct for virtual-dispatch backends (the reactors, which
+    /// override operator()/destroy() and leave func_ null).
+    coro_op() noexcept = default;
+
+    /// Construct with the completion function for func-pointer dispatch
+    /// (io_uring / IOCP completion handlers).
+    explicit coro_op(func_type func) noexcept : scheduler_op(func) {}
+
+    /** Arm the stop-token callback. Call before the op is submitted.
+
+        Resets the cancellation flag and (re)arms `stop_cb` against @a token.
+        Derived ops that carry extra pre-submit state (e.g. io_uring's
+        `sqe_set`) extend this.
+    */
+    void start(std::stop_token const& token)
+    {
+        cancelled.store(false, std::memory_order_relaxed);
+        stop_cb.reset();
+        if (token.stop_possible())
+            stop_cb.emplace(token, canceller{this});
+    }
+
+    /// Mark this op cancellation-requested. Shared by every backend.
+    void request_cancel() noexcept
+    {
+        cancelled.store(true, std::memory_order_release);
+    }
+
+    /** Backend cancellation hook, invoked when the stop_token fires.
+
+        The default just records the request. Backends override to also
+        drive the kernel: io_uring submits an ASYNC_CANCEL SQE; IOCP calls
+        its stored cancel_func_ (CancelIoEx / wait-reactor deregister).
+    */
+    virtual void on_cancel() noexcept { request_cancel(); }
+};
+
+} // namespace boost::corosio::detail
+
+#endif

--- a/include/boost/corosio/native/detail/coro_op_complete.hpp
+++ b/include/boost/corosio/native/detail/coro_op_complete.hpp
@@ -1,0 +1,136 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_NATIVE_DETAIL_CORO_OP_COMPLETE_HPP
+#define BOOST_COROSIO_NATIVE_DETAIL_CORO_OP_COMPLETE_HPP
+
+#include <boost/corosio/detail/dispatch_coro.hpp>
+#include <boost/corosio/native/detail/coro_op.hpp>
+#include <boost/capy/error.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <system_error>
+
+/*
+    Shared completion-tail helpers for proactor ops. Every IOCP and io_uring
+    I/O handler ends the same way once its backend-specific result has been
+    decoded into ec_out/bytes_out:
+
+      1. disarm the stop_callback,
+      2. on the shutdown-drain path (owner == nullptr) just break the
+         impl_ptr keepalive cycle and return without resuming,
+      3. otherwise resume the coroutine on its executor, dropping the
+         keepalive only after the continuation has been handed off.
+
+    The *decode* step (raw DWORD/res -> {ec, bytes, eof, canceled}) stays
+    backend-specific because the raw encodings differ; in Phase 3 it is
+    formalized as `Traits::decode_result`. These two helpers capture the
+    backend-agnostic prologue and resume tail so the per-op handlers shrink to
+    "drain-or-decode, then resume".
+*/
+
+namespace boost::corosio::detail {
+
+/** Translate a decoded I/O result into `*ec_out` using the cancelled /
+    error / EOF / success priority shared by every native backend.
+
+    The raw error encodings differ per backend (reactor positive `errno`,
+    io_uring negative `res`, IOCP `DWORD`), so the native-error -> error_code
+    step stays backend-local: the caller passes @a err already converted
+    (an empty error_code means "no error"). This helper owns only the
+    priority logic, which is byte-for-byte identical everywhere:
+
+        cancelled                          -> operation_canceled
+        err set                            -> err
+        is_read && bytes == 0 && !empty    -> end_of_file
+        otherwise                          -> success
+
+    Writes nothing when @a ec_out is null. Does not touch bytes_out — callers
+    that report a byte count write it separately (connect/wait carry none).
+
+    @param ec_out        Destination (may be null).
+    @param cancelled     The op's cancellation flag.
+    @param err           Backend error already converted to error_code, or a
+                         default-constructed error_code on success.
+    @param is_read       True only for reads that should map a 0-byte
+                         completion to EOF — false for writes, connect, wait,
+                         and datagrams (a 0-byte datagram is success, not EOF).
+    @param bytes         Bytes transferred (consulted only for the EOF test).
+    @param empty_buffer  True when the submitted buffer was zero-length,
+                         which suppresses the otherwise-spurious EOF.
+*/
+inline void
+decode_io_result(
+    std::error_code* ec_out,
+    bool             cancelled,
+    std::error_code  err,
+    bool             is_read,
+    std::size_t      bytes,
+    bool             empty_buffer) noexcept
+{
+    if (!ec_out)
+        return;
+    if (cancelled)
+        *ec_out = capy::error::canceled;
+    else if (err)
+        *ec_out = err;
+    else if (is_read && bytes == 0 && !empty_buffer)
+        *ec_out = capy::error::eof;
+    else
+        *ec_out = {};
+}
+
+/** Completion prologue shared by every proactor handler.
+
+    Disarms the stop_callback, then detects the shutdown-drain path.
+
+    @param owner The scheduler pointer (nullptr during shutdown drain).
+    @param self  The completing op.
+    @return True if this was a shutdown drain — the caller must `return`
+            immediately without decoding or resuming. On that path the
+            impl_ptr keepalive is dropped here (which may destroy the impl,
+            and with it the op storage).
+*/
+inline bool
+coro_drain_if_shutdown(void* owner, coro_op* self) noexcept
+{
+    self->stop_cb.reset();
+    if (owner == nullptr)
+    {
+        auto suicide = std::move(self->impl_ptr);
+        return true;
+    }
+    return false;
+}
+
+/** Resume tail shared by every proactor handler.
+
+    Resumes the op's coroutine on its executor and then drops the impl_ptr
+    keepalive. The keepalive is moved into a local that is released *after*
+    `resume()` returns, matching the existing io_uring ordering: the impl (and
+    therefore this op's storage) may be destroyed as the local goes out of
+    scope, so nothing may touch `*self` after the resume.
+
+    @pre `self->ec_out`/`bytes_out` have already been written by the
+         backend's decode step.
+*/
+inline void
+coro_resume(coro_op* self) noexcept
+{
+    self->cont_op.cont.h = self->h;
+    auto next = dispatch_coro(self->ex, self->cont_op.cont);
+    auto suicide = std::move(self->impl_ptr);
+    next.resume();
+    // suicide drops here; may destroy impl + self.
+}
+
+} // namespace boost::corosio::detail
+
+#endif

--- a/include/boost/corosio/native/detail/io_uring/io_uring_dgram_ops.hpp
+++ b/include/boost/corosio/native/detail/io_uring/io_uring_dgram_ops.hpp
@@ -18,6 +18,7 @@
 
 #include <boost/corosio/detail/dispatch_coro.hpp>
 #include <boost/corosio/native/detail/io_uring/io_uring_op.hpp>
+#include <boost/corosio/native/detail/coro_op_complete.hpp>
 #include <boost/corosio/native/detail/speculative_state.hpp>
 #include <boost/corosio/native/detail/io_uring/io_uring_socket_ops.hpp>
 #include <boost/corosio/native/detail/make_err.hpp>
@@ -132,23 +133,18 @@ struct uring_dgram_send_op : io_uring_op
         std::uint32_t /*bytes*/, std::uint32_t /*error*/) noexcept
     {
         auto* self = static_cast<uring_dgram_send_op*>(base);
-        self->stop_cb.reset();
-
-        if (owner == nullptr)
-        {
-            auto suicide = std::move(self->impl_ptr);
+        if (coro_drain_if_shutdown(owner, self))
             return;
-        }
 
-        if (self->ec_out)
-        {
-            if (self->cancelled.load(std::memory_order_acquire))
-                *self->ec_out = capy::error::canceled;
-            else if (self->res < 0)
-                *self->ec_out = make_err(-self->res);
-            else
-                *self->ec_out = {};
-        }
+        if (self->sched_)
+            self->sched_->reset_inline_budget();
+
+        // Datagram send: no EOF (a 0-byte send is success).
+        decode_io_result(
+            self->ec_out,
+            self->cancelled.load(std::memory_order_acquire),
+            self->res < 0 ? make_err(-self->res) : std::error_code{},
+            /*is_read=*/false, /*bytes=*/0, /*empty_buffer=*/false);
         if (self->bytes_out)
             *self->bytes_out = (self->res >= 0)
                 ? static_cast<std::size_t>(self->res) : 0;
@@ -159,10 +155,7 @@ struct uring_dgram_send_op : io_uring_op
             self->spec_state->on_async_write_ready();
         }
 
-        self->cont_op.cont.h = self->h;
-        auto next = dispatch_coro(self->ex, self->cont_op.cont);
-        auto suicide = std::move(self->impl_ptr);
-        next.resume();
+        coro_resume(self);
     }
 };
 
@@ -299,23 +292,19 @@ struct uring_dgram_recv_op : io_uring_op
         std::uint32_t /*bytes*/, std::uint32_t /*error*/) noexcept
     {
         auto* self = static_cast<uring_dgram_recv_op*>(base);
-        self->stop_cb.reset();
-
-        if (owner == nullptr)
-        {
-            auto suicide = std::move(self->impl_ptr);
+        if (coro_drain_if_shutdown(owner, self))
             return;
-        }
 
-        if (self->ec_out)
-        {
-            if (self->cancelled.load(std::memory_order_acquire))
-                *self->ec_out = capy::error::canceled;
-            else if (self->res < 0)
-                *self->ec_out = make_err(-self->res);
-            else
-                *self->ec_out = {};   // zero-byte datagram is success, not EOF
-        }
+        if (self->sched_)
+            self->sched_->reset_inline_budget();
+
+        // Datagram recv: a 0-byte datagram is success, not EOF — is_read
+        // stays false so the shared decode never maps it to end_of_file.
+        decode_io_result(
+            self->ec_out,
+            self->cancelled.load(std::memory_order_acquire),
+            self->res < 0 ? make_err(-self->res) : std::error_code{},
+            /*is_read=*/false, /*bytes=*/0, /*empty_buffer=*/false);
         if (self->bytes_out)
             *self->bytes_out = (self->res >= 0)
                 ? static_cast<std::size_t>(self->res) : 0;
@@ -332,10 +321,7 @@ struct uring_dgram_recv_op : io_uring_op
             self->source_writer(self->source_writer_ctx,
                 self->source_storage, self->source_len);
 
-        self->cont_op.cont.h = self->h;
-        auto next = dispatch_coro(self->ex, self->cont_op.cont);
-        auto suicide = std::move(self->impl_ptr);
-        next.resume();
+        coro_resume(self);
     }
 };
 

--- a/include/boost/corosio/native/detail/io_uring/io_uring_file_ops.hpp
+++ b/include/boost/corosio/native/detail/io_uring/io_uring_file_ops.hpp
@@ -16,6 +16,7 @@
 
 #include <boost/corosio/native/detail/io_uring/io_uring_op.hpp>
 #include <boost/corosio/native/detail/io_uring/io_uring_socket_ops.hpp>
+#include <boost/corosio/native/detail/coro_op_complete.hpp>
 #include <boost/corosio/detail/dispatch_coro.hpp>
 
 #include <cstdint>
@@ -136,17 +137,17 @@ struct uring_file_read_op : uring_file_read_op_base
         std::uint32_t /*bytes*/, std::uint32_t /*error*/) noexcept
     {
         auto* self = static_cast<uring_file_read_op*>(base);
-        self->stop_cb.reset();
-
-        if (owner == nullptr)
-        {
-            auto suicide = std::move(self->impl_ptr);
+        if (coro_drain_if_shutdown(owner, self))
             return;
-        }
 
-        auto next = finish(self);
-        auto suicide = std::move(self->impl_ptr);
-        next.resume();
+        if (self->sched_)
+            self->sched_->reset_inline_budget();
+
+        uring_set_result(self, /*is_read=*/true, self->empty_buffer);
+        if (self->bytes_out)
+            *self->bytes_out =
+                self->res >= 0 ? static_cast<std::size_t>(self->res) : 0u;
+        coro_resume(self);
     }
 };
 
@@ -273,17 +274,17 @@ struct uring_file_write_op : uring_file_write_op_base
         std::uint32_t /*bytes*/, std::uint32_t /*error*/) noexcept
     {
         auto* self = static_cast<uring_file_write_op*>(base);
-        self->stop_cb.reset();
-
-        if (owner == nullptr)
-        {
-            auto suicide = std::move(self->impl_ptr);
+        if (coro_drain_if_shutdown(owner, self))
             return;
-        }
 
-        auto next = finish(self);
-        auto suicide = std::move(self->impl_ptr);
-        next.resume();
+        if (self->sched_)
+            self->sched_->reset_inline_budget();
+
+        uring_set_result(self, /*is_read=*/false, self->empty_buffer);
+        if (self->bytes_out)
+            *self->bytes_out =
+                self->res >= 0 ? static_cast<std::size_t>(self->res) : 0u;
+        coro_resume(self);
     }
 };
 

--- a/include/boost/corosio/native/detail/io_uring/io_uring_file_service_base.hpp
+++ b/include/boost/corosio/native/detail/io_uring/io_uring_file_service_base.hpp
@@ -1,0 +1,128 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_NATIVE_DETAIL_IO_URING_IO_URING_FILE_SERVICE_BASE_HPP
+#define BOOST_COROSIO_NATIVE_DETAIL_IO_URING_IO_URING_FILE_SERVICE_BASE_HPP
+
+#include <boost/corosio/detail/platform.hpp>
+
+#if BOOST_COROSIO_HAS_IO_URING
+
+#include <boost/corosio/detail/intrusive.hpp>
+#include <boost/corosio/io/io_object.hpp>
+#include <boost/corosio/native/detail/io_uring/io_uring_scheduler.hpp>
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+/*
+    Shared lifecycle plumbing for io_uring file services.
+
+    io_uring_stream_file_service and io_uring_random_access_file_service were
+    byte-for-byte identical apart from the impl type and open_file's parameter
+    type: both make_shared the file impl from the scheduler, track it in an
+    intrusive list + raw->shared_ptr map, and close every file on shutdown.
+    This base factors that out; the concrete services add only open_file.
+
+    This is a separate base from io_uring_socket_service_base because file
+    services differ from socket services in three ways that match the reactor
+    socket service instead: they track via an intrusive list + map (sockets:
+    map only), they CLOSE files on shutdown (sockets: cancel only), and the
+    impl ctor takes just the scheduler (sockets: service + scheduler). See
+    tasks/proactor-dedup-decisions.md (#14).
+
+    Requirements on File: derive from enable_shared_from_this<File> and
+    intrusive_list<File>::node, a `File(io_uring_scheduler&)` constructor, and
+    a `void close_file() noexcept` method (cancel in-flight ops + close fd).
+
+    @tparam Derived     The concrete service (CRTP; unused today but kept for
+                        symmetry / future hooks).
+    @tparam ServiceBase The abstract service vtable base (file_service,
+                        random_access_file_service).
+    @tparam File        The concrete io_uring file impl type.
+*/
+
+namespace boost::corosio::detail {
+
+template<class Derived, class ServiceBase, class File>
+class io_uring_file_service_base : public ServiceBase
+{
+    friend Derived;
+
+    // Private CRTP ctor: only `Derived` (the concrete service, a friend)
+    // constructs the base — prevents inheriting with the wrong Derived
+    // (bugprone-crtp-constructor-accessibility).
+    explicit io_uring_file_service_base(io_uring_scheduler& sched) noexcept
+        : sched_(&sched)
+    {
+    }
+
+public:
+    ~io_uring_file_service_base() override = default;
+
+    io_object::implementation* construct() override
+    {
+        auto  ptr  = std::make_shared<File>(*sched_);
+        auto* impl = ptr.get();
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            file_list_.push_back(impl);
+            file_ptrs_[impl] = std::move(ptr);
+        }
+        return impl;
+    }
+
+    void destroy(io_object::implementation* p) override
+    {
+        // close_file() already does cancel_and_flush(fd_) before ::close.
+        auto& impl = static_cast<File&>(*p);
+        impl.close_file();
+        std::lock_guard<std::mutex> lock(mutex_);
+        file_list_.remove(&impl);
+        file_ptrs_.erase(&impl);
+    }
+
+    void close(io_object::handle& h) override
+    {
+        if (h.get())
+            static_cast<File&>(*h.get()).close_file();
+    }
+
+    void shutdown() override
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (auto* impl = file_list_.pop_front(); impl != nullptr;
+             impl       = file_list_.pop_front())
+        {
+            impl->close_file();
+        }
+        file_ptrs_.clear();
+    }
+
+    /// Return the scheduler used by files created by this service.
+    io_uring_scheduler& scheduler() noexcept { return *sched_; }
+
+protected:
+    io_uring_scheduler*  sched_;
+    std::mutex           mutex_;
+    intrusive_list<File> file_list_;
+    std::unordered_map<File*, std::shared_ptr<File>> file_ptrs_;
+
+private:
+    io_uring_file_service_base(io_uring_file_service_base const&) = delete;
+    io_uring_file_service_base&
+    operator=(io_uring_file_service_base const&) = delete;
+};
+
+} // namespace boost::corosio::detail
+
+#endif // BOOST_COROSIO_HAS_IO_URING
+
+#endif // BOOST_COROSIO_NATIVE_DETAIL_IO_URING_IO_URING_FILE_SERVICE_BASE_HPP

--- a/include/boost/corosio/native/detail/io_uring/io_uring_op.hpp
+++ b/include/boost/corosio/native/detail/io_uring/io_uring_op.hpp
@@ -14,36 +14,28 @@
 
 #if BOOST_COROSIO_HAS_IO_URING
 
-#include <boost/corosio/detail/continuation_op.hpp>
-#include <boost/corosio/detail/scheduler_op.hpp>
-#include <boost/capy/ex/executor_ref.hpp>
+#include <boost/corosio/native/detail/coro_op.hpp>
 
 // Forward declare to avoid circular include with io_uring_scheduler.hpp.
 namespace boost::corosio::detail { class io_uring_scheduler; }
 
 #include <atomic>
-#include <coroutine>
-#include <cstddef>
-#include <memory>
-#include <optional>
-#include <stop_token>
 
 #include <liburing.h>
 
 namespace boost::corosio::detail {
 
-/** Base class for io_uring operations.
+/** io_uring operation: the shared proactor op envelope plus the
+    io_uring-specific completion plumbing.
 
-    Holds per-operation state common to every uring op: coroutine
-    handle, executor for handler dispatch, output pointers, the
-    stop_token wiring for cancellation, and a function pointer
-    used by the scheduler to dispatch a CQE arrival.
-
-    Concrete op types (uring_read_op, uring_write_op, etc.) set
-    `cqe_func` at construction so the run loop's completion path
-    has zero virtual indirection.
+    `coro_op` supplies the fields common to both proactor backends
+    (coroutine handle, executor, output pointers, stop_token wiring,
+    impl_ptr keepalive). This type adds the CQE result (`res`/`cqe_flags`),
+    the ring-cancel visibility flag (`sqe_set`), and the two function
+    pointers the run loop uses to prep an SQE and dispatch a CQE without
+    template instantiation.
 */
-struct io_uring_op : scheduler_op
+struct io_uring_op : coro_op
 {
     /// CQE-side dispatcher type. Called once per completion event.
     /// Pushes self into `local` rather than dispatching inline so
@@ -59,38 +51,20 @@ struct io_uring_op : scheduler_op
     using prep_func_type =
         void (*)(io_uring_op*, ::io_uring_sqe*) noexcept;
 
-    /// Stop-callback handler: requests cancellation of this op.
-    struct canceller
-    {
-        io_uring_op* op;
-        void operator()() const noexcept { op->request_cancel(); }
-    };
-
     explicit io_uring_op(
         func_type      post_func,
         cqe_func_type  cqe_fn,
         prep_func_type prep_fn = nullptr) noexcept
-        : scheduler_op(post_func)
+        : coro_op(post_func)
         , cqe_func(cqe_fn)
         , prep_func(prep_fn)
     {}
 
-    std::coroutine_handle<>                      h;
-    detail::continuation_op                      cont_op;
-    capy::executor_ref                           ex;
-    std::error_code*                             ec_out    = nullptr;
-    std::size_t*                                 bytes_out = nullptr;
-
     int                                          res       = 0;
     unsigned                                     cqe_flags = 0;
-    bool                                         is_read      = false;
-    bool                                         empty_buffer = false;
-
-    std::atomic<bool>                            cancelled{false};
     /// True after `io_uring_sqe_set_data` has linked an SQE to this op.
-    /// Until then, request_cancel() has nothing for the kernel to find.
+    /// Until then, on_cancel() has nothing for the kernel to find.
     std::atomic<bool>                            sqe_set{false};
-    std::optional<std::stop_callback<canceller>> stop_cb;
     cqe_func_type                                cqe_func;
     /// SQE-preparation dispatcher. nullptr for ops still using the
     /// old `io_uring_submit_op<PrepFn>(prep)` template path
@@ -98,15 +72,8 @@ struct io_uring_op : scheduler_op
     /// migrated to the queue-based submit path.
     prep_func_type                               prep_func;
 
-    /// Keeps the owning impl alive while the op is in flight (kernel
-    /// owns user buffers until completion).
-    std::shared_ptr<void>                        impl_ptr;
-
     /// Scheduler reference for submitting cancel SQEs on stop_token.
     io_uring_scheduler*                          sched_ = nullptr;
-
-    void request_cancel() noexcept;
-
 
     /// Bridge virtual dispatch to func-pointer dispatch. Lets the run
     /// loop dispatch any scheduler_op via `(*op)()` — both reactor-style
@@ -116,14 +83,16 @@ struct io_uring_op : scheduler_op
     void operator()() override { complete(this, 0, 0); }
 
     /// Arm the stop-token callback. Must be called before the SQE submits.
+    /// Extends coro_op::start to also clear the ring-cancel flag.
     void start(std::stop_token const& token)
     {
-        cancelled.store(false, std::memory_order_relaxed);
         sqe_set.store(false, std::memory_order_relaxed);
-        stop_cb.reset();
-        if (token.stop_possible())
-            stop_cb.emplace(token, canceller{this});
+        coro_op::start(token);
     }
+
+    /// io_uring cancellation: record the request and, if an SQE was already
+    /// linked, ask the kernel to cancel it by user_data.
+    void on_cancel() noexcept override;
 };
 
 } // namespace boost::corosio::detail

--- a/include/boost/corosio/native/detail/io_uring/io_uring_random_access_file.hpp
+++ b/include/boost/corosio/native/detail/io_uring/io_uring_random_access_file.hpp
@@ -17,6 +17,7 @@
 #include <boost/corosio/detail/random_access_file_service.hpp>
 #include <boost/corosio/detail/intrusive.hpp>
 #include <boost/corosio/native/detail/io_uring/io_uring_file_ops.hpp>
+#include <boost/corosio/native/detail/io_uring/io_uring_file_service_base.hpp>
 #include <boost/corosio/native/detail/io_uring/io_uring_scheduler.hpp>
 #include <boost/corosio/native/detail/make_err.hpp>
 #include <boost/corosio/random_access_file.hpp>
@@ -277,50 +278,24 @@ io_uring_random_access_file::write_some_at(
     by `io_uring_t::construct`.
 */
 class BOOST_COROSIO_DECL io_uring_random_access_file_service final
-    : public random_access_file_service
+    : public io_uring_file_service_base<
+          io_uring_random_access_file_service,
+          random_access_file_service,
+          io_uring_random_access_file>
 {
+    using base_service = io_uring_file_service_base<
+        io_uring_random_access_file_service,
+        random_access_file_service,
+        io_uring_random_access_file>;
+
 public:
     explicit io_uring_random_access_file_service(
         capy::execution_context& /*ctx*/, io_uring_scheduler& sched)
-        : sched_(&sched)
+        : base_service(sched)
     {}
 
-    ~io_uring_random_access_file_service() override = default;
-
-    io_uring_random_access_file_service(
-        io_uring_random_access_file_service const&)            = delete;
-    io_uring_random_access_file_service& operator=(
-        io_uring_random_access_file_service const&)            = delete;
-
-    io_object::implementation* construct() override
-    {
-        auto ptr   = std::make_shared<io_uring_random_access_file>(
-            *sched_);
-        auto* impl = ptr.get();
-        {
-            std::lock_guard<std::mutex> lock(mutex_);
-            file_list_.push_back(impl);
-            file_ptrs_[impl] = std::move(ptr);
-        }
-        return impl;
-    }
-
-    void destroy(io_object::implementation* p) override
-    {
-        // close_file() already does cancel_and_flush(fd_) before
-        // ::close — calling cancel() too would queue a redundant
-        // cancel-by-fd SQE that finds nothing.
-        auto& impl = static_cast<io_uring_random_access_file&>(*p);
-        impl.close_file();
-        destroy_impl(impl);
-    }
-
-    void close(io_object::handle& h) override
-    {
-        if (h.get())
-            static_cast<io_uring_random_access_file&>(
-                *h.get()).close_file();
-    }
+    // construct / destroy / close / shutdown / scheduler() are inherited
+    // from io_uring_file_service_base.
 
     std::error_code open_file(
         random_access_file::implementation& impl,
@@ -330,32 +305,6 @@ public:
         return static_cast<io_uring_random_access_file&>(impl).open_file(
             path, mode);
     }
-
-    void shutdown() override
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        for (auto* impl = file_list_.pop_front(); impl != nullptr;
-             impl       = file_list_.pop_front())
-        {
-            impl->close_file();
-        }
-        file_ptrs_.clear();
-    }
-
-private:
-    void destroy_impl(io_uring_random_access_file& impl)
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        file_list_.remove(&impl);
-        file_ptrs_.erase(&impl);
-    }
-
-    io_uring_scheduler*                              sched_;
-    std::mutex                                       mutex_;
-    intrusive_list<io_uring_random_access_file>      file_list_;
-    std::unordered_map<
-        io_uring_random_access_file*,
-        std::shared_ptr<io_uring_random_access_file>> file_ptrs_;
 };
 
 } // namespace boost::corosio::detail

--- a/include/boost/corosio/native/detail/io_uring/io_uring_scheduler.hpp
+++ b/include/boost/corosio/native/detail/io_uring/io_uring_scheduler.hpp
@@ -1209,9 +1209,9 @@ io_uring_scheduler::submit_cancel_by_fd(int fd) noexcept
 }
 
 inline void
-io_uring_op::request_cancel() noexcept
+io_uring_op::on_cancel() noexcept
 {
-    cancelled.store(true, std::memory_order_release);
+    request_cancel();   // coro_op: records the cancellation (sets the flag)
     // Skip the cancel SQE if we never linked an SQE to this op — the
     // bypass path in the caller will see cancelled=true and complete
     // synchronously without a kernel round-trip.

--- a/include/boost/corosio/native/detail/io_uring/io_uring_socket_ops.hpp
+++ b/include/boost/corosio/native/detail/io_uring/io_uring_socket_ops.hpp
@@ -24,6 +24,7 @@
 #include <boost/corosio/native/detail/io_uring/io_uring_buffer.hpp>
 #include <boost/corosio/native/detail/io_uring/io_uring_op.hpp>
 #include <boost/corosio/native/detail/io_uring/io_uring_scheduler.hpp>
+#include <boost/corosio/native/detail/coro_op_complete.hpp>
 #include <boost/corosio/native/detail/make_err.hpp>
 #include <boost/corosio/native/detail/speculative_state.hpp>
 
@@ -58,17 +59,13 @@ inline constexpr std::size_t io_uring_max_iov = 16;
 inline void
 uring_set_result(io_uring_op* self, bool is_read, bool empty_buf) noexcept
 {
-    if (!self->ec_out)
-        return;
-
-    if (self->cancelled.load(std::memory_order_acquire))
-        *self->ec_out = capy::error::canceled;
-    else if (self->res < 0)
-        *self->ec_out = make_err(-self->res);
-    else if (is_read && self->res == 0 && !empty_buf)
-        *self->ec_out = capy::error::eof;
-    else
-        *self->ec_out = {};
+    decode_io_result(
+        self->ec_out,
+        self->cancelled.load(std::memory_order_acquire),
+        self->res < 0 ? make_err(-self->res) : std::error_code{},
+        is_read,
+        self->res >= 0 ? static_cast<std::size_t>(self->res) : 0u,
+        empty_buf);
 }
 
 /** Scatter-gather read via `IORING_OP_READV`.
@@ -165,16 +162,11 @@ struct uring_read_op : io_uring_op
         std::uint32_t /*bytes*/, std::uint32_t /*error*/) noexcept
     {
         auto* self = static_cast<uring_read_op*>(base);
-        self->stop_cb.reset();
-
-        if (owner == nullptr)
-        {
-            // Shutdown drain: break the impl_ptr cycle. The op storage
-            // is owned by the impl, which destructs once the cycle is
-            // broken (if this was the last ref).
-            auto suicide = std::move(self->impl_ptr);
+        if (coro_drain_if_shutdown(owner, self))
             return;
-        }
+
+        if (self->sched_)
+            self->sched_->reset_inline_budget();
 
         uring_set_result(self, true, self->empty_buffer);
 
@@ -188,10 +180,7 @@ struct uring_read_op : io_uring_op
             *self->bytes_out =
                 self->res >= 0 ? static_cast<std::size_t>(self->res) : 0u;
 
-        self->cont_op.cont.h = self->h;
-        auto next = dispatch_coro(self->ex, self->cont_op.cont);
-        auto suicide = std::move(self->impl_ptr);
-        next.resume();
+        coro_resume(self);
         // suicide drops here; may destroy impl + self.
     }
 };
@@ -286,13 +275,11 @@ struct uring_write_op : io_uring_op
         std::uint32_t /*bytes*/, std::uint32_t /*error*/) noexcept
     {
         auto* self = static_cast<uring_write_op*>(base);
-        self->stop_cb.reset();
-
-        if (owner == nullptr)
-        {
-            auto suicide = std::move(self->impl_ptr);
+        if (coro_drain_if_shutdown(owner, self))
             return;
-        }
+
+        if (self->sched_)
+            self->sched_->reset_inline_budget();
 
         uring_set_result(self, false, self->empty_buffer);
 
@@ -306,10 +293,7 @@ struct uring_write_op : io_uring_op
             *self->bytes_out =
                 self->res >= 0 ? static_cast<std::size_t>(self->res) : 0u;
 
-        self->cont_op.cont.h = self->h;
-        auto next = dispatch_coro(self->ex, self->cont_op.cont);
-        auto suicide = std::move(self->impl_ptr);
-        next.resume();
+        coro_resume(self);
     }
 };
 
@@ -392,13 +376,11 @@ struct uring_connect_op : io_uring_op
         std::uint32_t /*bytes*/, std::uint32_t /*error*/) noexcept
     {
         auto* self = static_cast<uring_connect_op*>(base);
-        self->stop_cb.reset();
-
-        if (owner == nullptr)
-        {
-            auto suicide = std::move(self->impl_ptr);
+        if (coro_drain_if_shutdown(owner, self))
             return;
-        }
+
+        if (self->sched_)
+            self->sched_->reset_inline_budget();
 
         uring_set_result(self, false, false);
 
@@ -417,10 +399,7 @@ struct uring_connect_op : io_uring_op
             }
         }
 
-        self->cont_op.cont.h = self->h;
-        auto next = dispatch_coro(self->ex, self->cont_op.cont);
-        auto suicide = std::move(self->impl_ptr);
-        next.resume();
+        coro_resume(self);
     }
 };
 
@@ -562,29 +541,20 @@ struct uring_wait_op : io_uring_op
         std::uint32_t /*bytes*/, std::uint32_t /*error*/) noexcept
     {
         auto* self = static_cast<uring_wait_op*>(base);
-        self->stop_cb.reset();
-
-        if (owner == nullptr)
-        {
-            // Shutdown drain: break the impl_ptr cycle.
-            auto suicide = std::move(self->impl_ptr);
+        if (coro_drain_if_shutdown(owner, self))
             return;
-        }
 
-        if (self->ec_out)
-        {
-            if (self->cancelled.load(std::memory_order_acquire))
-                *self->ec_out = capy::error::canceled;
-            else if (self->res < 0)
-                *self->ec_out = make_err(-self->res);
-            else
-                *self->ec_out = {};
-        }
+        if (self->sched_)
+            self->sched_->reset_inline_budget();
 
-        self->cont_op.cont.h = self->h;
-        auto next = dispatch_coro(self->ex, self->cont_op.cont);
-        auto suicide = std::move(self->impl_ptr);
-        next.resume();
+        // Wait reports only success/cancel/error — no bytes, no EOF.
+        decode_io_result(
+            self->ec_out,
+            self->cancelled.load(std::memory_order_acquire),
+            self->res < 0 ? make_err(-self->res) : std::error_code{},
+            /*is_read=*/false, /*bytes=*/0, /*empty_buffer=*/false);
+
+        coro_resume(self);
     }
 };
 
@@ -662,13 +632,11 @@ struct uring_local_connect_op : io_uring_op
         std::uint32_t /*bytes*/, std::uint32_t /*error*/) noexcept
     {
         auto* self = static_cast<uring_local_connect_op*>(base);
-        self->stop_cb.reset();
-
-        if (owner == nullptr)
-        {
-            auto suicide = std::move(self->impl_ptr);
+        if (coro_drain_if_shutdown(owner, self))
             return;
-        }
+
+        if (self->sched_)
+            self->sched_->reset_inline_budget();
 
         uring_set_result(self, false, false);
 
@@ -688,10 +656,7 @@ struct uring_local_connect_op : io_uring_op
             }
         }
 
-        self->cont_op.cont.h = self->h;
-        auto next = dispatch_coro(self->ex, self->cont_op.cont);
-        auto suicide = std::move(self->impl_ptr);
-        next.resume();
+        coro_resume(self);
     }
 };
 

--- a/include/boost/corosio/native/detail/io_uring/io_uring_socket_service_base.hpp
+++ b/include/boost/corosio/native/detail/io_uring/io_uring_socket_service_base.hpp
@@ -1,0 +1,143 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_NATIVE_DETAIL_IO_URING_IO_URING_SOCKET_SERVICE_BASE_HPP
+#define BOOST_COROSIO_NATIVE_DETAIL_IO_URING_IO_URING_SOCKET_SERVICE_BASE_HPP
+
+#include <boost/corosio/detail/platform.hpp>
+
+#if BOOST_COROSIO_HAS_IO_URING
+
+#include <boost/corosio/io/io_object.hpp>
+#include <boost/corosio/native/detail/io_uring/io_uring_scheduler.hpp>
+#include <boost/capy/ex/execution_context.hpp>
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+/*
+    Shared lifecycle plumbing for io_uring socket/datagram services.
+
+    construct / destroy / shutdown / close / scheduler() are identical across
+    io_uring_tcp_service, io_uring_udp_service, io_uring_local_stream_service,
+    and io_uring_local_datagram_service — they all make_shared the impl, track
+    it in a raw->shared_ptr map, cancel on shutdown, and close eagerly. This
+    base factors that out; the concrete services add only the protocol-
+    specific open/bind/adopt.
+
+    This is io_uring's own service base rather than a reuse of
+    reactor_socket_service: io_uring tracks impls in a map (the reactor uses
+    an intrusive list + map), cancels (not closes) on shutdown, and constructs
+    impls with a (service&, scheduler&) ctor. Reusing the reactor template
+    would force io_uring sockets to adopt the intrusive node, a close-on-
+    shutdown behavior change, and an Impl(Derived&) ctor — high churn and a
+    teardown behavior change for marginal extra sharing. See
+    tasks/proactor-dedup-decisions.md (#13).
+
+    Requirements on Socket: a `(Derived& service, io_uring_scheduler& sched)`
+    constructor and a `void close_socket() noexcept` method (cancel in-flight
+    ops + close fd + reset cached endpoints).
+
+    @tparam Derived     The concrete service (CRTP, passed to the Socket ctor).
+    @tparam ServiceBase The abstract service vtable base (tcp_service, ...).
+    @tparam Socket      The concrete io_uring socket impl type.
+*/
+
+namespace boost::corosio::detail {
+
+template<class Derived, class ServiceBase, class Socket>
+class io_uring_socket_service_base : public ServiceBase
+{
+    friend Derived;
+
+    // Private CRTP ctor: only `Derived` (the concrete service, a friend)
+    // constructs the base — prevents inheriting with the wrong Derived
+    // (bugprone-crtp-constructor-accessibility).
+    explicit io_uring_socket_service_base(capy::execution_context& ctx)
+        : sched_(&ctx.template use_service<io_uring_scheduler>())
+    {
+    }
+
+public:
+    ~io_uring_socket_service_base() override = default;
+
+    void shutdown() override
+    {
+        // Snapshot live impls, then cancel without the lock held to avoid
+        // inversion if cancel() ever re-enters the service. Impls stay owned
+        // by impls_ until ~service (after the scheduler drains its queue),
+        // keeping every impl alive while its cancel CQEs are processed.
+        std::vector<std::shared_ptr<Socket>> live;
+        {
+            std::lock_guard lk(mutex_);
+            live.reserve(impls_.size());
+            for (auto& [_, p] : impls_)
+                live.push_back(p);
+        }
+        for (auto& p : live)
+            p->cancel();
+    }
+
+    io_object::implementation* construct() override
+    {
+        auto  p   = std::make_shared<Socket>(
+            static_cast<Derived&>(*this), *sched_);
+        auto* raw = p.get();
+        std::lock_guard lk(mutex_);
+        impls_.emplace(raw, std::move(p));
+        return raw;
+    }
+
+    void destroy(io_object::implementation* p) override
+    {
+        if (!p)
+            return;
+        std::lock_guard lk(mutex_);
+        impls_.erase(static_cast<Socket*>(p));
+    }
+
+    // Close the fd eagerly when the public close() is called, before
+    // destroy() drops the shared_ptr and the destructor runs.
+    void close(io_object::handle& h) override
+    {
+        if (auto* sock = static_cast<Socket*>(h.get()))
+            sock->close_socket();
+    }
+
+    /// Return the scheduler used by sockets created by this service.
+    io_uring_scheduler& scheduler() noexcept { return *sched_; }
+
+protected:
+    /// Register an externally-built impl (used by adopt_fd on stream
+    /// services after accept(2)). Returns the raw pointer.
+    Socket* register_impl(std::shared_ptr<Socket> p)
+    {
+        auto* raw = p.get();
+        std::lock_guard lk(mutex_);
+        impls_.emplace(raw, std::move(p));
+        return raw;
+    }
+
+    io_uring_scheduler* sched_;
+    std::mutex          mutex_;
+    std::unordered_map<Socket*, std::shared_ptr<Socket>> impls_;
+
+private:
+    io_uring_socket_service_base(io_uring_socket_service_base const&) = delete;
+    io_uring_socket_service_base&
+    operator=(io_uring_socket_service_base const&) = delete;
+};
+
+} // namespace boost::corosio::detail
+
+#endif // BOOST_COROSIO_HAS_IO_URING
+
+#endif // BOOST_COROSIO_NATIVE_DETAIL_IO_URING_IO_URING_SOCKET_SERVICE_BASE_HPP

--- a/include/boost/corosio/native/detail/io_uring/io_uring_stream_file.hpp
+++ b/include/boost/corosio/native/detail/io_uring/io_uring_stream_file.hpp
@@ -17,6 +17,7 @@
 #include <boost/corosio/detail/file_service.hpp>
 #include <boost/corosio/detail/intrusive.hpp>
 #include <boost/corosio/native/detail/io_uring/io_uring_file_ops.hpp>
+#include <boost/corosio/native/detail/io_uring/io_uring_file_service_base.hpp>
 #include <boost/corosio/native/detail/io_uring/io_uring_scheduler.hpp>
 #include <boost/corosio/native/detail/make_err.hpp>
 #include <boost/corosio/stream_file.hpp>
@@ -290,48 +291,20 @@ io_uring_stream_file::write_some(
     under the abstract `file_service` key by `io_uring_t::construct`.
 */
 class BOOST_COROSIO_DECL io_uring_stream_file_service final
-    : public file_service
+    : public io_uring_file_service_base<
+          io_uring_stream_file_service, file_service, io_uring_stream_file>
 {
+    using base_service = io_uring_file_service_base<
+        io_uring_stream_file_service, file_service, io_uring_stream_file>;
+
 public:
     explicit io_uring_stream_file_service(
         capy::execution_context& /*ctx*/, io_uring_scheduler& sched)
-        : sched_(&sched)
+        : base_service(sched)
     {}
 
-    ~io_uring_stream_file_service() override = default;
-
-    io_uring_stream_file_service(
-        io_uring_stream_file_service const&)            = delete;
-    io_uring_stream_file_service& operator=(
-        io_uring_stream_file_service const&)            = delete;
-
-    io_object::implementation* construct() override
-    {
-        auto ptr   = std::make_shared<io_uring_stream_file>(*sched_);
-        auto* impl = ptr.get();
-        {
-            std::lock_guard<std::mutex> lock(mutex_);
-            file_list_.push_back(impl);
-            file_ptrs_[impl] = std::move(ptr);
-        }
-        return impl;
-    }
-
-    void destroy(io_object::implementation* p) override
-    {
-        // close_file() already does cancel_and_flush(fd_) before
-        // ::close — calling cancel() too would queue a redundant
-        // cancel-by-fd SQE that finds nothing.
-        auto& impl = static_cast<io_uring_stream_file&>(*p);
-        impl.close_file();
-        destroy_impl(impl);
-    }
-
-    void close(io_object::handle& h) override
-    {
-        if (h.get())
-            static_cast<io_uring_stream_file&>(*h.get()).close_file();
-    }
+    // construct / destroy / close / shutdown / scheduler() are inherited
+    // from io_uring_file_service_base.
 
     std::error_code open_file(
         stream_file::implementation& impl,
@@ -341,32 +314,6 @@ public:
         return static_cast<io_uring_stream_file&>(impl).open_file(
             path, mode);
     }
-
-    void shutdown() override
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        for (auto* impl = file_list_.pop_front(); impl != nullptr;
-             impl       = file_list_.pop_front())
-        {
-            impl->close_file();
-        }
-        file_ptrs_.clear();
-    }
-
-private:
-    void destroy_impl(io_uring_stream_file& impl)
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        file_list_.remove(&impl);
-        file_ptrs_.erase(&impl);
-    }
-
-    io_uring_scheduler*                       sched_;
-    std::mutex                                mutex_;
-    intrusive_list<io_uring_stream_file>      file_list_;
-    std::unordered_map<
-        io_uring_stream_file*,
-        std::shared_ptr<io_uring_stream_file>> file_ptrs_;
 };
 
 } // namespace boost::corosio::detail

--- a/include/boost/corosio/native/detail/io_uring/io_uring_types.hpp
+++ b/include/boost/corosio/native/detail/io_uring/io_uring_types.hpp
@@ -22,6 +22,8 @@
 #include <boost/corosio/native/detail/io_uring/io_uring_scheduler.hpp>
 #include <boost/corosio/native/detail/io_uring/io_uring_multishot_acceptor.hpp>
 #include <boost/corosio/native/detail/io_uring/io_uring_socket_ops.hpp>
+#include <boost/corosio/native/detail/io_uring/io_uring_socket_service_base.hpp>
+#include <boost/corosio/native/detail/native_socket_base.hpp>
 #include <boost/corosio/native/detail/make_err.hpp>
 #include <boost/corosio/native/detail/msg_flags.hpp>
 #include <boost/corosio/detail/local_datagram_service.hpp>
@@ -75,17 +77,20 @@ class io_uring_local_datagram_service;
     the same type in flight simultaneously.
 */
 class BOOST_COROSIO_DECL io_uring_tcp_socket final
-    : public tcp_socket::implementation
-    , public std::enable_shared_from_this<io_uring_tcp_socket>
+    : public native_socket_base<
+          io_uring_tcp_socket, tcp_socket::implementation, endpoint>
 {
     friend io_uring_tcp_service;
 
-    int                   fd_     = -1;
     int                   family_ = AF_UNSPEC;  // cached at open_socket
     io_uring_scheduler*   sched_  = nullptr;
     io_uring_tcp_service* svc_    = nullptr;
 
-    mutable endpoint local_endpoint_;
+    // fd_ and local_endpoint_ are provided by native_socket_base (the
+    // readiness/completion-agnostic socket base shared with the reactor
+    // sockets). native_handle()/is_open()/set_option()/get_option() come
+    // from there too; local_endpoint() is overridden below for lazy
+    // getsockname resolution.
     // Three-state machine for the local endpoint:
     //   unresolved    — never set; accessor returns default endpoint
     //                   (open-but-unbound socket, failed-connect, etc.)
@@ -182,17 +187,10 @@ public:
         {
             if (sched_->try_consume_inline_budget())
             {
-                if (ec)
-                {
-                    if (stop_now)
-                        *ec = capy::error::canceled;
-                    else if (err)
-                        *ec = make_err(err);
-                    else if (n == 0 && !empty_buf)
-                        *ec = capy::error::eof;
-                    else
-                        *ec = {};
-                }
+                decode_io_result(
+                    ec, stop_now, err ? make_err(err) : std::error_code{},
+                    /*is_read=*/true,
+                    n < 0 ? 0u : static_cast<std::size_t>(n), empty_buf);
                 if (bytes)
                     *bytes = (n < 0) ? 0u : static_cast<std::size_t>(n);
                 rd_.cont_op.cont.h = h;
@@ -266,10 +264,9 @@ public:
         {
             if (sched_->try_consume_inline_budget())
             {
-                if (ec)
-                    *ec = stop_now ? capy::error::canceled
-                          : err   ? make_err(err)
-                                  : std::error_code{};
+                decode_io_result(
+                    ec, stop_now, err ? make_err(err) : std::error_code{},
+                    /*is_read=*/false, /*bytes=*/0, /*empty_buffer=*/false);
                 if (bytes)
                     *bytes = (n < 0) ? 0u : static_cast<std::size_t>(n);
                 wr_.cont_op.cont.h = h;
@@ -384,10 +381,8 @@ public:
         return {};
     }
 
-    native_handle_type native_handle() const noexcept override
-    {
-        return fd_;
-    }
+    // native_handle() / set_option() / get_option() are inherited from
+    // native_socket_base.
 
     void cancel() noexcept override
     {
@@ -395,32 +390,22 @@ public:
             sched_->submit_cancel_by_fd(fd_);
     }
 
-    std::error_code set_option(
-        int         level,
-        int         optname,
-        void const* data,
-        std::size_t size) noexcept override
+    /// Cancel in-flight ops, close the fd, and reset cached endpoints.
+    /// Called by the service on close()/teardown. cancel_and_flush submits
+    /// the cancel SQE while the fd is still open so IORING_ASYNC_CANCEL_FD
+    /// resolves before the fd number can be recycled.
+    void close_socket() noexcept
     {
-        if (::setsockopt(
-                fd_, level, optname,
-                reinterpret_cast<char const*>(data),
-                static_cast<socklen_t>(size)) != 0)
-            return make_err(errno);
-        return {};
-    }
-
-    std::error_code get_option(
-        int         level,
-        int         optname,
-        void*       data,
-        std::size_t* size) const noexcept override
-    {
-        socklen_t len = static_cast<socklen_t>(*size);
-        if (::getsockopt(fd_, level, optname,
-                reinterpret_cast<char*>(data), &len) != 0)
-            return make_err(errno);
-        *size = static_cast<std::size_t>(len);
-        return {};
+        if (fd_ >= 0)
+        {
+            sched_->cancel_and_flush(fd_);
+            ::close(fd_);
+            fd_ = -1;
+        }
+        local_endpoint_  = endpoint{};
+        remote_endpoint_ = endpoint{};
+        local_endpoint_state_.store(
+            endpoint_state::unresolved, std::memory_order_release);
     }
 
     endpoint local_endpoint() const noexcept override
@@ -468,8 +453,12 @@ public:
     All public member functions are thread-safe.
 */
 class BOOST_COROSIO_DECL io_uring_tcp_service final
-    : public tcp_service
+    : public io_uring_socket_service_base<
+          io_uring_tcp_service, tcp_service, io_uring_tcp_socket>
 {
+    using base_service = io_uring_socket_service_base<
+        io_uring_tcp_service, tcp_service, io_uring_tcp_socket>;
+
 public:
     /// Identifies this service for `execution_context` lookup.
     using key_type = tcp_service;
@@ -480,59 +469,11 @@ public:
             must already be registered.
     */
     explicit io_uring_tcp_service(capy::execution_context& ctx)
-        : sched_(&ctx.use_service<io_uring_scheduler>())
+        : base_service(ctx)
     {}
 
-    void shutdown() override
-    {
-        std::vector<std::shared_ptr<io_uring_tcp_socket>> live;
-        {
-            std::lock_guard lk(mutex_);
-            live.reserve(impls_.size());
-            for (auto& [_, p] : impls_)
-                live.push_back(p);
-        }
-        // Cancel without the lock held to avoid inversion if cancel()
-        // ever needs to re-enter the service.
-        for (auto& p : live)
-            p->cancel();
-    }
-
-    io_object::implementation* construct() override
-    {
-        auto p   = std::make_shared<io_uring_tcp_socket>(*this, *sched_);
-        auto* raw = p.get();
-        std::lock_guard lk(mutex_);
-        impls_.emplace(raw, std::move(p));
-        return raw;
-    }
-
-    void destroy(io_object::implementation* p) override
-    {
-        if (!p)
-            return;
-        std::lock_guard lk(mutex_);
-        impls_.erase(static_cast<io_uring_tcp_socket*>(p));
-    }
-
-    // Close the fd eagerly when tcp_socket::close() is called, before
-    // destroy() drops the shared_ptr and the destructor runs.
-    void close(io_object::handle& h) override
-    {
-        auto* sock = static_cast<io_uring_tcp_socket*>(h.get());
-        if (sock && sock->fd_ >= 0)
-        {
-            // Cancel pending SQEs before closing. The cancel SQE must
-            // be submitted to the kernel while the fd is still open;
-            // otherwise IORING_ASYNC_CANCEL_FD resolves to the wrong
-            // file if the fd number is immediately recycled.
-            sched_->cancel_and_flush(sock->fd_);
-            ::close(sock->fd_);
-            sock->fd_              = -1;
-            sock->local_endpoint_  = endpoint{};
-            sock->remote_endpoint_ = endpoint{};
-        }
-    }
+    // construct / destroy / shutdown / close / scheduler() are inherited
+    // from io_uring_socket_service_base. The methods below are TCP-specific.
 
     /** Open a socket fd and associate it with an impl.
 
@@ -623,20 +564,8 @@ public:
             io_uring_tcp_socket::endpoint_state::lazy_pending,
             std::memory_order_release);
 
-        std::lock_guard lk(mutex_);
-        auto* raw = p.get();
-        impls_.emplace(raw, std::move(p));
-        return raw;
+        return this->register_impl(std::move(p));
     }
-
-    /// Return the scheduler used by sockets created by this service.
-    io_uring_scheduler& scheduler() noexcept { return *sched_; }
-
-private:
-    io_uring_scheduler*  sched_;
-    std::mutex           mutex_;
-    std::unordered_map<io_uring_tcp_socket*,
-                       std::shared_ptr<io_uring_tcp_socket>> impls_;
 };
 
 /** TCP acceptor implementation for io_uring.
@@ -921,16 +850,18 @@ private:
     the same type in flight simultaneously.
 */
 class BOOST_COROSIO_DECL io_uring_local_stream_socket final
-    : public local_stream_socket::implementation
-    , public std::enable_shared_from_this<io_uring_local_stream_socket>
+    : public native_socket_base<
+          io_uring_local_stream_socket,
+          local_stream_socket::implementation,
+          corosio::local_endpoint>
 {
     friend io_uring_local_stream_service;
 
-    int                           fd_    = -1;
     io_uring_scheduler*           sched_ = nullptr;
     io_uring_local_stream_service* svc_  = nullptr;
 
-    corosio::local_endpoint local_endpoint_;
+    // fd_ and local_endpoint_ live in native_socket_base, which also
+    // provides native_handle/is_open/set_option/get_option/local_endpoint.
     corosio::local_endpoint remote_endpoint_;
 
     // Per-fd op slots — embedded to eliminate per-call heap allocation.
@@ -1011,17 +942,10 @@ public:
         {
             if (sched_->try_consume_inline_budget())
             {
-                if (ec)
-                {
-                    if (stop_now)
-                        *ec = capy::error::canceled;
-                    else if (err)
-                        *ec = make_err(err);
-                    else if (n == 0 && !empty_buf)
-                        *ec = capy::error::eof;
-                    else
-                        *ec = {};
-                }
+                decode_io_result(
+                    ec, stop_now, err ? make_err(err) : std::error_code{},
+                    /*is_read=*/true,
+                    n < 0 ? 0u : static_cast<std::size_t>(n), empty_buf);
                 if (bytes)
                     *bytes = (n < 0) ? 0u : static_cast<std::size_t>(n);
                 rd_.cont_op.cont.h = h;
@@ -1095,10 +1019,9 @@ public:
         {
             if (sched_->try_consume_inline_budget())
             {
-                if (ec)
-                    *ec = stop_now ? capy::error::canceled
-                          : err   ? make_err(err)
-                                  : std::error_code{};
+                decode_io_result(
+                    ec, stop_now, err ? make_err(err) : std::error_code{},
+                    /*is_read=*/false, /*bytes=*/0, /*empty_buffer=*/false);
                 if (bytes)
                     *bytes = (n < 0) ? 0u : static_cast<std::size_t>(n);
                 wr_.cont_op.cont.h = h;
@@ -1213,10 +1136,8 @@ public:
         return {};
     }
 
-    native_handle_type native_handle() const noexcept override
-    {
-        return fd_;
-    }
+    // native_handle / is_open / set_option / get_option / local_endpoint
+    // are inherited from native_socket_base.
 
     native_handle_type release_socket() noexcept override
     {
@@ -1233,37 +1154,18 @@ public:
             sched_->submit_cancel_by_fd(fd_);
     }
 
-    std::error_code set_option(
-        int         level,
-        int         optname,
-        void const* data,
-        std::size_t size) noexcept override
+    /// Cancel in-flight ops, close the fd, and reset cached endpoints.
+    /// Called by the service on close()/teardown.
+    void close_socket() noexcept
     {
-        if (::setsockopt(
-                fd_, level, optname,
-                reinterpret_cast<char const*>(data),
-                static_cast<socklen_t>(size)) != 0)
-            return make_err(errno);
-        return {};
-    }
-
-    std::error_code get_option(
-        int         level,
-        int         optname,
-        void*       data,
-        std::size_t* size) const noexcept override
-    {
-        socklen_t len = static_cast<socklen_t>(*size);
-        if (::getsockopt(fd_, level, optname,
-                reinterpret_cast<char*>(data), &len) != 0)
-            return make_err(errno);
-        *size = static_cast<std::size_t>(len);
-        return {};
-    }
-
-    corosio::local_endpoint local_endpoint() const noexcept override
-    {
-        return local_endpoint_;
+        if (fd_ >= 0)
+        {
+            sched_->cancel_and_flush(fd_);
+            ::close(fd_);
+            fd_ = -1;
+        }
+        local_endpoint_  = corosio::local_endpoint{};
+        remote_endpoint_ = corosio::local_endpoint{};
     }
 
     corosio::local_endpoint remote_endpoint() const noexcept override
@@ -1287,8 +1189,14 @@ public:
     All public member functions are thread-safe.
 */
 class BOOST_COROSIO_DECL io_uring_local_stream_service final
-    : public local_stream_service
+    : public io_uring_socket_service_base<
+          io_uring_local_stream_service, local_stream_service,
+          io_uring_local_stream_socket>
 {
+    using base_service = io_uring_socket_service_base<
+        io_uring_local_stream_service, local_stream_service,
+        io_uring_local_stream_socket>;
+
 public:
     /// Identifies this service for `execution_context` lookup.
     using key_type = local_stream_service;
@@ -1299,59 +1207,11 @@ public:
             must already be registered.
     */
     explicit io_uring_local_stream_service(capy::execution_context& ctx)
-        : sched_(&ctx.use_service<io_uring_scheduler>())
+        : base_service(ctx)
     {}
 
-    void shutdown() override
-    {
-        std::vector<std::shared_ptr<io_uring_local_stream_socket>> live;
-        {
-            std::lock_guard lk(mutex_);
-            live.reserve(impls_.size());
-            for (auto& [_, p] : impls_)
-                live.push_back(p);
-        }
-        // Cancel without the lock held to avoid inversion if cancel()
-        // ever needs to re-enter the service.
-        for (auto& p : live)
-            p->cancel();
-    }
-
-    io_object::implementation* construct() override
-    {
-        auto p   = std::make_shared<io_uring_local_stream_socket>(*this, *sched_);
-        auto* raw = p.get();
-        std::lock_guard lk(mutex_);
-        impls_.emplace(raw, std::move(p));
-        return raw;
-    }
-
-    void destroy(io_object::implementation* p) override
-    {
-        if (!p)
-            return;
-        std::lock_guard lk(mutex_);
-        impls_.erase(static_cast<io_uring_local_stream_socket*>(p));
-    }
-
-    // Close the fd eagerly when local_stream_socket::close() is called,
-    // before destroy() drops the shared_ptr and the destructor runs.
-    void close(io_object::handle& h) override
-    {
-        auto* sock = static_cast<io_uring_local_stream_socket*>(h.get());
-        if (sock && sock->fd_ >= 0)
-        {
-            // Cancel pending SQEs before closing. The cancel SQE must
-            // be submitted to the kernel while the fd is still open;
-            // otherwise IORING_ASYNC_CANCEL_FD resolves to the wrong
-            // file if the fd number is immediately recycled.
-            sched_->cancel_and_flush(sock->fd_);
-            ::close(sock->fd_);
-            sock->fd_              = -1;
-            sock->local_endpoint_  = corosio::local_endpoint{};
-            sock->remote_endpoint_ = corosio::local_endpoint{};
-        }
-    }
+    // construct / destroy / shutdown / close / scheduler() are inherited
+    // from io_uring_socket_service_base.
 
     /** Open an AF_UNIX stream socket and associate it with an impl.
 
@@ -1439,20 +1299,8 @@ public:
         if (::getsockname(fd, reinterpret_cast<sockaddr*>(&local), &len) == 0)
             p->local_endpoint_ = sockaddr_to_local_endpoint(local, len);
 
-        std::lock_guard lk(mutex_);
-        auto* raw = p.get();
-        impls_.emplace(raw, std::move(p));
-        return raw;
+        return this->register_impl(std::move(p));
     }
-
-    /// Return the scheduler used by sockets created by this service.
-    io_uring_scheduler& scheduler() noexcept { return *sched_; }
-
-private:
-    io_uring_scheduler*  sched_;
-    std::mutex           mutex_;
-    std::unordered_map<io_uring_local_stream_socket*,
-                       std::shared_ptr<io_uring_local_stream_socket>> impls_;
 };
 
 /** Local-stream (Unix domain) acceptor for io_uring.
@@ -1747,17 +1595,17 @@ private:
     simultaneously, but two sends or two recvs must not overlap.
 */
 class BOOST_COROSIO_DECL io_uring_udp_socket final
-    : public udp_socket::implementation
-    , public std::enable_shared_from_this<io_uring_udp_socket>
+    : public native_socket_base<
+          io_uring_udp_socket, udp_socket::implementation, corosio::endpoint>
 {
     friend io_uring_udp_service;
 
-    int                    fd_     = -1;
     int                    family_ = AF_UNSPEC;  // cached at open_socket
     io_uring_scheduler*    sched_  = nullptr;
     io_uring_udp_service*  svc_    = nullptr;
 
-    corosio::endpoint local_endpoint_;
+    // fd_ and local_endpoint_ live in native_socket_base, which also
+    // provides native_handle/is_open/set_option/get_option/local_endpoint.
     corosio::endpoint remote_endpoint_;
 
     // Per-fd op slots — embedded to eliminate per-call heap allocation.
@@ -1922,10 +1770,8 @@ public:
         return std::noop_coroutine();
     }
 
-    native_handle_type native_handle() const noexcept override
-    {
-        return fd_;
-    }
+    // native_handle / is_open / set_option / get_option / local_endpoint
+    // are inherited from native_socket_base.
 
     void cancel() noexcept override
     {
@@ -1933,37 +1779,18 @@ public:
             sched_->submit_cancel_by_fd(fd_);
     }
 
-    std::error_code set_option(
-        int         level,
-        int         optname,
-        void const* data,
-        std::size_t size) noexcept override
+    /// Cancel in-flight ops, close the fd, and reset cached endpoints.
+    /// Called by the service on close()/teardown.
+    void close_socket() noexcept
     {
-        if (::setsockopt(
-                fd_, level, optname,
-                reinterpret_cast<char const*>(data),
-                static_cast<socklen_t>(size)) != 0)
-            return make_err(errno);
-        return {};
-    }
-
-    std::error_code get_option(
-        int          level,
-        int          optname,
-        void*        data,
-        std::size_t* size) const noexcept override
-    {
-        socklen_t len = static_cast<socklen_t>(*size);
-        if (::getsockopt(fd_, level, optname,
-                reinterpret_cast<char*>(data), &len) != 0)
-            return make_err(errno);
-        *size = static_cast<std::size_t>(len);
-        return {};
-    }
-
-    endpoint local_endpoint() const noexcept override
-    {
-        return local_endpoint_;
+        if (fd_ >= 0)
+        {
+            sched_->cancel_and_flush(fd_);
+            ::close(fd_);
+            fd_ = -1;
+        }
+        local_endpoint_  = endpoint{};
+        remote_endpoint_ = endpoint{};
     }
 
     endpoint remote_endpoint() const noexcept override
@@ -2023,10 +1850,9 @@ private:
         {
             if (sched_->try_consume_inline_budget())
             {
-                if (ec)
-                    *ec = stop_now ? capy::error::canceled
-                          : err   ? make_err(err)
-                                  : std::error_code{};
+                decode_io_result(
+                    ec, stop_now, err ? make_err(err) : std::error_code{},
+                    /*is_read=*/false, /*bytes=*/0, /*empty_buffer=*/false);
                 if (bytes)
                     *bytes = (n < 0) ? 0u : static_cast<std::size_t>(n);
                 send_.cont_op.cont.h = h;
@@ -2114,10 +1940,9 @@ private:
         {
             if (sched_->try_consume_inline_budget())
             {
-                if (ec)
-                    *ec = stop_now ? capy::error::canceled
-                          : err   ? make_err(err)
-                                  : std::error_code{};
+                decode_io_result(
+                    ec, stop_now, err ? make_err(err) : std::error_code{},
+                    /*is_read=*/false, /*bytes=*/0, /*empty_buffer=*/false);
                 if (bytes)
                     *bytes = (n < 0) ? 0u : static_cast<std::size_t>(n);
                 if (n >= 0 && want_source && source_out && !empty_buf)
@@ -2190,8 +2015,12 @@ private:
     All public member functions are thread-safe.
 */
 class BOOST_COROSIO_DECL io_uring_udp_service final
-    : public udp_service
+    : public io_uring_socket_service_base<
+          io_uring_udp_service, udp_service, io_uring_udp_socket>
 {
+    using base_service = io_uring_socket_service_base<
+        io_uring_udp_service, udp_service, io_uring_udp_socket>;
+
 public:
     /// Identifies this service for `execution_context` lookup.
     using key_type = udp_service;
@@ -2202,57 +2031,11 @@ public:
             must already be registered.
     */
     explicit io_uring_udp_service(capy::execution_context& ctx)
-        : sched_(&ctx.use_service<io_uring_scheduler>())
+        : base_service(ctx)
     {}
 
-    void shutdown() override
-    {
-        std::vector<std::shared_ptr<io_uring_udp_socket>> live;
-        {
-            std::lock_guard lk(mutex_);
-            live.reserve(impls_.size());
-            for (auto& [_, p] : impls_)
-                live.push_back(p);
-        }
-        // Cancel without the lock held to avoid inversion if cancel()
-        // ever needs to re-enter the service.
-        for (auto& p : live)
-            p->cancel();
-    }
-
-    io_object::implementation* construct() override
-    {
-        auto p   = std::make_shared<io_uring_udp_socket>(*this, *sched_);
-        auto* raw = p.get();
-        std::lock_guard lk(mutex_);
-        impls_.emplace(raw, std::move(p));
-        return raw;
-    }
-
-    void destroy(io_object::implementation* p) override
-    {
-        if (!p)
-            return;
-        std::lock_guard lk(mutex_);
-        impls_.erase(static_cast<io_uring_udp_socket*>(p));
-    }
-
-    // Close the fd eagerly when udp_socket::close() is called, before
-    // destroy() drops the shared_ptr and the destructor runs.
-    void close(io_object::handle& h) override
-    {
-        auto* sock = static_cast<io_uring_udp_socket*>(h.get());
-        if (sock && sock->fd_ >= 0)
-        {
-            // Cancel pending SQEs before closing so the kernel resolves
-            // the fd number while it is still valid.
-            sched_->cancel_and_flush(sock->fd_);
-            ::close(sock->fd_);
-            sock->fd_              = -1;
-            sock->local_endpoint_  = endpoint{};
-            sock->remote_endpoint_ = endpoint{};
-        }
-    }
+    // construct / destroy / shutdown / close / scheduler() are inherited
+    // from io_uring_socket_service_base.
 
     /** Open a datagram socket and associate it with an impl.
 
@@ -2313,15 +2096,6 @@ public:
             sock.local_endpoint_ = sockaddr_to_endpoint(local);
         return {};
     }
-
-    /// Return the scheduler used by sockets created by this service.
-    io_uring_scheduler& scheduler() noexcept { return *sched_; }
-
-private:
-    io_uring_scheduler*  sched_;
-    std::mutex           mutex_;
-    std::unordered_map<io_uring_udp_socket*,
-                       std::shared_ptr<io_uring_udp_socket>> impls_;
 };
 
 /** Unix domain datagram socket implementation for io_uring.
@@ -2341,16 +2115,18 @@ private:
     simultaneously, but two sends or two recvs must not overlap.
 */
 class BOOST_COROSIO_DECL io_uring_local_datagram_socket final
-    : public local_datagram_socket::implementation
-    , public std::enable_shared_from_this<io_uring_local_datagram_socket>
+    : public native_socket_base<
+          io_uring_local_datagram_socket,
+          local_datagram_socket::implementation,
+          corosio::local_endpoint>
 {
     friend io_uring_local_datagram_service;
 
-    int                              fd_    = -1;
     io_uring_scheduler*              sched_ = nullptr;
     io_uring_local_datagram_service* svc_   = nullptr;
 
-    corosio::local_endpoint local_endpoint_;
+    // fd_ and local_endpoint_ live in native_socket_base, which also
+    // provides native_handle/is_open/set_option/get_option/local_endpoint.
     corosio::local_endpoint remote_endpoint_;
 
     // Per-fd op slots — embedded to eliminate per-call heap allocation.
@@ -2523,10 +2299,8 @@ public:
         return {};
     }
 
-    native_handle_type native_handle() const noexcept override
-    {
-        return fd_;
-    }
+    // native_handle / is_open / set_option / get_option / local_endpoint
+    // are inherited from native_socket_base.
 
     native_handle_type release_socket() noexcept override
     {
@@ -2543,37 +2317,18 @@ public:
             sched_->submit_cancel_by_fd(fd_);
     }
 
-    std::error_code set_option(
-        int         level,
-        int         optname,
-        void const* data,
-        std::size_t size) noexcept override
+    /// Cancel in-flight ops, close the fd, and reset cached endpoints.
+    /// Called by the service on close()/teardown.
+    void close_socket() noexcept
     {
-        if (::setsockopt(
-                fd_, level, optname,
-                reinterpret_cast<char const*>(data),
-                static_cast<socklen_t>(size)) != 0)
-            return make_err(errno);
-        return {};
-    }
-
-    std::error_code get_option(
-        int          level,
-        int          optname,
-        void*        data,
-        std::size_t* size) const noexcept override
-    {
-        socklen_t len = static_cast<socklen_t>(*size);
-        if (::getsockopt(fd_, level, optname,
-                reinterpret_cast<char*>(data), &len) != 0)
-            return make_err(errno);
-        *size = static_cast<std::size_t>(len);
-        return {};
-    }
-
-    corosio::local_endpoint local_endpoint() const noexcept override
-    {
-        return local_endpoint_;
+        if (fd_ >= 0)
+        {
+            sched_->cancel_and_flush(fd_);
+            ::close(fd_);
+            fd_ = -1;
+        }
+        local_endpoint_  = corosio::local_endpoint{};
+        remote_endpoint_ = corosio::local_endpoint{};
     }
 
     corosio::local_endpoint remote_endpoint() const noexcept override
@@ -2649,10 +2404,9 @@ private:
         {
             if (sched_->try_consume_inline_budget())
             {
-                if (ec)
-                    *ec = stop_now ? capy::error::canceled
-                          : err   ? make_err(err)
-                                  : std::error_code{};
+                decode_io_result(
+                    ec, stop_now, err ? make_err(err) : std::error_code{},
+                    /*is_read=*/false, /*bytes=*/0, /*empty_buffer=*/false);
                 if (bytes)
                     *bytes = (n < 0) ? 0u : static_cast<std::size_t>(n);
                 send_.cont_op.cont.h = h;
@@ -2740,10 +2494,9 @@ private:
         {
             if (sched_->try_consume_inline_budget())
             {
-                if (ec)
-                    *ec = stop_now ? capy::error::canceled
-                          : err   ? make_err(err)
-                                  : std::error_code{};
+                decode_io_result(
+                    ec, stop_now, err ? make_err(err) : std::error_code{},
+                    /*is_read=*/false, /*bytes=*/0, /*empty_buffer=*/false);
                 if (bytes)
                     *bytes = (n < 0) ? 0u : static_cast<std::size_t>(n);
                 if (n >= 0 && want_source && source_out && !empty_buf)
@@ -2816,8 +2569,14 @@ private:
     All public member functions are thread-safe.
 */
 class BOOST_COROSIO_DECL io_uring_local_datagram_service final
-    : public local_datagram_service
+    : public io_uring_socket_service_base<
+          io_uring_local_datagram_service, local_datagram_service,
+          io_uring_local_datagram_socket>
 {
+    using base_service = io_uring_socket_service_base<
+        io_uring_local_datagram_service, local_datagram_service,
+        io_uring_local_datagram_socket>;
+
 public:
     /// Identifies this service for `execution_context` lookup.
     using key_type = local_datagram_service;
@@ -2828,58 +2587,11 @@ public:
             must already be registered.
     */
     explicit io_uring_local_datagram_service(capy::execution_context& ctx)
-        : sched_(&ctx.use_service<io_uring_scheduler>())
+        : base_service(ctx)
     {}
 
-    void shutdown() override
-    {
-        std::vector<std::shared_ptr<io_uring_local_datagram_socket>> live;
-        {
-            std::lock_guard lk(mutex_);
-            live.reserve(impls_.size());
-            for (auto& [_, p] : impls_)
-                live.push_back(p);
-        }
-        // Cancel without the lock held to avoid inversion if cancel()
-        // ever needs to re-enter the service.
-        for (auto& p : live)
-            p->cancel();
-    }
-
-    io_object::implementation* construct() override
-    {
-        auto p   = std::make_shared<io_uring_local_datagram_socket>(
-            *this, *sched_);
-        auto* raw = p.get();
-        std::lock_guard lk(mutex_);
-        impls_.emplace(raw, std::move(p));
-        return raw;
-    }
-
-    void destroy(io_object::implementation* p) override
-    {
-        if (!p)
-            return;
-        std::lock_guard lk(mutex_);
-        impls_.erase(static_cast<io_uring_local_datagram_socket*>(p));
-    }
-
-    // Close the fd eagerly when local_datagram_socket::close() is called,
-    // before destroy() drops the shared_ptr and the destructor runs.
-    void close(io_object::handle& h) override
-    {
-        auto* sock = static_cast<io_uring_local_datagram_socket*>(h.get());
-        if (sock && sock->fd_ >= 0)
-        {
-            // Cancel pending SQEs before closing so the kernel resolves
-            // the fd number while it is still valid.
-            sched_->cancel_and_flush(sock->fd_);
-            ::close(sock->fd_);
-            sock->fd_              = -1;
-            sock->local_endpoint_  = corosio::local_endpoint{};
-            sock->remote_endpoint_ = corosio::local_endpoint{};
-        }
-    }
+    // construct / destroy / shutdown / close / scheduler() are inherited
+    // from io_uring_socket_service_base.
 
     /** Open an AF_UNIX datagram socket and associate it with an impl.
 
@@ -2971,15 +2683,6 @@ public:
             sock.local_endpoint_ = sockaddr_to_local_endpoint(local, local_len);
         return {};
     }
-
-    /// Return the scheduler used by sockets created by this service.
-    io_uring_scheduler& scheduler() noexcept { return *sched_; }
-
-private:
-    io_uring_scheduler*  sched_;
-    std::mutex           mutex_;
-    std::unordered_map<io_uring_local_datagram_socket*,
-                       std::shared_ptr<io_uring_local_datagram_socket>> impls_;
 };
 
 } // namespace boost::corosio::detail

--- a/include/boost/corosio/native/detail/iocp/win_file_service.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_file_service.hpp
@@ -365,7 +365,7 @@ win_stream_file_internal::read_some(
 
     auto& op = rd_;
     op.reset();
-    op.is_read_  = true;
+    op.is_read  = true;
     op.h         = h;
     op.ex        = ex;
     op.ec_out    = ec;

--- a/include/boost/corosio/native/detail/iocp/win_local_stream_service.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_local_stream_service.hpp
@@ -471,7 +471,7 @@ win_local_stream_socket_internal::read_some(
 
     auto& op = rd_;
     op.reset();
-    op.is_read_  = true;
+    op.is_read  = true;
     op.h         = h;
     op.ex        = d;
     op.ec_out    = ec;

--- a/include/boost/corosio/native/detail/iocp/win_overlapped_op.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_overlapped_op.hpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -16,19 +17,17 @@
 #if BOOST_COROSIO_HAS_IOCP
 
 #include <boost/corosio/detail/config.hpp>
-#include <boost/capy/ex/executor_ref.hpp>
 #include <boost/capy/error.hpp>
 #include <system_error>
 
 #include <boost/corosio/native/detail/make_err.hpp>
 #include <boost/corosio/detail/dispatch_coro.hpp>
-#include <boost/corosio/detail/scheduler_op.hpp>
+#include <boost/corosio/native/detail/coro_op.hpp>
+#include <boost/corosio/native/detail/coro_op_complete.hpp>
 
 #include <atomic>
 #include <coroutine>
 #include <cstddef>
-#include <optional>
-#include <stop_token>
 
 #include <boost/corosio/native/detail/iocp/win_windows.hpp>
 
@@ -45,36 +44,17 @@ namespace boost::corosio::detail {
 */
 struct overlapped_op
     : OVERLAPPED
-    , scheduler_op
+    , coro_op
 {
-    struct canceller
-    {
-        overlapped_op* op;
-        void operator()() const noexcept
-        {
-            op->request_cancel();
-            op->do_cancel();
-        }
-    };
-
     /** Function pointer type for cancellation hook. */
     using cancel_func_type = void (*)(overlapped_op*) noexcept;
 
     long ready_ = 0;
-    std::coroutine_handle<> h;
-    detail::continuation_op cont_op;
-    capy::executor_ref ex;
-    std::error_code* ec_out = nullptr;
-    std::size_t* bytes_out  = nullptr;
     DWORD dwError           = 0;
     DWORD bytes_transferred = 0;
-    bool empty_buffer       = false;
-    bool is_read_           = false;
-    std::atomic<bool> cancelled{false};
-    std::optional<std::stop_callback<canceller>> stop_cb;
     cancel_func_type cancel_func_ = nullptr;
 
-    explicit overlapped_op(func_type func) noexcept : scheduler_op(func)
+    explicit overlapped_op(func_type func) noexcept : coro_op(func)
     {
         reset_overlapped();
     }
@@ -95,14 +75,13 @@ struct overlapped_op
         dwError           = 0;
         bytes_transferred = 0;
         empty_buffer      = false;
-        is_read_          = false;
+        is_read           = false;
         cancelled.store(false, std::memory_order_relaxed);
     }
 
-    void request_cancel() noexcept
-    {
-        cancelled.store(true, std::memory_order_release);
-    }
+    // coro_op::request_cancel() (set the cancelled flag) is inherited
+    // and used directly by close()/cancel() paths. The stop_token path
+    // additionally drives the kernel via on_cancel() below.
 
     void do_cancel() noexcept
     {
@@ -110,13 +89,12 @@ struct overlapped_op
             cancel_func_(this);
     }
 
-    void start(std::stop_token token)
+    /** IOCP cancellation hook (stop_token path): set the flag, then issue
+        the registered CancelIoEx / wait-reactor deregister via cancel_func_. */
+    void on_cancel() noexcept override
     {
-        cancelled.store(false, std::memory_order_release);
-        stop_cb.reset();
-
-        if (token.stop_possible())
-            stop_cb.emplace(token, canceller{this});
+        request_cancel();
+        do_cancel();
     }
 
     void store_result(DWORD bytes, DWORD err) noexcept
@@ -130,17 +108,12 @@ struct overlapped_op
     {
         stop_cb.reset();
 
-        if (ec_out)
-        {
-            if (cancelled.load(std::memory_order_acquire))
-                *ec_out = capy::error::canceled;
-            else if (dwError != 0)
-                *ec_out = make_err(dwError);
-            else if (is_read_ && bytes_transferred == 0 && !empty_buffer)
-                *ec_out = capy::error::eof;
-            else
-                *ec_out = {};
-        }
+        decode_io_result(
+            ec_out,
+            cancelled.load(std::memory_order_acquire),
+            dwError != 0 ? make_err(dwError) : std::error_code{},
+            is_read, static_cast<std::size_t>(bytes_transferred),
+            empty_buffer);
 
         if (bytes_out)
             *bytes_out = static_cast<std::size_t>(bytes_transferred);

--- a/include/boost/corosio/native/detail/iocp/win_random_access_file_service.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_random_access_file_service.hpp
@@ -163,7 +163,7 @@ raf_concurrent_op::do_complete(
             *op->ec_out = capy::error::canceled;
         else if (op->dwError != 0)
             *op->ec_out = make_err(op->dwError);
-        else if (op->is_read_ && op->bytes_transferred == 0 && !op->empty_buffer)
+        else if (op->is_read && op->bytes_transferred == 0 && !op->empty_buffer)
             *op->ec_out = capy::error::eof;
         else
             *op->ec_out = {};
@@ -317,7 +317,7 @@ win_random_access_file_internal::read_some_at(
     op->file_ref = shared_from_this();
 
     op->reset();
-    op->is_read_  = true;
+    op->is_read  = true;
     op->h         = h;
     op->ex        = ex;
     op->ec_out    = ec;
@@ -386,7 +386,7 @@ win_random_access_file_internal::write_some_at(
     op->file_ref = shared_from_this();
 
     op->reset();
-    op->is_read_  = false;
+    op->is_read  = false;
     op->h         = h;
     op->ex        = ex;
     op->ec_out    = ec;

--- a/include/boost/corosio/native/detail/iocp/win_tcp_acceptor_service.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_tcp_acceptor_service.hpp
@@ -573,7 +573,7 @@ win_tcp_socket_internal::read_some(
 
     auto& op = rd_;
     op.reset();
-    op.is_read_  = true;
+    op.is_read  = true;
     op.h         = h;
     op.ex        = d;
     op.ec_out    = ec;

--- a/include/boost/corosio/native/detail/native_socket_base.hpp
+++ b/include/boost/corosio/native/detail/native_socket_base.hpp
@@ -1,0 +1,155 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_NATIVE_DETAIL_NATIVE_SOCKET_BASE_HPP
+#define BOOST_COROSIO_NATIVE_DETAIL_NATIVE_SOCKET_BASE_HPP
+
+#include <boost/corosio/detail/native_handle.hpp>
+#include <boost/corosio/endpoint.hpp>
+#include <boost/corosio/native/detail/endpoint_convert.hpp>
+#include <boost/corosio/native/detail/make_err.hpp>
+
+#include <memory>
+#include <system_error>
+
+#include <errno.h>
+#include <sys/socket.h>
+
+/*
+    Readiness/completion-agnostic socket base for the POSIX-fd backends.
+
+    Holds the part of a socket impl that does not care whether the backend
+    is readiness-based (epoll/kqueue/select, which park ops on a
+    descriptor_state) or completion-based (io_uring, which submits SQEs):
+    the file descriptor, the cached local endpoint, the impl lifecycle
+    bases (enable_shared_from_this + the service's intrusive tracking node),
+    and the synchronous accessors (native_handle / options / bind).
+
+    reactor_basic_socket derives from this and adds the readiness machinery
+    (descriptor_state, register_op, the cancel/close that deregister from
+    the reactor). io_uring's socket impls derive from it and add their op
+    slots + SQE submission. This is the socket-layer analogue of io_uring
+    deriving from reactor_scheduler: io_uring sockets share the reactor's
+    readiness-agnostic socket surface, while the on-EAGAIN action (park vs
+    submit-SQE) and the op model stay backend-specific.
+
+    @tparam Derived   The concrete socket type (CRTP, for shared_from_this
+                      and the intrusive node).
+    @tparam ImplBase  The public vtable base (tcp_socket::implementation,
+                      udp_socket::implementation, ...).
+    @tparam Endpoint  The endpoint type (endpoint or local_endpoint).
+*/
+
+namespace boost::corosio::detail {
+
+template<class Derived, class ImplBase, class Endpoint = endpoint>
+class native_socket_base
+    : public ImplBase
+    , public std::enable_shared_from_this<Derived>
+{
+protected:
+    // CRTP base: not publicly constructible. The check's preferred fix
+    // (private ctor + `friend Derived`) is infeasible here — the reactor
+    // sockets reach this base through intermediate templates
+    // (reactor_stream_socket -> reactor_basic_socket) that are not `Derived`,
+    // so a private ctor would stop those intermediates from constructing it.
+    // Protected is the correct access; suppress the private-only suggestion.
+    native_socket_base() = default;  // NOLINT(bugprone-crtp-constructor-accessibility)
+
+    int      fd_ = -1;
+    // mutable so a derived const local_endpoint() override can lazily fill
+    // it via getsockname() on first read (io_uring's lazy_pending state).
+    mutable Endpoint local_endpoint_;
+
+public:
+    ~native_socket_base() override = default;
+
+    /// Return the underlying file descriptor.
+    native_handle_type native_handle() const noexcept override
+    {
+        return fd_;
+    }
+
+    /// Return the cached local endpoint.
+    Endpoint local_endpoint() const noexcept override
+    {
+        return local_endpoint_;
+    }
+
+    /// Return true if the socket has an open file descriptor.
+    bool is_open() const noexcept
+    {
+        return fd_ >= 0;
+    }
+
+    /// Set a socket option.
+    std::error_code set_option(
+        int level, int optname, void const* data, std::size_t size)
+        noexcept override
+    {
+        if (::setsockopt(
+                fd_, level, optname, data, static_cast<socklen_t>(size)) != 0)
+            return make_err(errno);
+        return {};
+    }
+
+    /// Get a socket option.
+    std::error_code get_option(
+        int level, int optname, void* data, std::size_t* size)
+        const noexcept override
+    {
+        socklen_t len = static_cast<socklen_t>(*size);
+        if (::getsockopt(fd_, level, optname, data, &len) != 0)
+            return make_err(errno);
+        *size = static_cast<std::size_t>(len);
+        return {};
+    }
+
+    /// Assign the file descriptor.
+    void set_socket(int fd) noexcept
+    {
+        fd_ = fd;
+    }
+
+    /// Cache the local endpoint.
+    void set_local_endpoint(Endpoint ep) noexcept
+    {
+        local_endpoint_ = ep;
+    }
+
+    /** Bind the socket to a local endpoint.
+
+        Calls ::bind() and caches the resulting local endpoint via
+        getsockname(). Readiness-agnostic; usable by any fd backend.
+
+        @param ep The endpoint to bind to.
+        @return Error code on failure, empty on success.
+    */
+    std::error_code do_bind(Endpoint const& ep) noexcept
+    {
+        sockaddr_storage storage{};
+        socklen_t addrlen = to_sockaddr(ep, socket_family(fd_), storage);
+        if (::bind(fd_, reinterpret_cast<sockaddr*>(&storage), addrlen) != 0)
+            return make_err(errno);
+
+        sockaddr_storage local_storage{};
+        socklen_t        local_len = sizeof(local_storage);
+        if (::getsockname(
+                fd_, reinterpret_cast<sockaddr*>(&local_storage), &local_len)
+            == 0)
+            local_endpoint_ =
+                from_sockaddr_as(local_storage, local_len, Endpoint{});
+
+        return {};
+    }
+};
+
+} // namespace boost::corosio::detail
+
+#endif // BOOST_COROSIO_NATIVE_DETAIL_NATIVE_SOCKET_BASE_HPP

--- a/include/boost/corosio/native/detail/reactor/reactor_basic_socket.hpp
+++ b/include/boost/corosio/native/detail/reactor/reactor_basic_socket.hpp
@@ -13,6 +13,7 @@
 #include <boost/corosio/detail/intrusive.hpp>
 #include <boost/corosio/detail/native_handle.hpp>
 #include <boost/corosio/endpoint.hpp>
+#include <boost/corosio/native/detail/native_socket_base.hpp>
 #include <boost/corosio/native/detail/reactor/reactor_op_base.hpp>
 #include <boost/corosio/native/detail/make_err.hpp>
 #include <boost/corosio/native/detail/endpoint_convert.hpp>
@@ -51,8 +52,7 @@ template<
     class DescState,
     class Endpoint = endpoint>
 class reactor_basic_socket
-    : public ImplBase
-    , public std::enable_shared_from_this<Derived>
+    : public native_socket_base<Derived, ImplBase, Endpoint>
     , public intrusive_list<Derived>::node
 {
     friend Derived;
@@ -66,96 +66,22 @@ class reactor_basic_socket
     explicit reactor_basic_socket(Service& svc) noexcept : svc_(svc) {}
 
 protected:
+    // fd_ / local_endpoint_ and the synchronous accessors (native_handle,
+    // is_open, set_option/get_option, set_socket/set_local_endpoint, do_bind)
+    // live in native_socket_base — the readiness/completion-agnostic base
+    // shared with io_uring's sockets. The using-declarations make the
+    // inherited members visible to this template's own unqualified
+    // references below (two-phase lookup).
+    using native_socket_base<Derived, ImplBase, Endpoint>::fd_;
+    using native_socket_base<Derived, ImplBase, Endpoint>::local_endpoint_;
+
     Service& svc_;
-    int fd_ = -1;
-    Endpoint local_endpoint_;
 
 public:
     /// Per-descriptor state for persistent reactor registration.
     DescState desc_state_;
 
     ~reactor_basic_socket() override = default;
-
-    /// Return the underlying file descriptor.
-    native_handle_type native_handle() const noexcept override
-    {
-        return fd_;
-    }
-
-    /// Return the cached local endpoint.
-    Endpoint local_endpoint() const noexcept override
-    {
-        return local_endpoint_;
-    }
-
-    /// Return true if the socket has an open file descriptor.
-    bool is_open() const noexcept
-    {
-        return fd_ >= 0;
-    }
-
-    /// Set a socket option.
-    std::error_code set_option(
-        int level,
-        int optname,
-        void const* data,
-        std::size_t size) noexcept override
-    {
-        if (::setsockopt(
-                fd_, level, optname, data, static_cast<socklen_t>(size)) != 0)
-            return make_err(errno);
-        return {};
-    }
-
-    /// Get a socket option.
-    std::error_code
-    get_option(int level, int optname, void* data, std::size_t* size)
-        const noexcept override
-    {
-        socklen_t len = static_cast<socklen_t>(*size);
-        if (::getsockopt(fd_, level, optname, data, &len) != 0)
-            return make_err(errno);
-        *size = static_cast<std::size_t>(len);
-        return {};
-    }
-
-    /// Assign the file descriptor.
-    void set_socket(int fd) noexcept
-    {
-        fd_ = fd;
-    }
-
-    /// Cache the local endpoint.
-    void set_local_endpoint(Endpoint ep) noexcept
-    {
-        local_endpoint_ = ep;
-    }
-
-    /** Bind the socket to a local endpoint.
-
-        Calls ::bind() and caches the resulting local endpoint
-        via getsockname().
-
-        @param ep The endpoint to bind to.
-        @return Error code on failure, empty on success.
-    */
-    std::error_code do_bind(Endpoint const& ep) noexcept
-    {
-        sockaddr_storage storage{};
-        socklen_t addrlen = to_sockaddr(ep, socket_family(fd_), storage);
-        if (::bind(fd_, reinterpret_cast<sockaddr*>(&storage), addrlen) != 0)
-            return make_err(errno);
-
-        sockaddr_storage local_storage{};
-        socklen_t local_len = sizeof(local_storage);
-        if (::getsockname(
-                fd_, reinterpret_cast<sockaddr*>(&local_storage), &local_len) ==
-            0)
-            local_endpoint_ =
-                from_sockaddr_as(local_storage, local_len, Endpoint{});
-
-        return {};
-    }
 
     /// Assign the fd, initialize descriptor state, and register with the reactor.
     void init_and_register(int fd) noexcept

--- a/include/boost/corosio/native/detail/reactor/reactor_op.hpp
+++ b/include/boost/corosio/native/detail/reactor/reactor_op.hpp
@@ -50,41 +50,18 @@ namespace boost::corosio::detail {
 template<class Socket, class Acceptor>
 struct reactor_op : reactor_op_base
 {
-    /// Stop-token callback that invokes cancel() on the target op.
-    struct canceller
-    {
-        reactor_op* op;
-        void operator()() const noexcept
-        {
-            op->cancel();
-        }
-    };
-
-    /// Caller's coroutine handle to resume on completion.
-    std::coroutine_handle<> h;
-
-    /// Scheduler-ready continuation for executor dispatch/post (wraps h).
-    detail::continuation_op cont_op;
-
-    /// Executor for dispatching the completion.
-    capy::executor_ref ex;
-
-    /// Output pointer for the error code.
-    std::error_code* ec_out = nullptr;
-
-    /// Output pointer for bytes transferred.
-    std::size_t* bytes_out = nullptr;
+    // The op envelope — coroutine handle h, cont_op, executor ex, ec_out,
+    // bytes_out, cancelled, stop_cb (+ its canceller), impl_ptr — lives in
+    // coro_op (via reactor_op_base) and is shared with io_uring/IOCP.
+    // reactor_op adds only the reactor-specific routing state below.
 
     /// File descriptor this operation targets.
     int fd = -1;
 
-    /// Stop-token callback registration.
-    std::optional<std::stop_callback<canceller>> stop_cb;
-
-    /// Owning socket impl (for stop_token cancellation).
+    /// Owning socket impl (for stop_token cancellation routing).
     Socket* socket_impl_ = nullptr;
 
-    /// Owning acceptor impl (for stop_token cancellation).
+    /// Owning acceptor impl (for stop_token cancellation routing).
     Acceptor* acceptor_impl_ = nullptr;
 
     reactor_op() = default;
@@ -110,6 +87,13 @@ struct reactor_op : reactor_op_base
     /// Cancel this operation via the owning impl.
     virtual void cancel() noexcept = 0;
 
+    /// coro_op cancellation hook (fired by the shared canceller when the
+    /// stop_token requests cancellation): route to the impl-specific cancel().
+    void on_cancel() noexcept override
+    {
+        cancel();
+    }
+
     /// Destroy without invoking.
     void destroy() override
     {
@@ -120,25 +104,17 @@ struct reactor_op : reactor_op_base
     /// Arm the stop-token callback for a socket operation.
     void start(std::stop_token const& token, Socket* impl)
     {
-        cancelled.store(false, std::memory_order_release);
-        stop_cb.reset();
         socket_impl_   = impl;
         acceptor_impl_ = nullptr;
-
-        if (token.stop_possible())
-            stop_cb.emplace(token, canceller{this});
+        coro_op::start(token);
     }
 
     /// Arm the stop-token callback for an acceptor operation.
     void start(std::stop_token const& token, Acceptor* impl)
     {
-        cancelled.store(false, std::memory_order_release);
-        stop_cb.reset();
         socket_impl_   = nullptr;
         acceptor_impl_ = impl;
-
-        if (token.stop_possible())
-            stop_cb.emplace(token, canceller{this});
+        coro_op::start(token);
     }
 };
 

--- a/include/boost/corosio/native/detail/reactor/reactor_op_base.hpp
+++ b/include/boost/corosio/native/detail/reactor/reactor_op_base.hpp
@@ -10,24 +10,26 @@
 #ifndef BOOST_COROSIO_NATIVE_DETAIL_REACTOR_REACTOR_OP_BASE_HPP
 #define BOOST_COROSIO_NATIVE_DETAIL_REACTOR_REACTOR_OP_BASE_HPP
 
-#include <boost/corosio/detail/scheduler_op.hpp>
+#include <boost/corosio/native/detail/coro_op.hpp>
 
-#include <atomic>
 #include <cstddef>
-#include <memory>
 
 namespace boost::corosio::detail {
 
 /** Non-template base for reactor operations.
 
-    Holds per-operation state accessed by reactor_descriptor_state
-    and reactor_stream_socket without requiring knowledge of the concrete
-    backend socket/acceptor types. This avoids duplicate template
-    instantiations for the descriptor_state and scheduler hot paths.
+    Adds the reactor-specific result model (the recorded errno + bytes and
+    the perform_io() readiness re-run) on top of coro_op, the shared op
+    envelope (coroutine handle, executor, output pointers, stop_token wiring,
+    cancelled flag, impl_ptr keepalive) common to every backend.
 
-    @see reactor_op
+    Kept as a non-template layer so reactor_descriptor_state and the
+    scheduler hot paths can touch op state without knowing the concrete
+    socket/acceptor types.
+
+    @see coro_op, reactor_op
 */
-struct reactor_op_base : scheduler_op
+struct reactor_op_base : coro_op
 {
     /// Errno from the last I/O attempt.
     int errn = 0;
@@ -35,11 +37,7 @@ struct reactor_op_base : scheduler_op
     /// Bytes transferred on success.
     std::size_t bytes_transferred = 0;
 
-    /// True when cancellation has been requested.
-    std::atomic<bool> cancelled{false};
-
-    /// Prevents use-after-free when socket is closed with pending ops.
-    std::shared_ptr<void> impl_ptr;
+    // cancelled, impl_ptr, and request_cancel() are inherited from coro_op.
 
     /// Record the result of an I/O attempt.
     void complete(int err, std::size_t bytes) noexcept
@@ -51,13 +49,7 @@ struct reactor_op_base : scheduler_op
     /// Perform the I/O syscall (overridden by concrete op types).
     virtual void perform_io() noexcept {}
 
-    /// Mark as cancelled (visible to the I/O completion path).
-    void request_cancel() noexcept
-    {
-        cancelled.store(true, std::memory_order_release);
-    }
-
-    /// Destroy without invoking.
+    /// Destroy without invoking — drop the keepalive (impl_ptr from coro_op).
     void destroy() override
     {
         impl_ptr.reset();

--- a/include/boost/corosio/native/detail/reactor/reactor_op_complete.hpp
+++ b/include/boost/corosio/native/detail/reactor/reactor_op_complete.hpp
@@ -11,6 +11,7 @@
 #define BOOST_COROSIO_NATIVE_DETAIL_REACTOR_REACTOR_OP_COMPLETE_HPP
 
 #include <boost/corosio/detail/dispatch_coro.hpp>
+#include <boost/corosio/native/detail/coro_op_complete.hpp>
 #include <boost/corosio/native/detail/endpoint_convert.hpp>
 #include <boost/corosio/native/detail/make_err.hpp>
 #include <boost/corosio/io/io_object.hpp>
@@ -41,21 +42,19 @@ complete_io_op(Op& op)
     op.stop_cb.reset();
     op.socket_impl_->desc_state_.scheduler_->reset_inline_budget();
 
-    if (op.cancelled.load(std::memory_order_acquire))
-        *op.ec_out = capy::error::canceled;
-    else if (op.errn != 0)
-        *op.ec_out = make_err(op.errn);
-    else if (op.is_read_operation() && op.bytes_transferred == 0)
-        *op.ec_out = capy::error::eof;
-    else
-        *op.ec_out = {};
+    // is_read_operation() already folds in the empty-buffer case (it
+    // returns false for a zero-length read), so empty_buffer stays false
+    // here and the shared EOF test reduces to the reactor's original
+    // `is_read && bytes == 0`.
+    decode_io_result(
+        op.ec_out,
+        op.cancelled.load(std::memory_order_acquire),
+        op.errn != 0 ? make_err(op.errn) : std::error_code{},
+        op.is_read_operation(), op.bytes_transferred, /*empty_buffer=*/false);
 
     *op.bytes_out = op.bytes_transferred;
 
-    op.cont_op.cont.h = op.h;
-    capy::executor_ref saved_ex(op.ex);
-    auto prevent = std::move(op.impl_ptr);
-    dispatch_coro(saved_ex, op.cont_op.cont).resume();
+    coro_resume(&op);
 }
 
 /** Complete a datagram recv operation (connected mode).
@@ -73,19 +72,16 @@ complete_dgram_recv_op(Op& op)
     op.stop_cb.reset();
     op.socket_impl_->desc_state_.scheduler_->reset_inline_budget();
 
-    if (op.cancelled.load(std::memory_order_acquire))
-        *op.ec_out = capy::error::canceled;
-    else if (op.errn != 0)
-        *op.ec_out = make_err(op.errn);
-    else
-        *op.ec_out = {};
+    // No EOF: a zero-length datagram is valid (success with 0 bytes).
+    decode_io_result(
+        op.ec_out,
+        op.cancelled.load(std::memory_order_acquire),
+        op.errn != 0 ? make_err(op.errn) : std::error_code{},
+        /*is_read=*/false, /*bytes=*/0, /*empty_buffer=*/false);
 
     *op.bytes_out = op.bytes_transferred;
 
-    op.cont_op.cont.h = op.h;
-    capy::executor_ref saved_ex(op.ex);
-    auto prevent = std::move(op.impl_ptr);
-    dispatch_coro(saved_ex, op.cont_op.cont).resume();
+    coro_resume(&op);
 }
 
 /** Complete a wait operation.
@@ -107,17 +103,14 @@ complete_wait_op(Op& op)
     else
         op.acceptor_impl_->desc_state_.scheduler_->reset_inline_budget();
 
-    if (op.cancelled.load(std::memory_order_acquire))
-        *op.ec_out = capy::error::canceled;
-    else if (op.errn != 0)
-        *op.ec_out = make_err(op.errn);
-    else
-        *op.ec_out = {};
+    // Wait reports only success/cancel/error — no bytes, no EOF.
+    decode_io_result(
+        op.ec_out,
+        op.cancelled.load(std::memory_order_acquire),
+        op.errn != 0 ? make_err(op.errn) : std::error_code{},
+        /*is_read=*/false, /*bytes=*/0, /*empty_buffer=*/false);
 
-    op.cont_op.cont.h = op.h;
-    capy::executor_ref saved_ex(op.ex);
-    auto prevent = std::move(op.impl_ptr);
-    dispatch_coro(saved_ex, op.cont_op.cont).resume();
+    coro_resume(&op);
 }
 
 /** Complete a connect operation with endpoint caching.
@@ -153,17 +146,13 @@ complete_connect_op(Op& op)
         op.socket_impl_->set_endpoints(local_ep, op.target_endpoint);
     }
 
-    if (op.cancelled.load(std::memory_order_acquire))
-        *op.ec_out = capy::error::canceled;
-    else if (op.errn != 0)
-        *op.ec_out = make_err(op.errn);
-    else
-        *op.ec_out = {};
+    decode_io_result(
+        op.ec_out,
+        op.cancelled.load(std::memory_order_acquire),
+        op.errn != 0 ? make_err(op.errn) : std::error_code{},
+        /*is_read=*/false, /*bytes=*/0, /*empty_buffer=*/false);
 
-    op.cont_op.cont.h = op.h;
-    capy::executor_ref saved_ex(op.ex);
-    auto prevent = std::move(op.impl_ptr);
-    dispatch_coro(saved_ex, op.cont_op.cont).resume();
+    coro_resume(&op);
 }
 
 /** Construct and register a peer socket from an accepted fd.
@@ -243,12 +232,11 @@ complete_accept_op(Op& op)
     bool success =
         (op.errn == 0 && !op.cancelled.load(std::memory_order_acquire));
 
-    if (op.cancelled.load(std::memory_order_acquire))
-        *op.ec_out = capy::error::canceled;
-    else if (op.errn != 0)
-        *op.ec_out = make_err(op.errn);
-    else
-        *op.ec_out = {};
+    decode_io_result(
+        op.ec_out,
+        op.cancelled.load(std::memory_order_acquire),
+        op.errn != 0 ? make_err(op.errn) : std::error_code{},
+        /*is_read=*/false, /*bytes=*/0, /*empty_buffer=*/false);
 
     if (success && op.accepted_fd >= 0 && op.acceptor_impl_)
     {
@@ -269,10 +257,7 @@ complete_accept_op(Op& op)
             *op.impl_out = nullptr;
     }
 
-    op.cont_op.cont.h = op.h;
-    capy::executor_ref saved_ex(op.ex);
-    auto prevent = std::move(op.impl_ptr);
-    dispatch_coro(saved_ex, op.cont_op.cont).resume();
+    coro_resume(&op);
 }
 
 /** Complete a datagram operation (send_to or recv_from).
@@ -291,19 +276,16 @@ complete_datagram_op(Op& op)
     op.stop_cb.reset();
     op.socket_impl_->desc_state_.scheduler_->reset_inline_budget();
 
-    if (op.cancelled.load(std::memory_order_acquire))
-        *op.ec_out = capy::error::canceled;
-    else if (op.errn != 0)
-        *op.ec_out = make_err(op.errn);
-    else
-        *op.ec_out = {};
+    // No EOF: a zero-length datagram is valid (success with 0 bytes).
+    decode_io_result(
+        op.ec_out,
+        op.cancelled.load(std::memory_order_acquire),
+        op.errn != 0 ? make_err(op.errn) : std::error_code{},
+        /*is_read=*/false, /*bytes=*/0, /*empty_buffer=*/false);
 
     *op.bytes_out = op.bytes_transferred;
 
-    op.cont_op.cont.h = op.h;
-    capy::executor_ref saved_ex(op.ex);
-    auto prevent = std::move(op.impl_ptr);
-    dispatch_coro(saved_ex, op.cont_op.cont).resume();
+    coro_resume(&op);
 }
 
 /** Complete a datagram operation with source endpoint capture.
@@ -324,12 +306,12 @@ complete_datagram_op(Op& op, Endpoint* source_out)
     op.stop_cb.reset();
     op.socket_impl_->desc_state_.scheduler_->reset_inline_budget();
 
-    if (op.cancelled.load(std::memory_order_acquire))
-        *op.ec_out = capy::error::canceled;
-    else if (op.errn != 0)
-        *op.ec_out = make_err(op.errn);
-    else
-        *op.ec_out = {};
+    // No EOF: a zero-length datagram is valid (success with 0 bytes).
+    decode_io_result(
+        op.ec_out,
+        op.cancelled.load(std::memory_order_acquire),
+        op.errn != 0 ? make_err(op.errn) : std::error_code{},
+        /*is_read=*/false, /*bytes=*/0, /*empty_buffer=*/false);
 
     *op.bytes_out = op.bytes_transferred;
 
@@ -340,10 +322,7 @@ complete_datagram_op(Op& op, Endpoint* source_out)
             op.source_addrlen,
             Endpoint{});
 
-    op.cont_op.cont.h = op.h;
-    capy::executor_ref saved_ex(op.ex);
-    auto prevent = std::move(op.impl_ptr);
-    dispatch_coro(saved_ex, op.cont_op.cont).resume();
+    coro_resume(&op);
 }
 
 } // namespace boost::corosio::detail


### PR DESCRIPTION
… io_uring service plumbing

Deduplicate the backend-independent parts of the native backends without sharing the scheduler loop:

  - coro_op: the shared non-template op envelope (reactor_op_base, io_uring_op, overlapped_op derive from it) + coro_op_complete (drain/resume tail and decode_io_result); each backend keeps its own native-error -> error_code conversion.
  - native_socket_base: socket accessors shared by reactor and io_uring sockets.
  - io_uring_socket_service_base / io_uring_file_service_base: shared io_uring service construct/destroy/shutdown/close plumbing.

The scheduler loop is deliberately not shared — io_uring keeps its leader/follower loop, the reactors share reactor_scheduler, IOCP stays standalone.