### PR TITLE
docs: fix snippet-preamble notes and io_uring platform detail

### DIFF
--- a/doc/modules/ROOT/pages/3.tutorials/3e.hash-server.adoc
+++ b/doc/modules/ROOT/pages/3.tutorials/3e.hash-server.adoc
@@ -14,7 +14,9 @@ hash on a thread pool, and sends the result back. You'll learn how to combine
 an `io_context` for network I/O with a `thread_pool` for CPU-bound work,
 switching between them mid-coroutine with `capy::run()`.
 
-NOTE: Code snippets assume:
+[NOTE]
+====
+Code snippets assume:
 [source,cpp]
 ----
 #include <boost/corosio/io_context.hpp>
@@ -30,6 +32,7 @@ NOTE: Code snippets assume:
 namespace corosio = boost::corosio;
 namespace capy = boost::capy;
 ----
+====
 
 == Overview
 

--- a/doc/modules/ROOT/pages/3.tutorials/3f.reconnect.adoc
+++ b/doc/modules/ROOT/pages/3.tutorials/3f.reconnect.adoc
@@ -14,7 +14,9 @@ reconnects with exponential backoff when the connection fails. You'll learn
 how to combine timers with sockets for retry logic and how to use stop tokens
 for graceful shutdown.
 
-NOTE: Code snippets assume:
+[NOTE]
+====
+Code snippets assume:
 [source,cpp]
 ----
 #include <boost/corosio/endpoint.hpp>
@@ -29,6 +31,7 @@ NOTE: Code snippets assume:
 namespace corosio = boost::corosio;
 namespace capy = boost::capy;
 ----
+====
 
 == Overview
 

--- a/doc/modules/ROOT/pages/4.guide/4c.io-context.adoc
+++ b/doc/modules/ROOT/pages/4.guide/4c.io-context.adoc
@@ -301,9 +301,9 @@ On Linux, the `io_context` uses epoll:
 * Edge-triggered notifications
 * Efficient for long-lived connections
 
-==== io_uring — Planned
+==== io_uring
 
-Future Linux support will add io_uring for:
+Linux also provides an io_uring backend:
 
 * Kernel-level async I/O
 * Reduced system calls


### PR DESCRIPTION
- Wrap the "Code snippets assume" preamble in the hash-server and reconnect tutorials in a [NOTE] block so the snippet renders inside the admonition, matching the other pages
- io_context platform details: io_uring is an implemented Linux backend, not planned