### PR TITLE
fix(gcc): silence GCC CI false positives (-Wmaybe-uninitialized, -Wtsan)

### DIFF
--- a/include/boost/corosio/native/detail/io_uring/io_uring_scheduler.hpp
+++ b/include/boost/corosio/native/detail/io_uring/io_uring_scheduler.hpp
@@ -636,7 +636,12 @@ io_uring_scheduler::post(std::coroutine_handle<> h) const
         {
             auto saved = h_;
             delete this;
+            // TSan cannot instrument standalone fences; this acquire
+            // pairs with the posting thread's release and is intentional.
+            BOOST_COROSIO_GCC_WARNING_PUSH
+            BOOST_COROSIO_GCC_WARNING_DISABLE("-Wtsan")
             std::atomic_thread_fence(std::memory_order_acquire);
+            BOOST_COROSIO_GCC_WARNING_POP
             saved.resume();
         }
 

--- a/include/boost/corosio/native/detail/reactor/reactor_scheduler.hpp
+++ b/include/boost/corosio/native/detail/reactor/reactor_scheduler.hpp
@@ -490,8 +490,13 @@ reactor_scheduler::post(std::coroutine_handle<> h) const
         {
             auto saved = h_;
             delete this;
-            // Ensure stores from the posting thread are visible
+            // Ensure stores from the posting thread are visible. TSan
+            // cannot instrument standalone fences; this acquire pairs
+            // with the posting thread's release and is intentional.
+            BOOST_COROSIO_GCC_WARNING_PUSH
+            BOOST_COROSIO_GCC_WARNING_DISABLE("-Wtsan")
             std::atomic_thread_fence(std::memory_order_acquire);
+            BOOST_COROSIO_GCC_WARNING_POP
             saved.resume();
         }
 

--- a/test/unit/Jamfile
+++ b/test/unit/Jamfile
@@ -21,6 +21,12 @@ project boost/corosio/test/unit
       <target-os>windows:<define>_WIN32_WINNT=0x0602
       <warnings>extra
       <warnings-as-errors>on
+      # GCC mis-analyzes the structured-binding-from-co_await idiom
+      # (auto [ec, ...] = co_await op) in coroutine frames and reports a
+      # bogus -Wmaybe-uninitialized. The pattern is unavoidable and used by
+      # most async tests, so suppress it for GCC across the test project.
+      # (The library itself is clean; see capy test/unit/Jamfile.)
+      <toolset>gcc:<cxxflags>-Wno-maybe-uninitialized
     ;
 
 # Non-TLS tests (recurses into test/, native/, etc.)


### PR DESCRIPTION
GCC mis-analyzes the structured-binding-from-co_await idiom (auto [ec, ...] = co_await op) inside coroutine frames and reports a bogus -Wmaybe-uninitialized. The pattern is the core async API and is used by most async tests, so suppress it for GCC across the test project (the library itself is warning-clean). Mirrors capy.

Also wrap the two POSIX scheduler post_handler acquire fences (reactor_scheduler, io_uring_scheduler) with the existing -Wtsan suppression macros. TSan cannot instrument standalone fences; these acquire fences pair with the posting thread's release and are intentional. They compile only on Linux, so they slipped past every non-tsan job and failed solely under GCC 15 + -fsanitize=thread, matching the suppression already applied in continuation_op.hpp.