### PR TITLE
docs: sort reference operators alphabetically (#254)

### DIFF
--- a/doc/mrdocs.yml
+++ b/doc/mrdocs.yml
@@ -26,4 +26,7 @@ multipage: true
 # use-system-libc: true
 # use-system-stdlib: true
 
+# Sorting
+sort-members-relational-last: false
+
 cmake: '-DCMAKE_CXX_STANDARD=20 -DBOOST_COROSIO_MRDOCS_BUILD=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF'


### PR DESCRIPTION
Disable sort-members-relational-last so operator<< sorts by name instead of being grouped after the "p" functions.

Resolve #254