### PR TITLE
fix: make the library warning-clean and enforce it in CI (#245)

### DIFF
--- a/include/boost/corosio/detail/config.hpp
+++ b/include/boost/corosio/detail/config.hpp
@@ -17,6 +17,35 @@
 #define BOOST_COROSIO_ASSERT(expr) assert(expr)
 #endif
 
+// MSVC warning suppression helpers.
+// On MSVC these expand to __pragma(); elsewhere they are empty. Used to
+// silence C4251/C4275 (dll-interface) on exported classes whose private
+// members are std:: or detail:: types the clients never touch.
+#ifdef _MSC_VER
+# define BOOST_COROSIO_MSVC_WARNING_PUSH       __pragma(warning(push))
+# define BOOST_COROSIO_MSVC_WARNING_DISABLE(x) __pragma(warning(disable: x))
+# define BOOST_COROSIO_MSVC_WARNING_POP        __pragma(warning(pop))
+#else
+# define BOOST_COROSIO_MSVC_WARNING_PUSH
+# define BOOST_COROSIO_MSVC_WARNING_DISABLE(x)
+# define BOOST_COROSIO_MSVC_WARNING_POP
+#endif
+
+// GCC warning suppression helpers, for GCC-only diagnostics (e.g. -Wtsan).
+// clang rejects unknown warning names under -Werror, so these expand only
+// on real GCC; the warning name is passed as a string, e.g.
+// BOOST_COROSIO_GCC_WARNING_DISABLE("-Wtsan").
+#if defined(__GNUC__) && !defined(__clang__)
+# define BOOST_COROSIO_GCC_DO_PRAGMA(x)       _Pragma(#x)
+# define BOOST_COROSIO_GCC_WARNING_PUSH       _Pragma("GCC diagnostic push")
+# define BOOST_COROSIO_GCC_WARNING_DISABLE(w) BOOST_COROSIO_GCC_DO_PRAGMA(GCC diagnostic ignored w)
+# define BOOST_COROSIO_GCC_WARNING_POP        _Pragma("GCC diagnostic pop")
+#else
+# define BOOST_COROSIO_GCC_WARNING_PUSH
+# define BOOST_COROSIO_GCC_WARNING_DISABLE(w)
+# define BOOST_COROSIO_GCC_WARNING_POP
+#endif
+
 // Symbol export/import for shared libraries
 #if defined(_WIN32) || defined(__CYGWIN__)
 #define BOOST_COROSIO_SYMBOL_EXPORT __declspec(dllexport)

--- a/include/boost/corosio/detail/continuation_op.hpp
+++ b/include/boost/corosio/detail/continuation_op.hpp
@@ -48,7 +48,12 @@ struct continuation_op final : scheduler_op
     // routes to do_complete below.
     void operator()() override
     {
+        // ThreadSanitizer cannot instrument standalone fences; this acquire
+        // fence pairs with the scheduler's release and is intentional.
+        BOOST_COROSIO_GCC_WARNING_PUSH
+        BOOST_COROSIO_GCC_WARNING_DISABLE("-Wtsan")
         std::atomic_thread_fence(std::memory_order_acquire);
+        BOOST_COROSIO_GCC_WARNING_POP
         cont.h.resume();
     }
 
@@ -73,7 +78,10 @@ private:
                 self->cont.h.destroy();
             return;
         }
+        BOOST_COROSIO_GCC_WARNING_PUSH
+        BOOST_COROSIO_GCC_WARNING_DISABLE("-Wtsan")
         std::atomic_thread_fence(std::memory_order_acquire);
+        BOOST_COROSIO_GCC_WARNING_POP
         self->cont.h.resume();
     }
 

--- a/include/boost/corosio/detail/intrusive.hpp
+++ b/include/boost/corosio/detail/intrusive.hpp
@@ -35,8 +35,8 @@ public:
         friend class intrusive_list;
 
     private:
-        T* next_;
-        T* prev_;
+        T* next_ = nullptr;
+        T* prev_ = nullptr;
     };
 
 private:
@@ -172,7 +172,7 @@ public:
         friend class intrusive_queue;
 
     private:
-        T* next_;
+        T* next_ = nullptr;
     };
 
 private:

--- a/include/boost/corosio/detail/timer_service.hpp
+++ b/include/boost/corosio/detail/timer_service.hpp
@@ -122,6 +122,8 @@ private:
     };
 
     scheduler* sched_ = nullptr;
+    BOOST_COROSIO_MSVC_WARNING_PUSH
+    BOOST_COROSIO_MSVC_WARNING_DISABLE(4251) // std:: members, dll-interface
     mutable std::mutex mutex_;
     std::vector<heap_entry> heap_;
     implementation* free_list_     = nullptr;
@@ -131,6 +133,7 @@ private:
     // Avoids mutex in nearest_expiry() and empty()
     mutable std::atomic<std::int64_t> cached_nearest_ns_{
         (std::numeric_limits<std::int64_t>::max)()};
+    BOOST_COROSIO_MSVC_WARNING_POP
 
 public:
     /// Construct the timer service bound to a scheduler.

--- a/include/boost/corosio/io/io_object.hpp
+++ b/include/boost/corosio/io/io_object.hpp
@@ -61,7 +61,7 @@ public:
         creation, closing, and destruction of I/O object
         implementations.
     */
-    struct io_service
+    struct BOOST_COROSIO_DECL io_service
     {
         virtual ~io_service() = default;
 
@@ -224,7 +224,10 @@ protected:
     io_object& operator=(io_object const&) = delete;
 
     /// The platform I/O handle owned by this object.
+    BOOST_COROSIO_MSVC_WARNING_PUSH
+    BOOST_COROSIO_MSVC_WARNING_DISABLE(4251)
     handle h_;
+    BOOST_COROSIO_MSVC_WARNING_POP
 };
 
 } // namespace boost::corosio

--- a/include/boost/corosio/io/io_read_stream.hpp
+++ b/include/boost/corosio/io/io_read_stream.hpp
@@ -85,9 +85,6 @@ protected:
 
     io_read_stream() noexcept = default;
 
-    /// Construct from a handle.
-    explicit io_read_stream(handle h) noexcept : io_object(std::move(h)) {}
-
     io_read_stream(io_read_stream&&) noexcept            = default;
     io_read_stream& operator=(io_read_stream&&) noexcept = delete;
     io_read_stream(io_read_stream const&)                = delete;

--- a/include/boost/corosio/io/io_write_stream.hpp
+++ b/include/boost/corosio/io/io_write_stream.hpp
@@ -85,9 +85,6 @@ protected:
 
     io_write_stream() noexcept = default;
 
-    /// Construct from a handle.
-    explicit io_write_stream(handle h) noexcept : io_object(std::move(h)) {}
-
     io_write_stream(io_write_stream&&) noexcept            = default;
     io_write_stream& operator=(io_write_stream&&) noexcept = delete;
     io_write_stream(io_write_stream const&)                = delete;

--- a/include/boost/corosio/native/detail/io_uring/io_uring_types.hpp
+++ b/include/boost/corosio/native/detail/io_uring/io_uring_types.hpp
@@ -84,7 +84,7 @@ class BOOST_COROSIO_DECL io_uring_tcp_socket final
 
     int                   family_ = AF_UNSPEC;  // cached at open_socket
     io_uring_scheduler*   sched_  = nullptr;
-    io_uring_tcp_service* svc_    = nullptr;
+    [[maybe_unused]] io_uring_tcp_service* svc_    = nullptr;
 
     // fd_ and local_endpoint_ are provided by native_socket_base (the
     // readiness/completion-agnostic socket base shared with the reactor
@@ -858,7 +858,7 @@ class BOOST_COROSIO_DECL io_uring_local_stream_socket final
     friend io_uring_local_stream_service;
 
     io_uring_scheduler*           sched_ = nullptr;
-    io_uring_local_stream_service* svc_  = nullptr;
+    [[maybe_unused]] io_uring_local_stream_service* svc_  = nullptr;
 
     // fd_ and local_endpoint_ live in native_socket_base, which also
     // provides native_handle/is_open/set_option/get_option/local_endpoint.
@@ -1602,7 +1602,7 @@ class BOOST_COROSIO_DECL io_uring_udp_socket final
 
     int                    family_ = AF_UNSPEC;  // cached at open_socket
     io_uring_scheduler*    sched_  = nullptr;
