### PR TITLE
fix(iocp): block indefinitely when idle instead of polling every 500ms

### DIFF
--- a/doc/modules/ROOT/pages/4.guide/4c2.configuration.adoc
+++ b/doc/modules/ROOT/pages/4.guide/4c2.configuration.adoc
@@ -73,13 +73,6 @@ corosio::native_io_context<corosio::epoll> ioc(opts);
 | Inline budget when no other thread is running the event loop.
   Prevents a single-threaded context from starving connections.
 
-| `gqcs_timeout_ms`
-| 500
-| IOCP
-| Maximum `GetQueuedCompletionStatus` blocking time in
-  milliseconds.  Lower values improve timer responsiveness at the
-  cost of more syscalls.
-
 | `thread_pool_size`
 | 1
 | POSIX (epoll, kqueue, select)
@@ -140,14 +133,6 @@ fast path.  Multi-thread workloads benefit from cross-thread
 work-stealing, which "post-everything" mode enables.  Setting any
 budget field to a non-default value disables the override.
 ====
-
-=== IOCP Timeout (`gqcs_timeout_ms`)
-
-On Windows, the IOCP scheduler periodically wakes to recheck timers.
-The default 500ms balances responsiveness with efficiency.
-
-* *Sub-second timer precision*: reduce to 50-100ms.
-* *Minimal syscall overhead*: increase to 1000ms or higher.
 
 === Thread Pool Size (`thread_pool_size`)
 

--- a/include/boost/corosio/io_context.hpp
+++ b/include/boost/corosio/io_context.hpp
@@ -89,14 +89,6 @@ struct io_context_options
     */
     unsigned unassisted_budget = 4;
 
-    /** Maximum `GetQueuedCompletionStatus` timeout in milliseconds.
-
-        Bounds how long the IOCP scheduler blocks between timer
-        rechecks. Lower values improve timer responsiveness at the
-        cost of more syscalls. Applies to IOCP only.
-    */
-    unsigned gqcs_timeout_ms = 500;
-
     /** Thread pool size for blocking I/O (file I/O, DNS resolution).
 
         Sets the number of worker threads in the shared thread pool

--- a/include/boost/corosio/native/detail/iocp/win_scheduler.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_scheduler.hpp
@@ -82,15 +82,6 @@ public:
     void work_started() noexcept override;
     void work_finished() noexcept override;
 
-    /** Apply runtime IOCP configuration.
-
-        @param gqcs_timeout_ms  Max GQCS blocking time in milliseconds.
-    */
-    void configure_iocp(unsigned gqcs_timeout_ms) noexcept
-    {
-        gqcs_timeout_ms_ = gqcs_timeout_ms;
-    }
-
     /** Enable or disable single-threaded (lockless) mode.
 
         When enabled, the dispatch mutex becomes a no-op.
@@ -131,7 +122,6 @@ private:
     mutable long stopped_;
     long stop_event_posted_;
     mutable long dispatch_required_;
-    unsigned long gqcs_timeout_ms_ = 500;
     bool single_threaded_ = false;
 
     BOOST_COROSIO_MSVC_WARNING_PUSH
@@ -185,9 +175,11 @@ public:
 
 namespace iocp {
 
-// Max timeout for GQCS to allow periodic re-checking of conditions.
-// Matches Asio's default_gqcs_timeout for pre-Vista compatibility.
-inline constexpr unsigned long max_gqcs_timeout = 500;
+// Poll interval (ms) for the one-time shutdown drain loop. Unlike the
+// steady-state loop (which blocks indefinitely until a real wake-up),
+// the drain must keep re-checking the work count and the deferred
+// completion queue to make progress, so it uses a finite wait.
+inline constexpr unsigned long shutdown_drain_timeout_ms = 500;
 
 struct BOOST_COROSIO_SYMBOL_VISIBLE scheduler_context
 {
@@ -388,10 +380,12 @@ win_scheduler::stop()
         {
             if (!::PostQueuedCompletionStatus(iocp_, 0, key_shutdown, nullptr))
             {
-                // PQCS failure is non-fatal: stopped_ is already set.
-                // The run() loop will notice via the GQCS timeout
-                // (gqcs_timeout_ms_, default 500ms) and exit.
-                ::InterlockedExchange(&dispatch_required_, 1);
+                // The shutdown post is the only thing that wakes a
+                // run()/run_one() thread blocked indefinitely in GQCS.
+                // With no periodic timeout there is no fallback, so a
+                // failed post is fatal (matches Asio). It can only fail
+                // under resource exhaustion (ERROR_NO_SYSTEM_RESOURCES).
+                detail::throw_system_error(make_err(::GetLastError()));
             }
         }
     }
@@ -547,9 +541,7 @@ win_scheduler::do_one(unsigned long timeout_ms)
         ::SetLastError(0);
 
         BOOL result = ::GetQueuedCompletionStatus(
-            iocp_, &bytes, &key, &overlapped,
-            timeout_ms < gqcs_timeout_ms_ ? timeout_ms
-                                        : gqcs_timeout_ms_);
+            iocp_, &bytes, &key, &overlapped, timeout_ms);
         DWORD dwError = ::GetLastError();
 
         // Handle based on completion key
@@ -630,17 +622,14 @@ win_scheduler::do_one(unsigned long timeout_ms)
             }
         }
 
-        // Timeout or error
+        // Timeout or error. INFINITE never times out, so a WAIT_TIMEOUT
+        // can only be a finite caller timeout (wait_one/poll) elapsing
+        // with no work. run()/run_one() pass INFINITE and block until a
+        // real wake-up; they exit only when stop() posts key_shutdown
+        // (a failed post is fatal in stop()).
         if (dwError != WAIT_TIMEOUT)
             detail::throw_system_error(make_err(dwError));
-        if (timeout_ms != INFINITE)
-            return 0;
-        // PQCS-failure fallback: stop() sets stopped_ and
-        // dispatch_required_ but if the key_shutdown post failed,
-        // no completion is ever dequeued.  Catch it here on the
-        // periodic 500 ms GQCS timeout so run()/run_one() can exit.
-        if (stopped())
-            return 0;
+        return 0;
     }
 }
 
@@ -726,7 +715,8 @@ win_scheduler::shutdown()
             ULONG_PTR key;
             LPOVERLAPPED overlapped;
             ::GetQueuedCompletionStatus(
-                iocp_, &bytes, &key, &overlapped, gqcs_timeout_ms_);
+                iocp_, &bytes, &key, &overlapped,
+                iocp::shutdown_drain_timeout_ms);
             if (overlapped)
             {
                 ::InterlockedDecrement(&outstanding_work_);

--- a/include/boost/corosio/native/detail/iocp/win_wait_reactor.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_wait_reactor.hpp
@@ -240,7 +240,16 @@ win_wait_reactor::wake_self() noexcept
     if (wakeup_write_ != INVALID_SOCKET)
     {
         char b = 0;
-        ::send(wakeup_write_, &b, 1, 0);
+        if (::send(wakeup_write_, &b, 1, 0) == SOCKET_ERROR)
+        {
+            // The self-pipe byte is the only thing that wakes the reactor
+            // thread from an indefinite poll(); a coalesced lost wakeup
+            // would leave wake_pending_ stuck true and hang the op.
+            // wakeup_write_ is a blocking socket, so a 1-byte send can
+            // only fail on a hard error -- fatal, mirroring a failed
+            // PostQueuedCompletionStatus in win_scheduler.
+            detail::throw_system_error(make_err(::WSAGetLastError()));
+        }
     }
 }
 
@@ -326,17 +335,15 @@ win_wait_reactor::run()
         for (auto& e : registered_)
             pollfds.push_back({e.fd, events_for_wait(e.w), 0});
 
-        // Bounded timeout rather than infinite: this is a safety net
-        // against a lost self-pipe wakeup (e.g. a failed/coalesced
-        // send in wake_self leaving wake_pending_ stuck true). On
-        // timeout the loop re-drains pending_register_/pending_cancel_
-        // and re-checks stop_, so a missed wakeup costs at most one
-        // poll interval of latency instead of a permanent hang. This
-        // mirrors the 500 ms GQCS safety timeout in win_scheduler.
+        // Block until the self-pipe (slot 0) is poked by a register,
+        // cancel, or stop, or a watched socket becomes ready. There is
+        // no periodic safety-net timeout: a lost self-pipe wakeup is
+        // fatal in wake_self() (the byte send can only fail on a hard
+        // error), so an idle reactor consumes no CPU.
         int n = ::WSAPoll(
             pollfds.data(),
             static_cast<ULONG>(pollfds.size()),
-            500 /* ms */);
+            -1 /* infinite */);
         if (n == SOCKET_ERROR)
             break;
 

