### PR TITLE
fix(tls): assign OpenSSL and WolfSSL errors a proper error_category

### DIFF
--- a/include/boost/corosio/openssl_stream.hpp
+++ b/include/boost/corosio/openssl_stream.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -19,6 +20,7 @@
 #include <boost/capy/io_task.hpp>
 
 #include <concepts>
+#include <system_error>
 
 namespace boost::corosio {
 
@@ -196,6 +198,24 @@ protected:
 private:
     static impl* make_impl(capy::any_stream& stream, tls_context const& ctx);
 };
+
+/** Return the error category for raw OpenSSL errors.
+
+    Errors reported by @ref openssl_stream that originate from the OpenSSL
+    error queue (`ERR_get_error`) are assigned this category. Its
+    `message()` decodes the packed OpenSSL error code using OpenSSL's own
+    diagnostic strings, so printing such an `error_code` yields a readable
+    description (for example, "certificate verify failed").
+
+    OpenSSL errors whose library is `ERR_LIB_SYS` are reported with
+    `std::system_category()` instead, since their reason code is a genuine
+    `errno` value.
+
+    @return A reference to a static category object with name
+        `"corosio.openssl"`.
+*/
+BOOST_COROSIO_DECL std::error_category const&
+openssl_category() noexcept;
 
 } // namespace boost::corosio
 

--- a/include/boost/corosio/wolfssl_stream.hpp
+++ b/include/boost/corosio/wolfssl_stream.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -19,6 +20,7 @@
 #include <boost/capy/io_task.hpp>
 
 #include <concepts>
+#include <system_error>
 
 namespace boost::corosio {
 
@@ -196,6 +198,20 @@ protected:
 private:
     static impl* make_impl(capy::any_stream& stream, tls_context const& ctx);
 };
+
+/** Return the error category for raw WolfSSL errors.
+
+    Errors reported by @ref wolfssl_stream that originate from
+    `wolfSSL_get_error` are assigned this category. Its `message()`
+    decodes the WolfSSL error code using WolfSSL's own diagnostic
+    strings, so printing such an `error_code` yields a readable
+    description (for example, "ASN no signer error to confirm failure").
+
+    @return A reference to a static category object with name
+        `"corosio.wolfssl"`.
+*/
+BOOST_COROSIO_DECL std::error_category const&
+wolfssl_category() noexcept;
 
 } // namespace boost::corosio
 

--- a/src/openssl/src/openssl_stream.cpp
+++ b/src/openssl/src/openssl_stream.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -102,7 +103,44 @@ normalize_openssl_shutdown_read_error(std::error_code ec) noexcept
     return ec;
 }
 
+class openssl_category_impl final : public std::error_category
+{
+    char const*
+    name() const noexcept override
+    {
+        return "corosio.openssl";
+    }
+
+    std::string
+    message(int value) const override
+    {
+        char buf[256];
+        ::ERR_error_string_n(
+            static_cast<unsigned long>(value), buf, sizeof(buf));
+        return buf;
+    }
+};
+
+// Convert a packed OpenSSL error (from ERR_get_error) into an error_code.
+// Codes from the ERR_LIB_SYS library carry a genuine errno reason and are
+// reported with the system category; everything else uses openssl_category.
+inline std::error_code
+make_openssl_error(unsigned long err) noexcept
+{
+    if (ERR_GET_LIB(err) == ERR_LIB_SYS)
+        return std::error_code(
+            static_cast<int>(ERR_GET_REASON(err)), std::system_category());
+    return std::error_code(static_cast<int>(err), openssl_category());
+}
+
 } // namespace
+
+std::error_category const&
+openssl_category() noexcept
+{
+    static openssl_category_impl instance;
+    return instance;
+}
 
 //
 // Native context caching
@@ -474,16 +512,13 @@ struct openssl_stream::impl
                         if (ssl_err == 0)
                             ec = make_error_code(capy::error::stream_truncated);
                         else
-                            ec = std::error_code(
-                                static_cast<int>(ssl_err),
-                                std::system_category());
+                            ec = make_openssl_error(ssl_err);
                         co_return {ec, total_read};
                     }
                     else
                     {
                         unsigned long ssl_err = ERR_get_error();
-                        ec                    = std::error_code(
-                            static_cast<int>(ssl_err), std::system_category());
+                        ec                    = make_openssl_error(ssl_err);
                         co_return {ec, total_read};
                     }
                 }
@@ -544,8 +579,7 @@ struct openssl_stream::impl
                     else
                     {
                         unsigned long ssl_err = ERR_get_error();
-                        ec                    = std::error_code(
-                            static_cast<int>(ssl_err), std::system_category());
+                        ec                    = make_openssl_error(ssl_err);
                         co_return {ec, total_written};
                     }
                 }
@@ -600,8 +634,7 @@ struct openssl_stream::impl
                 else
                 {
                     unsigned long ssl_err = ERR_get_error();
-                    ec                    = std::error_code(
-                        static_cast<int>(ssl_err), std::system_category());
+                    ec                    = make_openssl_error(ssl_err);
                     co_return {ec};
                 }
             }