-    io_uring_udp_service*  svc_    = nullptr;
+    [[maybe_unused]] io_uring_udp_service*  svc_    = nullptr;
 
     // fd_ and local_endpoint_ live in native_socket_base, which also
     // provides native_handle/is_open/set_option/get_option/local_endpoint.
@@ -2123,7 +2123,7 @@ class BOOST_COROSIO_DECL io_uring_local_datagram_socket final
     friend io_uring_local_datagram_service;
 
     io_uring_scheduler*              sched_ = nullptr;
-    io_uring_local_datagram_service* svc_   = nullptr;
+    [[maybe_unused]] io_uring_local_datagram_service* svc_   = nullptr;
 
     // fd_ and local_endpoint_ live in native_socket_base, which also
     // provides native_handle/is_open/set_option/get_option/local_endpoint.

--- a/include/boost/corosio/native/detail/iocp/win_file_service.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_file_service.hpp
@@ -94,9 +94,12 @@ private:
         HANDLE, ULONG, void*, ULONG, io_status_block*);
 
     win_scheduler& sched_;
+    BOOST_COROSIO_MSVC_WARNING_PUSH
+    BOOST_COROSIO_MSVC_WARNING_DISABLE(4251) // detail:: members, dll-interface
     win_mutex mutex_;
     intrusive_list<win_stream_file_internal> file_list_;
     intrusive_list<win_stream_file> wrapper_list_;
+    BOOST_COROSIO_MSVC_WARNING_POP
     void* iocp_;
     nt_flush_fn nt_flush_buffers_file_ex_;
 };

--- a/include/boost/corosio/native/detail/iocp/win_local_stream_service.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_local_stream_service.hpp
@@ -116,11 +116,14 @@ private:
 
     win_tcp_service& tcp_svc_;
     win_scheduler& sched_;
+    BOOST_COROSIO_MSVC_WARNING_PUSH
+    BOOST_COROSIO_MSVC_WARNING_DISABLE(4251) // detail:: members, dll-interface
     win_mutex mutex_;
     intrusive_list<win_local_stream_socket_internal> socket_list_;
     intrusive_list<win_local_stream_acceptor_internal> acceptor_list_;
     intrusive_list<win_local_stream_socket> socket_wrapper_list_;
     intrusive_list<win_local_stream_acceptor> acceptor_wrapper_list_;
+    BOOST_COROSIO_MSVC_WARNING_POP
     void* iocp_;
 };
 

--- a/include/boost/corosio/native/detail/iocp/win_random_access_file_service.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_random_access_file_service.hpp
@@ -96,9 +96,12 @@ private:
         HANDLE, ULONG, void*, ULONG, io_status_block*);
 
     win_scheduler& sched_;
+    BOOST_COROSIO_MSVC_WARNING_PUSH
+    BOOST_COROSIO_MSVC_WARNING_DISABLE(4251) // detail:: members, dll-interface
     win_mutex mutex_;
     intrusive_list<win_random_access_file_internal> file_list_;
     intrusive_list<win_random_access_file> wrapper_list_;
+    BOOST_COROSIO_MSVC_WARNING_POP
     void* iocp_;
     nt_flush_fn nt_flush_buffers_file_ex_;
 };

--- a/include/boost/corosio/native/detail/iocp/win_resolver_service.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_resolver_service.hpp
@@ -37,6 +37,9 @@ namespace boost::corosio::detail {
 
     @note Only available on Windows platforms with _WIN32_WINNT >= 0x0602.
 */
+BOOST_COROSIO_MSVC_WARNING_PUSH
+// 4251: std::/detail:: members; 4275: non-exported win_wsa_init base
+BOOST_COROSIO_MSVC_WARNING_DISABLE(4251 4275)
 class BOOST_COROSIO_DECL win_resolver_service final
     : private win_wsa_init
     , public capy::execution_context::service
@@ -96,6 +99,7 @@ private:
     std::unordered_map<win_resolver*, std::shared_ptr<win_resolver>>
         resolver_ptrs_;
 };
