### PR TITLE
fix(signals): make POSIX signal handling async-signal-safe (#296)

### DIFF
--- a/doc/modules/ROOT/pages/4.guide/4i.signals.adoc
+++ b/doc/modules/ROOT/pages/4.guide/4i.signals.adoc
@@ -422,6 +422,13 @@ On POSIX systems, signals are handled using `sigaction()` which provides:
 The `restart` flag is particularly useful—without it, blocking calls like
 `read()` can fail with `EINTR` when a signal arrives.
 
+The installed handler is async-signal-safe: it only writes the signal number
+to an internal self-pipe (a `write()`, saving and restoring `errno`). It never
+locks a mutex, allocates memory, or dispatches handlers. The event loop drains
+the pipe and completes waiting `wait()` operations in normal context. As a
+result it is safe for a signal to arrive at any time, including while another
+thread is modifying a `signal_set`.
+
 == Next Steps
 
 * xref:4.guide/4h.timers.adoc[Timers] — Timed operations

--- a/include/boost/corosio/detail/scheduler.hpp
+++ b/include/boost/corosio/detail/scheduler.hpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -75,6 +76,22 @@ struct BOOST_COROSIO_DECL scheduler
 
     /// Run at most one ready handler without blocking.
     virtual std::size_t poll_one() = 0;
+
+    /** Register the read end of the POSIX signal self-pipe.
+
+        Called once (by the first signal_set to register a signal) so the
+        backend's event loop watches @p read_fd for readability. When the
+        pipe becomes readable the backend drains it and calls
+        `posix_signal_service::deliver_signal` for each pending signal, in
+        normal thread context. This keeps the C signal handler
+        async-signal-safe: it only writes the signal number to the pipe.
+
+        POSIX backends override this; the default is a no-op (Windows/IOCP
+        uses synchronous C-runtime signal handling instead).
+
+        @param read_fd The read end of the global signal self-pipe.
+    */
+    virtual void register_signal_reader(int read_fd) { (void)read_fd; }
 
     /// True if the scheduler is configured for single-threaded use.
     /// Default false; overridden by backends that support the mode.

--- a/include/boost/corosio/native/detail/epoll/epoll_scheduler.hpp
+++ b/include/boost/corosio/native/detail/epoll/epoll_scheduler.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -18,6 +19,7 @@
 #include <boost/capy/ex/execution_context.hpp>
 
 #include <boost/corosio/native/detail/reactor/reactor_scheduler.hpp>
+#include <boost/corosio/native/detail/reactor/reactor_signal_pipe.hpp>
 
 #include <boost/corosio/native/detail/epoll/epoll_traits.hpp>
 #include <boost/corosio/detail/timer_service.hpp>
@@ -120,6 +122,12 @@ public:
     */
     void deregister_descriptor(int fd) const;
 
+    /// Watch the read end of the POSIX signal self-pipe (see scheduler.hpp).
+    void register_signal_reader(int read_fd) override
+    {
+        register_descriptor(read_fd, signal_pipe_reader_.arm());
+    }
+
 private:
     void
     run_task(lock_type& lock, context_type* ctx,
@@ -130,6 +138,10 @@ private:
     int epoll_fd_;
     int event_fd_;
     int timer_fd_;
+
+    // Watches the global signal self-pipe's read end (armed lazily by
+    // register_signal_reader on the first signal registration).
+    reactor_signal_pipe_reader signal_pipe_reader_;
 
     // Edge-triggered eventfd state
     mutable std::atomic<bool> eventfd_armed_{false};

--- a/include/boost/corosio/native/detail/io_uring/io_uring_scheduler.hpp
+++ b/include/boost/corosio/native/detail/io_uring/io_uring_scheduler.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -91,6 +92,11 @@ public:
     std::size_t poll_one() override;
     void work_started() noexcept override;
     void work_finished() noexcept override;
+
+    /// Watch the read end of the POSIX signal self-pipe (see scheduler.hpp).
+    /// Submits a multishot POLL on @p read_fd; on readiness the drain+deliver
+    /// runs in dispatch context via signal_drain_op_.
+    void register_signal_reader(int read_fd) override;
 
     /** Return the underlying liburing ring.
 
@@ -318,6 +324,35 @@ private:
     int                               cancel_sentinel_ = 0;
     mutable std::atomic<bool>         wakeup_armed_{false};
 
+    // Signal self-pipe integration. The read end is watched via a multishot
+    // POLL SQE tagged with &signal_pipe_sentinel_ (distinct from nullptr =
+    // wakeup eventfd and &cancel_sentinel_). On its CQE we re-arm the poll if
+    // needed and enqueue signal_drain_op_ so the drain+deliver runs in
+    // dispatch context — never under ring_mutex_ — keeping deliver_signal's
+    // mutex locking off the ring critical section.
+    int                               signal_pipe_read_fd_ = -1;
+    int                               signal_pipe_sentinel_ = 0;
+
+    /// Dispatch-context op that drains the signal self-pipe and delivers each
+    /// pending signal. Enqueued (once at a time, guarded by queued_) from
+    /// process_completions when the poll CQE fires. Scheduler-owned; destroy()
+    /// is a no-op.
+    struct signal_drain_op final : scheduler_op
+    {
+        std::atomic<bool> queued_{false};
+
+        void operator()() override
+        {
+            // Clear before draining so a signal that arrives mid-drain re-arms
+            // the op via a fresh CQE rather than being lost.
+            queued_.store(false, std::memory_order_release);
+            posix_signal_detail::drain_signal_pipe();
+        }
+
+        void destroy() override {}
+    };
+    mutable signal_drain_op           signal_drain_op_;
+
     /// Flushes the SQ ring and drains CQEs in one mutex-held pass.
     /// One instance covers a whole batch; subsequent SQEs in the same
     /// batch skip the post, amortising syscall cost across the batch.
@@ -356,6 +391,7 @@ private:
     std::size_t do_one(long timeout_us);
     void        process_completions();
     void        drain_wakeup_eventfd() const noexcept;
+    void        prep_multishot_poll(int fd, void* data) noexcept;
     void        lazy_init_ring_unlocked() const;
 };
 
@@ -622,6 +658,44 @@ io_uring_scheduler::drain_wakeup_eventfd() const noexcept
     // a posting thread that observes wakeup_armed_ == false from this
     // store will see the eventfd already drained by the leader.
     wakeup_armed_.store(false, std::memory_order_release);
+}
+
+inline void
+io_uring_scheduler::prep_multishot_poll(int fd, void* data) noexcept
+{
+    // Prepare a multishot POLLIN SQE on `fd` tagged with `data`. Caller holds
+    // ring_mutex_ and flushes separately (re-arm sites ride the batch submit;
+    // register/init submit explicitly). Best-effort: a get_sqe failure after
+    // one flush leaves the poll un-armed. Shared by the wakeup-eventfd and
+    // signal self-pipe multishot polls.
+    ::io_uring_sqe* sqe = ::io_uring_get_sqe(&ring_);
+    if (!sqe)
+    {
+        ::io_uring_submit(&ring_);
+        sqe = ::io_uring_get_sqe(&ring_);
+    }
+    if (!sqe)
+        return;
+    ::io_uring_prep_poll_multishot(sqe, fd, POLLIN);
+    ::io_uring_sqe_set_data(sqe, data);
+}
+
+inline void
+io_uring_scheduler::register_signal_reader(int read_fd)
+{
+    // Called once per service from add_signal(), holding neither the
+    // signal_state mutex nor the service mutex (see the call site). Submit a
+    // multishot POLL on the pipe read end; its CQE (tagged with
+    // &signal_pipe_sentinel_) is recognised in process_completions. The actual
+    // drain+deliver is deferred to dispatch context, so the only lock taken
+    // here is ring_mutex_ with no outer lock held, hence no lock-order
+    // inversion with the reactor drain path.
+    signal_pipe_read_fd_ = read_fd;
+    lazy_init_ring();
+
+    lock_type lock(ring_mutex_);
+    prep_multishot_poll(read_fd, &signal_pipe_sentinel_);
+    ::io_uring_submit(&ring_);
 }
 
 inline void
@@ -1097,20 +1171,7 @@ io_uring_scheduler::process_completions()
             // pressure or similar), re-arm. Each CQE except the last
             // sets IORING_CQE_F_MORE.
             if ((cqe->flags & IORING_CQE_F_MORE) == 0)
-            {
-                ::io_uring_sqe* re = ::io_uring_get_sqe(&ring_);
-                if (!re)
-                {
-                    ::io_uring_submit(&ring_);
-                    re = ::io_uring_get_sqe(&ring_);
-                }
-                if (re)
-                {
-                    ::io_uring_prep_poll_multishot(
-                        re, wakeup_eventfd_, POLLIN);
-                    ::io_uring_sqe_set_data(re, nullptr);
-                }
-            }
+                prep_multishot_poll(wakeup_eventfd_, nullptr);
         }
         else if (ud == &cancel_sentinel_)
         {
@@ -1118,6 +1179,26 @@ io_uring_scheduler::process_completions()
             // CQE arrives separately and is dispatched via cqe_func.
             // Cancels are one-shot, no F_MORE, decrement inflight.
             ++inflight_dec;
+        }
+        else if (ud == &signal_pipe_sentinel_)
+        {
+            // Signal self-pipe readiness. Re-arm the multishot poll if it
+            // terminated (F_MORE cleared), then enqueue signal_drain_op_ to
+            // drain + deliver in dispatch context. Not counted in
+            // io_uring_inflight_ (like the wakeup eventfd poll): its progress
+            // does not gate DEFER_TASKRUN GETEVENTS.
+            if ((cqe->flags & IORING_CQE_F_MORE) == 0)
+                prep_multishot_poll(
+                    signal_pipe_read_fd_, &signal_pipe_sentinel_);
+            bool expected = false;
+            if (signal_drain_op_.queued_.compare_exchange_strong(
+                    expected, true, std::memory_order_acq_rel,
+                    std::memory_order_relaxed))
+            {
+                // Balance the work_finished() do_one runs after dispatching.
+                work_started();
+                local_ops.push(&signal_drain_op_);
+            }
         }
         else
         {

--- a/include/boost/corosio/native/detail/kqueue/kqueue_scheduler.hpp
+++ b/include/boost/corosio/native/detail/kqueue/kqueue_scheduler.hpp
@@ -1,6 +1,6 @@
 //
-// Copyright (c) 2026 Michael Vandeberg
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -19,6 +19,7 @@
 #include <boost/capy/ex/execution_context.hpp>
 
 #include <boost/corosio/native/detail/reactor/reactor_scheduler.hpp>
+#include <boost/corosio/native/detail/reactor/reactor_signal_pipe.hpp>
 
 #include <boost/corosio/native/detail/kqueue/kqueue_traits.hpp>
 #include <boost/corosio/detail/timer_service.hpp>
@@ -144,6 +145,12 @@ public:
     */
     void deregister_descriptor(int fd) const;
 
+    /// Watch the read end of the POSIX signal self-pipe (see scheduler.hpp).
+    void register_signal_reader(int read_fd) override
+    {
+        register_descriptor(read_fd, signal_pipe_reader_.arm());
+    }
+
 private:
     void
     run_task(lock_type& lock, context_type* ctx,
@@ -152,6 +159,10 @@ private:
     long calculate_timeout(long requested_timeout_us) const;
 
     int kq_fd_;
+
+    // Watches the global signal self-pipe's read end (armed lazily by
+    // register_signal_reader on the first signal registration).
+    reactor_signal_pipe_reader signal_pipe_reader_;
 
     // EVFILT_USER idempotency
     mutable std::atomic<bool> user_event_armed_{false};

--- a/include/boost/corosio/native/detail/posix/posix_signal_service.hpp
+++ b/include/boost/corosio/native/detail/posix/posix_signal_service.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -23,7 +24,10 @@
 
 #include <mutex>
 
+#include <errno.h>
+#include <fcntl.h>
 #include <signal.h>
+#include <unistd.h>
 
 /*
     POSIX Signal Service
@@ -68,15 +72,24 @@
     Signal Delivery Flow
     --------------------
 
-    1. Signal arrives -> corosio_posix_signal_handler() (must be async-signal-safe)
-       -> deliver_signal()
+    Delivery uses the self-pipe trick so the signal handler itself performs
+    only async-signal-safe work (mirrors Boost.Asio):
 
-    2. deliver_signal() iterates all posix_signal_service services:
+    1. Signal arrives -> corosio_posix_signal_handler(). The handler only
+       write()s the signal number to the global self-pipe (write_fd) and
+       restores errno. No locks, no allocation, no scheduler dispatch.
+
+    2. The read end of the pipe is watched by one backend's event loop
+       (registered via scheduler::register_signal_reader on the first
+       registration). When it becomes readable the backend drains it
+       (drain_signal_pipe) and calls deliver_signal() in normal context.
+
+    3. deliver_signal() iterates all posix_signal_service services:
        - If a signal_set is waiting (impl->waiting_ == true), post the signal_op
          to the scheduler for immediate completion
        - Otherwise, increment reg->undelivered to queue the signal
 
-    3. When wait() is called via start_wait():
+    4. When wait() is called via start_wait():
        - First check for queued signals (undelivered > 0); if found, post
          immediate completion without blocking
        - Otherwise, set waiting_ = true and call work_started() to keep
@@ -89,25 +102,17 @@
       1. signal_state::mutex - protects handler registration and service list
       2. posix_signal_service::mutex_ - protects per-service registration tables
 
-    Async-Signal-Safety Limitation
-    ------------------------------
+    Async-Signal-Safety
+    -------------------
 
-    IMPORTANT: deliver_signal() is called from signal handler context and
-    acquires mutexes. This is NOT strictly async-signal-safe per POSIX.
-    The limitation:
-      - If a signal arrives while another thread holds state->mutex or
-        service->mutex_, and that same thread receives the signal, a
-        deadlock can occur (self-deadlock on non-recursive mutex).
-
-    This design trades strict async-signal-safety for implementation simplicity.
-    In practice, deadlocks are rare because:
-      - Mutexes are held only briefly during registration changes
-      - Most programs don't modify signal sets while signals are expected
-      - The window for signal arrival during mutex hold is small
-
-    A fully async-signal-safe implementation would require lock-free data
-    structures and atomic operations throughout, significantly increasing
-    complexity.
+    The C signal handler (corosio_posix_signal_handler) performs only
+    async-signal-safe operations: it reads the single global write_fd and
+    calls write(), saving/restoring errno. It never locks a mutex, allocates
+    memory, or dispatches through the scheduler. All of that happens in
+    deliver_signal(), which runs in normal thread context from the backend
+    event loop after draining the self-pipe. There is therefore no
+    self-deadlock risk if a signal arrives while a thread holds state->mutex
+    or service->mutex_.
 
     Flag Handling
     -------------
@@ -192,6 +197,13 @@ private:
 
     scheduler* sched_;
     std::mutex mutex_;
+
+    // Registers the signal self-pipe's read end with sched_ exactly once per
+    // service, so every io_context that waits on a signal can drain the pipe.
+    // A once_flag (not a bool under mutex_) because registration must run
+    // without holding mutex_ or the signal-state mutex — see add_signal.
+    std::once_flag reader_once_;
+
     intrusive_list<posix_signal> impl_list_;
 
     // Per-signal registration table
@@ -237,6 +249,17 @@ struct signal_state
     posix_signal_service* service_list                      = nullptr;
     std::size_t registration_count[max_signal_number]       = {};
     signal_set::flags_t registered_flags[max_signal_number] = {};
+
+    // Self-pipe used to defer signal delivery out of handler context.
+    // The C handler writes the signal number to write_fd (async-signal-
+    // safe); a backend event loop drains read_fd and calls deliver_signal()
+    // in normal context. Created once (on the first signal registration) and
+    // kept for the process lifetime. Each posix_signal_service registers the
+    // read end with its own scheduler (see reader_once_) so every running
+    // io_context can drain it; multiple readers on one pipe are safe because
+    // each signal is a fixed sizeof(int) record read atomically.
+    int read_fd  = -1;
+    int write_fd = -1;
 };
 
 BOOST_COROSIO_DECL signal_state* get_signal_state();
@@ -288,13 +311,70 @@ flags_compatible(signal_set::flags_t existing, signal_set::flags_t requested)
     return (existing & mask) == (requested & mask);
 }
 
-// C signal handler - must be async-signal-safe
+// Lazily create the global signal self-pipe. Idempotent; call under
+// state->mutex before installing the first signal handler so write_fd is
+// valid by the time the handler can fire. Both ends are non-blocking and
+// close-on-exec (mirrors the reactor self-pipe setup in select_scheduler).
+// Returns false and leaves the fds at -1 if creation fails.
+inline bool
+open_signal_pipe(signal_state* state)
+{
+    if (state->read_fd >= 0)
+        return true;
+
+    int fds[2];
+    if (::pipe(fds) < 0)
+        return false;
+
+    for (int i = 0; i < 2; ++i)
+    {
+        int fl = ::fcntl(fds[i], F_GETFL, 0);
+        if (fl == -1 || ::fcntl(fds[i], F_SETFL, fl | O_NONBLOCK) == -1 ||
+            ::fcntl(fds[i], F_SETFD, FD_CLOEXEC) == -1)
+        {
+            ::close(fds[0]);
+            ::close(fds[1]);
+            return false;
+        }
+    }
+
+    state->read_fd  = fds[0];
+    state->write_fd = fds[1];
+    return true;
+}
+
+// C signal handler. Async-signal-safe: it touches only the single global
+// write_fd (an int set before any handler is installed) and calls write(),
+// which POSIX lists as async-signal-safe. errno is saved and restored so an
+// interrupted foreground syscall is unaffected. A full pipe (write returns
+// EAGAIN) or a short write is intentionally dropped — the reactor still
+// coalesces because deliver_signal reports the signal to every waiting set.
 inline void
 corosio_posix_signal_handler(int signal_number)
 {
-    posix_signal_service::deliver_signal(signal_number);
-    // Note: With sigaction(), the handler persists automatically
-    // (unlike some signal() implementations that reset to SIG_DFL)
+    int saved_errno         = errno;
+    signal_state* state     = get_signal_state();
+    [[maybe_unused]] ssize_t r =
+        ::write(state->write_fd, &signal_number, sizeof(int));
+    errno = saved_errno;
+    // With sigaction(), the handler persists automatically (unlike some
+    // signal() implementations that reset to SIG_DFL).
+}
+
+// Drain the signal self-pipe and deliver each pending signal. Runs in normal
+// thread context from the backend event loop, so deliver_signal()'s mutex
+// locking and scheduler post are safe here. Reads until EAGAIN (edge-
+// triggered backends require a full drain per readiness event).
+inline void
+drain_signal_pipe()
+{
+    signal_state* state = get_signal_state();
+    int signal_number;
+    while (::read(state->read_fd, &signal_number, sizeof(int)) ==
+           static_cast<ssize_t>(sizeof(int)))
+    {
+        posix_signal_service::deliver_signal(signal_number);
+    }
 }
 
 } // namespace posix_signal_detail
@@ -463,6 +543,24 @@ posix_signal_service::add_signal(
 
     posix_signal_detail::signal_state* state =
         posix_signal_detail::get_signal_state();
+
+    // Ensure the global self-pipe exists and this service's scheduler is
+    // watching its read end, BEFORE taking the registration locks. The
+    // reactor drain path locks the descriptor mutex and then the signal-state
+    // and service mutexes; register_signal_reader locks the descriptor mutex
+    // (via register_descriptor), so it must run holding neither of those or
+    // the lock order would invert (a real deadlock, caught by TSan). call_once
+    // makes the once-per-service registration safe when two signal_sets on
+    // this context race add() from different threads.
+    {
+        std::lock_guard state_lock(state->mutex);
+        if (!posix_signal_detail::open_signal_pipe(state))
+            return make_error_code(std::errc::io_error);
+    }
+    std::call_once(reader_once_, [this, state] {
+        sched_->register_signal_reader(state->read_fd);
+    });
+
     std::lock_guard state_lock(state->mutex);
     std::lock_guard lock(mutex_);
 

--- a/include/boost/corosio/native/detail/reactor/reactor_signal_pipe.hpp
+++ b/include/boost/corosio/native/detail/reactor/reactor_signal_pipe.hpp
@@ -1,0 +1,73 @@
+//
+// Copyright (c) 2026 Michael Vandeberg
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/cppalliance/corosio
+//
+
+#ifndef BOOST_COROSIO_NATIVE_DETAIL_REACTOR_REACTOR_SIGNAL_PIPE_HPP
+#define BOOST_COROSIO_NATIVE_DETAIL_REACTOR_REACTOR_SIGNAL_PIPE_HPP
+
+#include <boost/corosio/detail/platform.hpp>
+
+#if BOOST_COROSIO_POSIX
+
+#include <boost/corosio/native/detail/posix/posix_signal_service.hpp>
+#include <boost/corosio/native/detail/reactor/reactor_descriptor_state.hpp>
+#include <boost/corosio/native/detail/reactor/reactor_op_base.hpp>
+
+#include <errno.h>
+
+/*
+    Reactor signal-pipe reader
+    ==========================
+
+    Bridges the global POSIX signal self-pipe (see posix_signal_service.hpp)
+    to the reactor backends (epoll/kqueue/select). The concrete scheduler owns
+    one of these for its lifetime and, in register_signal_reader(), parks the
+    drain op as the descriptor's read_op then calls register_descriptor().
+
+    The drain op never completes: on each read-readiness edge, invoke_deferred_io
+    calls perform_io(), which drains the pipe and delivers the pending signals,
+    then reports EAGAIN so the op stays parked and re-fires on the next edge —
+    exactly the path a socket read op takes when the kernel has no more data.
+    Because deliver_signal() runs here, in normal dispatch context (not in the
+    signal handler and not under the reactor poll lock), its mutex locking is
+    safe.
+*/
+
+namespace boost::corosio::detail {
+
+struct reactor_signal_pipe_reader
+{
+    // Parked read op: drains the self-pipe and re-arms via EAGAIN.
+    struct drain_op final : reactor_op_base
+    {
+        void perform_io() noexcept override
+        {
+            posix_signal_detail::drain_signal_pipe();
+            // Stay parked: EAGAIN tells invoke_deferred_io to keep this op
+            // installed as read_op and re-run it on the next readiness edge.
+            errn = EAGAIN;
+        }
+    };
+
+    reactor_descriptor_state desc;
+    drain_op                 op;
+
+    // Park the drain op and return the descriptor to hand to
+    // scheduler::register_descriptor(read_fd, ...).
+    reactor_descriptor_state* arm() noexcept
+    {
+        desc.read_op = &op;
+        return &desc;
+    }
+};
+
+} // namespace boost::corosio::detail
+
+#endif // BOOST_COROSIO_POSIX
+
+#endif // BOOST_COROSIO_NATIVE_DETAIL_REACTOR_REACTOR_SIGNAL_PIPE_HPP

--- a/include/boost/corosio/native/detail/select/select_scheduler.hpp
+++ b/include/boost/corosio/native/detail/select/select_scheduler.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -18,6 +19,7 @@
 #include <boost/capy/ex/execution_context.hpp>
 
 #include <boost/corosio/native/detail/reactor/reactor_scheduler.hpp>
+#include <boost/corosio/native/detail/reactor/reactor_signal_pipe.hpp>
 
 #include <boost/corosio/native/detail/select/select_traits.hpp>
 #include <boost/corosio/detail/timer_service.hpp>
@@ -124,12 +126,22 @@ public:
     */
     void notify_reactor() const;
 
+    /// Watch the read end of the POSIX signal self-pipe (see scheduler.hpp).
+    void register_signal_reader(int read_fd) override
+    {
+        register_descriptor(read_fd, signal_pipe_reader_.arm());
+    }
+
 private:
     void
     run_task(lock_type& lock, context_type* ctx,
         long timeout_us) override;
     void interrupt_reactor() const override;
     long calculate_timeout(long requested_timeout_us) const;
+
+    // Watches the global signal self-pipe's read end (armed lazily by
+    // register_signal_reader on the first signal registration).
+    reactor_signal_pipe_reader signal_pipe_reader_;
 
     // Self-pipe for interrupting select()
     int pipe_fds_[2]; // [0]=read, [1]=write

--- a/test/unit/signal_set.cpp
+++ b/test/unit/signal_set.cpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -529,6 +530,78 @@ struct signal_set_test
         BOOST_TEST_EQ(wait_count, 2);
     }
 
+    // Async-signal-safety / self-pipe regression tests
+    //
+    // Signals are delivered via a self-pipe: the handler only write()s the
+    // signal number to a pipe and the event loop drains it. These exercise
+    // the drain path repeatedly to catch a broken re-arm (io_uring multishot),
+    // failure to re-park (epoll/kqueue edge-triggered), or a missed drain
+    // (select level-triggered).
+
+    void testManySequentialSignalCycles()
+    {
+        io_context ioc(Backend);
+        signal_set s(ioc, SIGINT);
+
+        constexpr int cycles = 100;
+        int delivered        = 0;
+
+        auto task = [](signal_set& s_ref, int& count_out) -> capy::task<> {
+            for (int i = 0; i < cycles; ++i)
+            {
+                std::raise(SIGINT);
+                auto [ec, signum] = co_await s_ref.wait();
+                BOOST_TEST(!ec);
+                BOOST_TEST_EQ(signum, SIGINT);
+                ++count_out;
+            }
+        };
+        capy::run_async(ioc.get_executor())(task(s, delivered));
+
+        ioc.run();
+        BOOST_TEST_EQ(delivered, cycles);
+    }
+
+    // A signal that arrives while a coroutine is NOT waiting must still be
+    // delivered on the next wait(). Repeat to exercise the queued path (the
+    // undelivered counter) alongside the self-pipe drain across many cycles.
+    void testInterleavedQueuedAndWaitedSignals()
+    {
+        io_context ioc(Backend);
+        signal_set s(ioc, SIGINT);
+        timer t(ioc);
+
+        int delivered = 0;
+
+        auto task = [](signal_set& s_ref, timer& t_ref,
+                       int& count_out) -> capy::task<> {
+            for (int i = 0; i < 20; ++i)
+            {
+                // Raise before waiting: exercises the queued (undelivered)
+                // path where deliver_signal runs with no waiter registered.
+                std::raise(SIGINT);
+                auto [ec1, sig1] = co_await s_ref.wait();
+                BOOST_TEST(!ec1);
+                BOOST_TEST_EQ(sig1, SIGINT);
+                ++count_out;
+
+                // Raise after a delay while waiting: exercises the live-waiter
+                // path where the drain posts a completion.
+                t_ref.expires_after(std::chrono::milliseconds(1));
+                (void)co_await t_ref.wait();
+                std::raise(SIGINT);
+                auto [ec2, sig2] = co_await s_ref.wait();
+                BOOST_TEST(!ec2);
+                BOOST_TEST_EQ(sig2, SIGINT);
+                ++count_out;
+            }
+        };
+        capy::run_async(ioc.get_executor())(task(s, t, delivered));
+
+        ioc.run();
+        BOOST_TEST_EQ(delivered, 40);
+    }
+
     // io_result tests
 
     void testIoResultSuccess()
@@ -849,6 +922,10 @@ struct signal_set_test
 
         // Sequential wait tests
         testSequentialWaits();
+
+        // Async-signal-safety / self-pipe regression tests
+        testManySequentialSignalCycles();
+        testInterleavedQueuedAndWaitedSignals();
 
         // io_result tests
         testIoResultSuccess();


### PR DESCRIPTION
The POSIX C signal handler called deliver_signal() directly, which locks the global signal-state mutex and each service mutex and dispatches through the scheduler. None of that is async-signal-safe; a signal arriving while a thread held one of those mutexes could self-deadlock.

Adopt Asio's self-pipe trick. The handler now performs only async-signal-safe work: it write()s the signal number to a global non-blocking pipe (saving and restoring errno). Each posix_signal_service registers the pipe's read end with its own scheduler; when readable, the event loop drains the pipe and calls the unchanged deliver_signal() in normal thread context.

- scheduler: new register_signal_reader(int) virtual (no-op default; IOCP keeps its synchronous C-runtime handling).
- reactor backends (epoll/kqueue/select): shared reactor_signal_pipe.hpp parks a drain op as the descriptor's read_op and re-arms via EAGAIN.
- io_uring: multishot POLL on the read fd (mirrors the wakeup eventfd); the drain+deliver is deferred to dispatch context so deliver_signal never runs under ring_mutex_.
- Reader registration is per-service (every io_context that waits can drain) and runs via call_once outside the signal-state/service mutexes, so it never locks the descriptor mutex under them (that order inverts the drain path).

Self-pipe (not signalfd) preserves the existing signal_set flags feature (SA_RESTART etc.) and signal-disposition semantics.