@@ -667,8 +700,7 @@ struct openssl_stream::impl
                     }
                     else
                     {
-                        ec = std::error_code(
-                            static_cast<int>(ssl_err), std::system_category());
+                        ec = make_openssl_error(ssl_err);
                     }
                     co_return {ec};
                 }
@@ -683,16 +715,14 @@ struct openssl_stream::impl
         if (!native_ctx)
         {
             unsigned long err = ERR_get_error();
-            return std::error_code(
-                static_cast<int>(err), std::system_category());
+            return make_openssl_error(err);
         }
 
         ssl_ = SSL_new(native_ctx);
         if (!ssl_)
         {
             unsigned long err = ERR_get_error();
-            return std::error_code(
-                static_cast<int>(err), std::system_category());
+            return make_openssl_error(err);
         }
 
         BIO* int_bio = nullptr;
@@ -701,8 +731,7 @@ struct openssl_stream::impl
             unsigned long err = ERR_get_error();
             SSL_free(ssl_);
             ssl_ = nullptr;
-            return std::error_code(
-                static_cast<int>(err), std::system_category());
+            return make_openssl_error(err);
         }
 
         SSL_set_bio(ssl_, int_bio, int_bio);

--- a/src/wolfssl/src/wolfssl_stream.cpp
+++ b/src/wolfssl/src/wolfssl_stream.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -96,7 +97,32 @@ has_peer_shutdown(WOLFSSL* ssl) noexcept
     return wolfSSL_get_shutdown(ssl) != 0;
 }
 
+class wolfssl_category_impl final : public std::error_category
+{
+    char const*
+    name() const noexcept override
+    {
+        return "corosio.wolfssl";
+    }
+
+    std::string
+    message(int value) const override
+    {
+        char buf[WOLFSSL_MAX_ERROR_SZ];
+        wolfSSL_ERR_error_string_n(
+            static_cast<unsigned long>(value), buf, sizeof(buf));
+        return buf;
+    }
+};
+
 } // namespace
+
+std::error_category const&
+wolfssl_category() noexcept
+{
+    static wolfssl_category_impl instance;
+    return instance;
+}
 
 //
 // Native context caching
@@ -558,7 +584,7 @@ struct wolfssl_stream::impl
                         // Other error
                         current_op_ = nullptr;
                         co_return {
-                            std::error_code(err, std::system_category()),
+                            std::error_code(err, wolfssl_category()),
                             total_read};
                     }
                 }
@@ -686,7 +712,7 @@ struct wolfssl_stream::impl
                         // Other error
                         current_op_ = nullptr;
                         co_return {
-                            std::error_code(err, std::system_category()),
+                            std::error_code(err, wolfssl_category()),
                             total_written};
                     }
                 }
@@ -828,7 +854,7 @@ struct wolfssl_stream::impl
                 else
                 {
                     // Other error
-                    ec = std::error_code(err, std::system_category());
+                    ec = std::error_code(err, wolfssl_category());
                     break;
                 }
             }
@@ -936,14 +962,14 @@ struct wolfssl_stream::impl
                 else
                 {
                     // Unexpected error
-                    ec = std::error_code(err, std::system_category());
+                    ec = std::error_code(err, wolfssl_category());
                     break;
                 }
             }
             else
             {
                 // SSL_FATAL_ERROR or negative return
-                ec = std::error_code(err, std::system_category());
+                ec = std::error_code(err, wolfssl_category());
                 break;
             }
         }
@@ -966,7 +992,7 @@ struct wolfssl_stream::impl
         if (!native)
         {
             return std::error_code(
-                wolfSSL_get_error(nullptr, 0), std::system_category());
+                wolfSSL_get_error(nullptr, 0), wolfssl_category());
         }
 
         // Select appropriate context based on role
@@ -977,7 +1003,7 @@ struct wolfssl_stream::impl
         if (!native_ctx)
         {
             return std::error_code(
-                wolfSSL_get_error(nullptr, 0), std::system_category());
+                wolfSSL_get_error(nullptr, 0), wolfssl_category());
         }
 
         // Create SSL session from the role-specific context
@@ -985,7 +1011,7 @@ struct wolfssl_stream::impl
         if (!ssl_)
         {
             int err = wolfSSL_get_error(nullptr, 0);
-            return std::error_code(err, std::system_category());
+            return std::error_code(err, wolfssl_category());
         }
 
         // Set custom I/O callbacks

--- a/test/unit/openssl_stream.cpp
+++ b/test/unit/openssl_stream.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -103,6 +104,42 @@ struct openssl_stream_test
         }
     }
 