+BOOST_COROSIO_MSVC_WARNING_POP
 
 namespace resolver_detail {
 

--- a/include/boost/corosio/native/detail/iocp/win_scheduler.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_scheduler.hpp
@@ -134,12 +134,15 @@ private:
     unsigned long gqcs_timeout_ms_ = 500;
     bool single_threaded_ = false;
 
+    BOOST_COROSIO_MSVC_WARNING_PUSH
+    BOOST_COROSIO_MSVC_WARNING_DISABLE(4251) // std::/detail:: members, dll-interface
     mutable win_mutex dispatch_mutex_;
     mutable op_queue completed_ops_;
     std::unique_ptr<win_timers> timers_;
     std::unique_ptr<win_wait_reactor> wait_reactor_;
     std::once_flag wait_reactor_once_;
     std::atomic<bool> wait_reactor_ready_{false};
+    BOOST_COROSIO_MSVC_WARNING_POP
 
 public:
     /** Auxiliary select-based reactor for IOCP wait operations.

--- a/include/boost/corosio/native/detail/iocp/win_signals.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_signals.hpp
@@ -236,8 +236,11 @@ private:
     static void remove_service(win_signals* service);
 
     win_scheduler& sched_;
+    BOOST_COROSIO_MSVC_WARNING_PUSH
+    BOOST_COROSIO_MSVC_WARNING_DISABLE(4251) // detail:: members, dll-interface
     win_mutex mutex_;
     intrusive_list<win_signal> impl_list_;
+    BOOST_COROSIO_MSVC_WARNING_POP
 
     // Per-signal registration table for this service
     signal_registration* registrations_[max_signal_number];

--- a/include/boost/corosio/native/detail/iocp/win_tcp_service.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_tcp_service.hpp
@@ -190,11 +190,14 @@ private:
     void load_extension_functions();
 
     win_scheduler& sched_;
+    BOOST_COROSIO_MSVC_WARNING_PUSH
+    BOOST_COROSIO_MSVC_WARNING_DISABLE(4251) // detail:: members, dll-interface
     win_mutex mutex_;
     intrusive_list<win_tcp_socket_internal> socket_list_;
     intrusive_list<win_tcp_acceptor_internal> acceptor_list_;
     intrusive_list<win_tcp_socket> socket_wrapper_list_;
     intrusive_list<win_tcp_acceptor> acceptor_wrapper_list_;
+    BOOST_COROSIO_MSVC_WARNING_POP
     void* iocp_;
     LPFN_CONNECTEX connect_ex_ = nullptr;
     LPFN_ACCEPTEX accept_ex_   = nullptr;

--- a/include/boost/corosio/native/detail/iocp/win_timers.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_timers.hpp
@@ -48,7 +48,7 @@ public:
 };
 
 std::unique_ptr<win_timers>
-make_win_timers(void* iocp, long* dispatch_required);
+make_win_timers(void* iocp_handle, long* dispatch_required);
 
 } // namespace boost::corosio::detail
 
@@ -59,15 +59,15 @@ make_win_timers(void* iocp, long* dispatch_required);
 namespace boost::corosio::detail {
 
 inline std::unique_ptr<win_timers>
-make_win_timers(void* iocp, long* dispatch_required)
+make_win_timers(void* iocp_handle, long* dispatch_required)
 {
     // Thread-based is faster; NT API requires one-shot re-association per
     // wakeup which tanks performance. See timers_nt.hpp for details.
-    return std::make_unique<win_timers_thread>(iocp, dispatch_required);
+    return std::make_unique<win_timers_thread>(iocp_handle, dispatch_required);
 
 #if 0
     // NT native API (Windows 8+)
-    if (auto p = win_timers_nt::try_create(iocp, dispatch_required))
+    if (auto p = win_timers_nt::try_create(iocp_handle, dispatch_required))
         return p;
 #endif
 }

--- a/include/boost/corosio/native/detail/iocp/win_timers_nt.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_timers_nt.hpp
@@ -47,7 +47,7 @@ class win_timers_nt final : public win_timers
     NtCancelWaitCompletionPacketFn nt_cancel_;
 
     win_timers_nt(
-        void* iocp,
+        void* iocp_handle,
         long* dispatch_required,
         NtAssociateWaitCompletionPacketFn nt_assoc,
         NtCancelWaitCompletionPacketFn nt_cancel);
@@ -55,7 +55,7 @@ class win_timers_nt final : public win_timers
 public:
     // Returns nullptr if NT APIs unavailable (pre-Windows 8)
     static std::unique_ptr<win_timers_nt>
-    try_create(void* iocp, long* dispatch_required);
+    try_create(void* iocp_handle, long* dispatch_required);
 
     ~win_timers_nt();
 
@@ -121,12 +121,12 @@ using NtCreateWaitCompletionPacketFn = NTSTATUS(NTAPI*)(
     void* ObjectAttributes);
 
 inline win_timers_nt::win_timers_nt(
-    void* iocp,
+    void* iocp_handle,
     long* dispatch_required,
     NtAssociateWaitCompletionPacketFn nt_assoc,
     NtCancelWaitCompletionPacketFn nt_cancel)
     : win_timers(dispatch_required)
-    , iocp_(iocp)
+    , iocp_(iocp_handle)
     , nt_associate_(nt_assoc)
     , nt_cancel_(nt_cancel)
 {
@@ -134,24 +134,31 @@ inline win_timers_nt::win_timers_nt(
 }
 
 inline std::unique_ptr<win_timers_nt>
-win_timers_nt::try_create(void* iocp, long* dispatch_required)
+win_timers_nt::try_create(void* iocp_handle, long* dispatch_required)
 {
     HMODULE ntdll = ::GetModuleHandleW(L"ntdll.dll");
     if (!ntdll)
         return nullptr;
 
+    // GetProcAddress returns FARPROC; cast through void* to the specific NT
+    // entry-point signature (same idiom as win_file_service and
+    // win_random_access_file_service). The void* hop avoids GCC/Clang's
+    // -Wcast-function-type without a compiler-specific pragma.
     auto nt_create = reinterpret_cast<NtCreateWaitCompletionPacketFn>(
-        ::GetProcAddress(ntdll, "NtCreateWaitCompletionPacket"));
+        reinterpret_cast<void*>(
+            ::GetProcAddress(ntdll, "NtCreateWaitCompletionPacket")));
     auto nt_assoc = reinterpret_cast<NtAssociateWaitCompletionPacketFn>(
-        ::GetProcAddress(ntdll, "NtAssociateWaitCompletionPacket"));
+        reinterpret_cast<void*>(
+            ::GetProcAddress(ntdll, "NtAssociateWaitCompletionPacket")));
     auto nt_cancel = reinterpret_cast<NtCancelWaitCompletionPacketFn>(
-        ::GetProcAddress(ntdll, "NtCancelWaitCompletionPacket"));
+        reinterpret_cast<void*>(
+            ::GetProcAddress(ntdll, "NtCancelWaitCompletionPacket")));
 
     if (!nt_create || !nt_assoc || !nt_cancel)
         return nullptr;
 
     auto p = std::unique_ptr<win_timers_nt>(
-        new win_timers_nt(iocp, dispatch_required, nt_assoc, nt_cancel));
+        new win_timers_nt(iocp_handle, dispatch_required, nt_assoc, nt_cancel));
 
     if (!p->waitable_timer_)
         return nullptr;

--- a/include/boost/corosio/native/detail/iocp/win_timers_thread.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_timers_thread.hpp
@@ -30,7 +30,7 @@ class win_timers_thread final : public win_timers
     long shutdown_ = 0;
 
 public:
-    win_timers_thread(void* iocp, long* dispatch_required) noexcept;
+    win_timers_thread(void* iocp_handle, long* dispatch_required) noexcept;
     ~win_timers_thread();
 
     win_timers_thread(win_timers_thread const&)            = delete;
@@ -45,9 +45,9 @@ private:
 };
 
 inline win_timers_thread::win_timers_thread(
-    void* iocp, long* dispatch_required) noexcept
+    void* iocp_handle, long* dispatch_required) noexcept
     : win_timers(dispatch_required)
-    , iocp_(iocp)
+    , iocp_(iocp_handle)
 {
     waitable_timer_ = ::CreateWaitableTimerW(nullptr, FALSE, nullptr);
 }

--- a/include/boost/corosio/native/detail/iocp/win_udp_service.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_udp_service.hpp
@@ -87,9 +87,12 @@ public:
 
 private:
     win_scheduler& sched_;
+    BOOST_COROSIO_MSVC_WARNING_PUSH
+    BOOST_COROSIO_MSVC_WARNING_DISABLE(4251) // detail:: members, dll-interface
     win_mutex mutex_;
     intrusive_list<win_udp_socket_internal> socket_list_;
     intrusive_list<win_udp_socket> wrapper_list_;
+    BOOST_COROSIO_MSVC_WARNING_POP
     void* iocp_;
 };
 

--- a/include/boost/corosio/native/detail/iocp/win_wsa_init.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_wsa_init.hpp
@@ -31,7 +31,7 @@ namespace boost::corosio::detail {
     Derive from this class to ensure Winsock is initialized before
     any socket operations.
 */
-class win_wsa_init
+class BOOST_COROSIO_DECL win_wsa_init
 {
 protected:
     win_wsa_init();
@@ -39,22 +39,28 @@ protected:
 
     win_wsa_init(win_wsa_init const&)            = delete;
     win_wsa_init& operator=(win_wsa_init const&) = delete;
-
-private:
-    static long count_;
 };
 
-inline long win_wsa_init::count_ = 0;
+// Process-wide Winsock init refcount. Kept as an inline function-local
+// static (one shared instance across TUs) rather than a static data member
+// so win_wsa_init can carry BOOST_COROSIO_DECL: an exported/imported static
+// data member defined in a header is rejected by MSVC and clang-cl
+// ("definition of dllimport static field not allowed").
+inline long& win_wsa_init_count() noexcept
+{
+    static long count = 0;
+    return count;
+}
 
 inline win_wsa_init::win_wsa_init()
 {
-    if (::InterlockedIncrement(&count_) == 1)
+    if (::InterlockedIncrement(&win_wsa_init_count()) == 1)
     {
         WSADATA wsaData;
         int result = ::WSAStartup(MAKEWORD(2, 2), &wsaData);
         if (result != 0)
         {
-            ::InterlockedDecrement(&count_);
+            ::InterlockedDecrement(&win_wsa_init_count());
             throw_system_error(make_err(result));
         }
     }
@@ -62,7 +68,7 @@ inline win_wsa_init::win_wsa_init()
 
 inline win_wsa_init::~win_wsa_init()
 {
-    if (::InterlockedDecrement(&count_) == 0)
+    if (::InterlockedDecrement(&win_wsa_init_count()) == 0)
         ::WSACleanup();
 }
 

--- a/include/boost/corosio/openssl_stream.hpp
+++ b/include/boost/corosio/openssl_stream.hpp
@@ -70,7 +70,10 @@ namespace boost::corosio {
 class BOOST_COROSIO_DECL openssl_stream final : public tls_stream
 {
     struct impl;
+    BOOST_COROSIO_MSVC_WARNING_PUSH
+    BOOST_COROSIO_MSVC_WARNING_DISABLE(4251) // capy::any_stream, dll-interface
     capy::any_stream stream_; // must be first - impl_ holds reference
+    BOOST_COROSIO_MSVC_WARNING_POP
     impl* impl_;
 
 public:

--- a/include/boost/corosio/socket_option.hpp
+++ b/include/boost/corosio/socket_option.hpp
@@ -40,7 +40,7 @@ namespace boost::corosio::socket_option {
     Stores a boolean as an `int` suitable for `setsockopt`/`getsockopt`.
     Derived types provide `level()` and `name()` for the specific option.
 */
-class boolean_option
+class BOOST_COROSIO_DECL boolean_option
 {
     int value_ = 0;
 
@@ -115,7 +115,7 @@ public:
     Stores an integer suitable for `setsockopt`/`getsockopt`.
     Derived types provide `level()` and `name()` for the specific option.
 */
-class integer_option
+class BOOST_COROSIO_DECL integer_option
 {
     int value_ = 0;
 
@@ -179,7 +179,7 @@ public:
     `EINVAL` for the four-byte form that Linux accepts. This base provides
     `unsigned char` storage so the same options work on every platform.
 */
-class byte_boolean_option
+class BOOST_COROSIO_DECL byte_boolean_option
 {
     unsigned char value_ = 0;
 
@@ -246,7 +246,7 @@ public:
     `IP_MULTICAST_TTL` to be set with a one-byte value. Linux accepts
     one-byte too, so single-byte storage is portable.
 */
-class byte_integer_option
+class BOOST_COROSIO_DECL byte_integer_option
 {
     unsigned char value_ = 0;
 

--- a/include/boost/corosio/wolfssl_stream.hpp
+++ b/include/boost/corosio/wolfssl_stream.hpp
@@ -70,7 +70,10 @@ namespace boost::corosio {
 class BOOST_COROSIO_DECL wolfssl_stream final : public tls_stream
 {
     struct impl;
+    BOOST_COROSIO_MSVC_WARNING_PUSH
+    BOOST_COROSIO_MSVC_WARNING_DISABLE(4251) // capy::any_stream, dll-interface
     capy::any_stream stream_; // must be first - impl_ holds reference
+    BOOST_COROSIO_MSVC_WARNING_POP
     impl* impl_;
 
 public:

--- a/src/corosio/src/io_context.cpp
+++ b/src/corosio/src/io_context.cpp
@@ -242,6 +242,7 @@ apply_scheduler_options(
 
     (void)sched;
     (void)opts;
+    (void)concurrency_hint;
 }
 
 detail::scheduler&

--- a/src/corosio/src/local_connect_pair.cpp
+++ b/src/corosio/src/local_connect_pair.cpp
@@ -21,6 +21,7 @@
 #elif BOOST_COROSIO_HAS_IOCP
 #include <boost/corosio/native/detail/endpoint_convert.hpp>
 
+#include <algorithm>
 #include <cstring>
 #include <filesystem>
 #include <random>
@@ -161,8 +162,9 @@ make_pair_sockets(SOCKET& a_sock, SOCKET& b_sock) noexcept
 
     detail::un_sa_t addr{};
     addr.sun_family = AF_UNIX;
-    std::strncpy(
-        addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
+    std::memcpy(
+        addr.sun_path, path.c_str(),
+        (std::min)(path.size(), sizeof(addr.sun_path) - 1));
     int addr_len = static_cast<int>(
         offsetof(detail::un_sa_t, sun_path) + path.size() + 1);
 
@@ -198,8 +200,9 @@ make_pair_sockets(SOCKET& a_sock, SOCKET& b_sock) noexcept
 
         detail::un_sa_t caddr{};
         caddr.sun_family = AF_UNIX;
-        std::strncpy(
-            caddr.sun_path, path.c_str(), sizeof(caddr.sun_path) - 1);
+        std::memcpy(
+            caddr.sun_path, path.c_str(),
+            (std::min)(path.size(), sizeof(caddr.sun_path) - 1));
         int caddr_len = static_cast<int>(
             offsetof(detail::un_sa_t, sun_path) + path.size() + 1);
 

--- a/src/corosio/src/udp_socket.cpp
+++ b/src/corosio/src/udp_socket.cpp
@@ -74,7 +74,13 @@ native_handle_type
 udp_socket::native_handle() const noexcept
 {
     if (!is_open())
+    {
+#if BOOST_COROSIO_HAS_IOCP
+        return static_cast<native_handle_type>(~0ull); // INVALID_SOCKET
+#else
         return -1;
+#endif
+    }
     return get().native_handle();
 }
 

--- a/test/unit/Jamfile
+++ b/test/unit/Jamfile
@@ -19,6 +19,8 @@ project boost/corosio/test/unit
       <include>.
       <include>../..
       <target-os>windows:<define>_WIN32_WINNT=0x0602
+      <warnings>extra
+      <warnings-as-errors>on
     ;
 
 # Non-TLS tests (recurses into test/, native/, etc.)


### PR DESCRIPTION
Enable <warnings>extra + <warnings-as-errors>on in the unit test Jamfile (mirroring capy; propagates to the library build, scoped to tests so downstream from-source builds are unaffected) and fix every resulting warning across MSVC, GCC, Clang, clang-cl and MinGW:

- MSVC /W4: drop dead abstract-base constructors (C4589), rename a shadowing timer parameter (C4459), use memcpy over strncpy (C4996), return INVALID_SOCKET not -1 (C4245), mark an unused param (C4100).
- MSVC shared/DLL: export the base classes behind C4275 and suppress C4251 on std::/detail:: members via BOOST_COROSIO_MSVC_WARNING_* macros.
- GCC/Clang: [[maybe_unused]] on reserved io_uring fields; value-init the intrusive node link pointers (fixes the coroutine-frame -Wmaybe-uninitialized at the source); scope the intentional atomic_thread_fence's -Wtsan via new GCC-only BOOST_COROSIO_GCC_WARNING_* macros.
- MinGW: cast GetProcAddress results through void* to avoid -Wcast-function-type.

Closes #245