### PR TITLE
fix(iocp): use release/acquire ordering for overlapped_op::ready_

### DIFF
--- a/.github/compilers.json
+++ b/.github/compilers.json
@@ -108,6 +108,20 @@
       "b2_toolset": "msvc-14.4",
       "generator": "Visual Studio 17 2022",
       "is_latest": true
+    },
+    {
+      "version": "14.34",
+      "cxxstd": "20",
+      "latest_cxxstd": "20",
+      "runs_on": "windows-11-arm",
+      "b2_toolset": "msvc-14.3"
+    },
+    {
+      "version": "14.44",
+      "cxxstd": "20",
+      "latest_cxxstd": "20",
+      "runs_on": "windows-11-arm",
+      "b2_toolset": "msvc-14.4"
     }
   ],
   "clang-cl": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,8 +251,12 @@ jobs:
           vcpkgJsonGlob: '**/corosio-root/vcpkg.json'
           runVcpkgInstall: true
 
+      # ARM Windows legs skip vcpkg entirely (see Setup vcpkg gate above), so
+      # there is no installed tree to resolve here. They build without TLS;
+      # the boost_corosio_openssl/wolfssl targets become <build>no and the TLS
+      # tests are skipped.
       - name: Set vcpkg paths (Windows)
-        if: ${{ matrix.windows }}
+        if: ${{ matrix.windows && !contains(matrix.runs-on, 'arm') }}
         id: vcpkg-paths-windows
         shell: bash
         run: |
@@ -399,7 +403,7 @@ jobs:
       # WolfSSL reads WOLFSSL_INCLUDE and WOLFSSL_LIBRARY_PATH env vars automatically
       # Linux uses system OpenSSL which B2 finds automatically
       - name: Create B2 user-config for OpenSSL (Windows)
-        if: ${{ matrix.windows }}
+        if: ${{ matrix.windows && !contains(matrix.runs-on, 'arm') }}
         shell: bash
         run: |
           openssl_root="${{ steps.vcpkg-paths-windows.outputs.openssl_root }}"

--- a/include/boost/corosio/native/detail/iocp/win_overlapped_op.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_overlapped_op.hpp
@@ -49,7 +49,13 @@ struct overlapped_op
     /** Function pointer type for cancellation hook. */
     using cancel_func_type = void (*)(overlapped_op*) noexcept;
 
-    long ready_ = 0;
+    /** Completion handshake between the I/O initiator and the GQCS completer,
+        and the release/acquire barrier that publishes the payload: the plain
+        `dwError` / `bytes_transferred` fields are written before a release
+        store to `ready_` and read after an acquiring load, so they need no
+        atomicity of their own. The CAS protocol lives at the access sites in
+        win_scheduler.hpp. */
+    std::atomic<long> ready_{0};
     DWORD dwError           = 0;
     DWORD bytes_transferred = 0;
     cancel_func_type cancel_func_ = nullptr;