--- a/src/corosio/src/io_context.cpp
+++ b/src/corosio/src/io_context.cpp
@@ -235,7 +235,6 @@ apply_scheduler_options(
 
 #if BOOST_COROSIO_HAS_IOCP
     auto& iocp_sched = static_cast<detail::win_scheduler&>(sched);
-    iocp_sched.configure_iocp(opts.gqcs_timeout_ms);
     if (opts.single_threaded)
         iocp_sched.configure_single_threaded(true);
 #endif

--- a/test/unit/io_context.cpp
+++ b/test/unit/io_context.cpp
@@ -276,14 +276,13 @@ struct io_context_test
 
     void testConstructionWithOptions()
     {
-        // Tune reactor budgets (POSIX) and IOCP gqcs timeout so the
-        // option-applying constructor path exercises non-default values.
+        // Tune reactor budgets so the option-applying constructor path
+        // exercises non-default values.
         io_context_options opts;
         opts.max_events_per_poll   = 256;
         opts.inline_budget_initial = 4;
         opts.inline_budget_max     = 32;
         opts.unassisted_budget     = 8;
-        opts.gqcs_timeout_ms       = 250;
 
         io_context ioc(opts, 2);
         BOOST_TEST(!ioc.stopped());


### PR DESCRIPTION
The IOCP scheduler and its auxiliary wait reactor both capped their blocking wait (GetQueuedCompletionStatus / WSAPoll) at 500ms. The 500ms came from Asio's default_gqcs_timeout, but Asio applies it only on pre-Vista Windows to work around a GQCS bug; on Vista+ it uses INFINITE. corosio targets modern Windows only, and timers, posted work, and reactor registrations already wake their loops precisely (waitable timer thread, PostQueuedCompletionStatus, self-pipe). So:

- Both loops now block indefinitely; only the failed wake-up post/send is fatal (matches Asio), since it can only fail under resource exhaustion.
- The one-time shutdown drain loop keeps a finite wait so it makes progress.
- Remove the gqcs_timeout_ms option and configure_iocp(): its only effect was forcing idle wake-ups, and Asio does not expose it.