+    /** Test that OpenSSL errors carry the OpenSSL category (issue #223).
+
+        Errors from the OpenSSL error queue must render readable messages,
+        not "Unknown error <packed code>" via the system category.
+    */
+    void testErrorCategory()
+    {
+        using namespace test;
+
+        // The category exists, is named, and decodes packed codes rather
+        // than treating them as errno values.
+        BOOST_TEST(openssl_category().name() ==
+            std::string_view("corosio.openssl"));
+
+        // 0x0A000086 is a packed SSL-routines error code (see issue #223).
+        std::error_code ec(0x0A000086, openssl_category());
+        std::string msg = ec.message();
+        BOOST_TEST(!msg.empty());
+        BOOST_TEST(msg.find("Unknown error") == std::string::npos);
+
+        // End-to-end: a certificate-validation failure surfaces an error
+        // in the OpenSSL category, not the system category.
+        {
+            io_context ioc;
+            auto client_ctx = make_untrusted_ca_client_context();
+            auto server_ctx = make_server_context();
+            std::error_code client_ec;
+            run_tls_test_fail(ioc, client_ctx, server_ctx, make_stream,
+                make_stream, &client_ec);
+            BOOST_TEST(client_ec);
+            BOOST_TEST(client_ec.category() == openssl_category());
+            BOOST_TEST(client_ec.message().find("Unknown error") ==
+                std::string::npos);
+        }
+    }
+
     void run()
     {
         test::testHandshakeFuse(make_stream);
@@ -128,6 +165,7 @@ struct openssl_stream_test
         test::testResetFuse(make_stream);
 
         testCertificateChain();
+        testErrorCategory();
         testName();
         testNextLayer();
     }

--- a/test/unit/test_utils.hpp
+++ b/test/unit/test_utils.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -900,7 +901,8 @@ run_tls_test_fail(
     tls_context client_ctx,
     tls_context server_ctx,
     ClientStreamFactory make_client,
-    ServerStreamFactory make_server)
+    ServerStreamFactory make_server,
+    std::error_code* client_ec_out = nullptr)
 {
     auto [s1, s2] = corosio::test::make_socket_pair(ioc);
 
@@ -919,9 +921,11 @@ run_tls_test_fail(
     // Store lambdas in named variables before invoking - anonymous lambda + immediate
     // invocation pattern [...](){}() can cause capture corruption with run_async
     auto client_task = [&client, &client_failed, &client_done, &server_done,
-                        &timeout, &s1, &s2]() -> capy::task<> {
+                        &timeout, &s1, &s2, client_ec_out]() -> capy::task<> {
         auto [ec] = co_await client.handshake(
             std::remove_reference_t<decltype(client)>::client);
+        if (client_ec_out)
+            *client_ec_out = ec;
         if (ec)
         {
             client_failed = true;

--- a/test/unit/wolfssl_stream.cpp
+++ b/test/unit/wolfssl_stream.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -108,6 +109,33 @@ struct wolfssl_stream_test
         // intermediates during handshake.
     }
 
+    /** Test that WolfSSL errors carry the WolfSSL category (issue #223).
+
+        Errors from wolfSSL_get_error must render readable messages, not
+        garbage produced by treating the code as an errno value.
+    */
+    void testErrorCategory()
+    {
+        using namespace test;
+
+        BOOST_TEST(wolfssl_category().name() ==
+            std::string_view("corosio.wolfssl"));
+
+        // End-to-end: a certificate-validation failure surfaces an error
+        // in the WolfSSL category with a non-empty, decoded message.
+        {
+            io_context ioc;
+            auto client_ctx = make_untrusted_ca_client_context();
+            auto server_ctx = make_server_context();
+            std::error_code client_ec;
+            run_tls_test_fail(ioc, client_ctx, server_ctx, make_stream,
+                make_stream, &client_ec);
+            BOOST_TEST(client_ec);
+            BOOST_TEST(client_ec.category() == wolfssl_category());
+            BOOST_TEST(!client_ec.message().empty());
+        }
+    }
+
     void run()
     {
         test::testHandshakeFuse(make_stream);
@@ -137,6 +165,7 @@ struct wolfssl_stream_test
         test::testResetFuse(make_stream);
 
         testCertificateChain();
+        testErrorCategory();
         testName();
         testNextLayer();
     }


### PR DESCRIPTION
Errors from ERR_get_error() (OpenSSL) and wolfSSL_get_error() (WolfSSL) were wrapped in std::system_category(), but these are library-specific codes, not errno values. error_code::message() therefore rendered garbage such as "system:167772294: Unknown error 167772294".

Add a dedicated error_category for each backend whose message() decodes the native code via the library's own string routines, and route every conversion site through it:

- openssl_category() + make_openssl_error(), with ERR_LIB_SYS codes still mapped to std::system_category() since their reason is a genuine errno.
- wolfssl_category() (flat enum, no SYS special-case), rendered via wolfSSL_ERR_error_string_n.

Both categories are public (declared in the respective *_stream.hpp) so callers can detect and compare TLS errors. Add a testErrorCategory unit test per backend; run_tls_test_fail gains an optional client_ec out-parameter to capture the handshake error.

Fixes #223