@@ -71,7 +77,7 @@ struct overlapped_op
     void reset() noexcept
     {
         reset_overlapped();
-        ready_            = 0;
+        ready_.store(0, std::memory_order_relaxed);
         dwError           = 0;
         bytes_transferred = 0;
         empty_buffer      = false;

--- a/include/boost/corosio/native/detail/iocp/win_scheduler.hpp
+++ b/include/boost/corosio/native/detail/iocp/win_scheduler.hpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2025 Vinnie Falco (vinnie.falco@gmail.com)
 // Copyright (c) 2026 Steve Gerbino
+// Copyright (c) 2026 Michael Vandeberg
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -358,10 +359,14 @@ win_scheduler::work_finished() noexcept
 inline void
 win_scheduler::on_pending(overlapped_op* op) const
 {
-    // CAS: try to set ready_ from 0 to 1.
-    // If the old value was 1, GQCS already grabbed this op and stored
-    // results — we need to re-post so do_one() can dispatch it.
-    if (::InterlockedCompareExchange(&op->ready_, 1, 0) == 1)
+    // If the CAS fails (ready_ was already 1), the completer got here first
+    // and stored the results — re-post so do_one() can dispatch. The acquire
+    // on failure makes those payload writes visible, so the re-posted op
+    // carries valid dwError / bytes_transferred.
+    long expected = 0;
+    if (!op->ready_.compare_exchange_strong(
+            expected, 1,
+            std::memory_order_acq_rel, std::memory_order_acquire))
     {
         if (!::PostQueuedCompletionStatus(
                 iocp_, 0, key_result_stored, static_cast<LPOVERLAPPED>(op)))
@@ -376,10 +381,12 @@ win_scheduler::on_pending(overlapped_op* op) const
 inline void
 win_scheduler::on_completion(overlapped_op* op, DWORD error, DWORD bytes) const
 {
-    // Sync completion: pack results into op and post for dispatch.
-    op->ready_            = 1;
+    // Synchronous-completion path. Write the payload before the release store
+    // to ready_ so the GQCS thread that dequeues the key_result_stored post
+    // sees both fields once it observes ready_ == 1.
     op->dwError           = error;
     op->bytes_transferred = bytes;
+    op->ready_.store(1, std::memory_order_release);
 
     if (!::PostQueuedCompletionStatus(
             iocp_, 0, key_result_stored, static_cast<LPOVERLAPPED>(op)))
@@ -575,24 +582,28 @@ win_scheduler::do_one(unsigned long timeout_ms)
             {
                 auto* ov_op = overlapped_to_op(overlapped);
 
-                // If key_result_stored, results are pre-stored in op fields
-                if (key == key_result_stored)
-                {
-                    bytes = ov_op->bytes_transferred;
-                    err   = ov_op->dwError;
-                }
+                // key_io carries fresh kernel results — publish them before
+                // the CAS so that losing the race (old value 0) still leaves
+                // valid data for the on_pending() re-post. For key_result_stored
+                // the payload was already written and released (by the completer
+                // in on_pending, or by on_completion), so we must not overwrite
+                // it.
+                if (key == key_io)
+                    ov_op->store_result(bytes, err);
 
-                // Store GQCS results so on_pending() re-post has valid data
-                ov_op->store_result(bytes, err);
-
-                // CAS: try to set ready_ from 0 to 1.
-                // If old value was 1, the initiator already returned
-                // (on_pending/on_completion set it) — safe to dispatch.
-                // If old value was 0, the initiator hasn't returned yet —
-                // skip dispatch; on_pending() will re-post.
-                if (::InterlockedCompareExchange(&ov_op->ready_, 1, 0) == 1)
+                // If old value was 1 the initiator already returned — dispatch.
+                // The acquire pairs with the publisher's release so the payload
+                // reads in complete() are ordered after the store that produced
+                // them. If old value was 0 the initiator hasn't returned yet;
+                // skip and let on_pending() re-post.
+                long expected = 0;
+                if (!ov_op->ready_.compare_exchange_strong(
+                        expected, 1,
+                        std::memory_order_acq_rel,
+                        std::memory_order_acquire))
                 {
-                    ov_op->complete(this, bytes, err);
+                    ov_op->complete(
+                        this, ov_op->bytes_transferred, ov_op->dwError);
                     work_finished();
                     return 1;
                 }

--- a/test/unit/native/iocp/iocp_shutdown.cpp
+++ b/test/unit/native/iocp/iocp_shutdown.cpp
@@ -90,9 +90,9 @@ struct iocp_shutdown_test
             void* ioc = ctx.iocp_handle();
 
             auto* op              = new test_overlapped_op(destroyed);
-            op->ready_            = 1;
             op->dwError           = 0;
             op->bytes_transferred = 42;
+            op->ready_.store(1, std::memory_order_relaxed);
 
             ex.on_work_started();
 
@@ -122,9 +122,9 @@ struct iocp_shutdown_test
                 ioc, 0, detail::key_io, static_cast<LPOVERLAPPED>(io_op));
 
             auto* stored_op    = new test_overlapped_op(stored_destroyed);
-            stored_op->ready_  = 1;
             stored_op->dwError = 0;
             stored_op->bytes_transferred = 0;
+            stored_op->ready_.store(1, std::memory_order_relaxed);
             ex.on_work_started();
             ::PostQueuedCompletionStatus(
                 ioc, 0, detail::key_result_stored,


### PR DESCRIPTION
The IOCP completion handshake published dwError/bytes_transferred through a plain `long ready_` that was accessed via both InterlockedCompareExchange and a plain store, with no release/acquire ordering on the payload — a data race in the C++ memory model and an ordering bug on weak-memory targets (ARM64).

Make ready_ a std::atomic<long> used as the single release/acquire guard:
  - on_completion writes the payload before a release store of ready_ (previously the flag was set before the payload)
  - on_pending and do_one use acq_rel/acquire compare_exchange
  - do_one reads the payload only after the acquiring CAS (drops the one pre-CAS read), so no site depends on the PQCS/GQCS kernel barrier for payload visibility

The payload fields stay plain DWORD, guarded by ready_, mirroring the existing `cancelled` flag idiom (one atomic guard + plain data).

Also add windows-11-arm MSVC CI legs (14.34, 14.44) so the IOCP backend is exercised on a weak-memory platform — every existing IOCP leg runs on x86-64 (TSO), where this ordering bug cannot surface. The ARM legs build without TLS: vcpkg is skipped on ARM, so boost_corosio_openssl/wolfssl become <build>no and their tests skip, matching how the Linux ARM legs already skip WolfSSL. Two CI steps that required the vcpkg tree are now gated off ARM.

Closes #300