### PR TITLE
fix(tls)!: surface canceled (not stream_truncated) on cancelled shutd…

### DIFF
--- a/include/boost/corosio/timeout.hpp
+++ b/include/boost/corosio/timeout.hpp
@@ -25,9 +25,9 @@ namespace boost::corosio {
     Starts the awaitable with an interposed stop token and arms a
     timer. If the awaitable finishes first, its result is returned
     as-is (success, error, or exception). If the deadline passes
-    first, the awaitable is cancelled and an `io_result` with
-    `ec == capy::error::timeout` and default-initialized payload
-    is produced.
+    first, the awaitable is cancelled and an `io_result` whose
+    `ec` compares equal to `capy::cond::timeout` (with a
+    default-initialized payload) is produced.
 
     Exceptions from the inner awaitable always propagate; they are
     never swallowed by the timer.

--- a/src/openssl/src/openssl_stream.cpp
+++ b/src/openssl/src/openssl_stream.cpp
@@ -12,6 +12,7 @@
 #include <boost/corosio/detail/config.hpp>
 #include <boost/capy/detail/buffer_array.hpp>
 #include <boost/capy/ex/async_mutex.hpp>
+#include <boost/capy/cond.hpp>
 #include <boost/capy/error.hpp>
 #include <boost/capy/write.hpp>
 
@@ -119,9 +120,10 @@ normalize_openssl_shutdown_read_error(std::error_code ec) noexcept
     if (!ec)
         return ec;
 
-    if (ec == make_error_code(capy::error::eof) ||
-        ec == make_error_code(capy::error::canceled) ||
-        ec == std::errc::connection_reset ||
+    // A peer that closed without a proper close_notify is a truncated stream.
+    // Cancellation is deliberately excluded: a stopped shutdown must surface as
+    // canceled, not stream_truncated.
+    if (ec == capy::cond::eof || ec == std::errc::connection_reset ||
         ec == std::errc::connection_aborted || ec == std::errc::broken_pipe)
         return make_error_code(capy::error::stream_truncated);
 
@@ -802,7 +804,7 @@ struct openssl_stream::impl
                         ec = co_await read_input();
                         if (ec)
                         {
-                            if (ec == make_error_code(capy::error::eof))
+                            if (ec == capy::cond::eof)
                             {
                                 if (SSL_get_shutdown(ssl_) &
                                     SSL_RECEIVED_SHUTDOWN)

--- a/src/wolfssl/src/wolfssl_stream.cpp
+++ b/src/wolfssl/src/wolfssl_stream.cpp
@@ -12,6 +12,7 @@
 #include <boost/corosio/detail/config.hpp>
 #include <boost/capy/detail/buffer_array.hpp>
 #include <boost/capy/ex/async_mutex.hpp>
+#include <boost/capy/cond.hpp>
 #include <boost/capy/error.hpp>
 #include <boost/capy/write.hpp>
 
@@ -876,7 +877,7 @@ struct wolfssl_stream::impl
                         auto [rec, rn] = co_await s_->read_some(rbuf);
                         if (rec)
                         {
-                            if (rec == make_error_code(capy::error::eof))
+                            if (rec == capy::cond::eof)
                             {
                                 // Check if we got a proper TLS shutdown
                                 if (has_peer_shutdown(ssl_))
@@ -1293,7 +1294,15 @@ struct wolfssl_stream::impl
                     capy::async_mutex::lock_guard io_guard(&io_cm_);
                     auto [rec, rn] = co_await s_->read_some(rbuf);
                     if (rec)
-                        break; // EOF or socket error during shutdown read - acceptable
+                    {
+                        // EOF or a socket error during the shutdown read is
+                        // acceptable, but a cancel must be surfaced so a stopped
+                        // shutdown reports canceled. Compare by condition so 
+                        // both representations of the cancel match.
+                        if (rec == capy::cond::canceled)
+                            ec = rec;
+                        break;
+                    }
                     read_in_len_ += rn;
                 }
                 else if (err == WOLFSSL_ERROR_WANT_WRITE)

--- a/test/unit/openssl_stream.cpp
+++ b/test/unit/openssl_stream.cpp
@@ -161,6 +161,7 @@ struct openssl_stream_test
         test::testTlsShutdown(make_stream, cert_modes);
         test::testStreamTruncated(make_stream, cert_modes);
         test::testStopTokenCancellation(make_stream);
+        test::testShutdownCancel(make_stream);
         test::testSocketErrorPropagation(make_stream);
         test::testCertificateValidation(make_stream);
         test::testSni(make_stream);

--- a/test/unit/test_utils.hpp
+++ b/test/unit/test_utils.hpp
@@ -2315,6 +2315,145 @@ run_stop_token_read_test(
         s2.close();
 }
 
+/** How the shutdown read is cancelled in run_shutdown_cancel_test. */
+enum class shutdown_cancel_mode
+{
+    // Cancel the whole task via std::stop_token. The pending socket read then
+    // completes with the generic std::errc::operation_canceled.
+    stop_token,
+    // Cancel just the socket via socket.cancel(). The pending read completes
+    // with the capy-category capy::error::canceled.
+    socket_cancel
+};
+
+/** Run a test for cancellation during TLS shutdown.
+
+    Regression test for cppalliance/corosio#301: cancelling a TLS task while it
+    is blocked reading the peer's close_notify during shutdown must surface
+    cond::canceled, not cond::stream_truncated (OpenSSL) and not a silent
+    success (WolfSSL).
+
+    Both cancel representations are exercised via @p mode (see
+    shutdown_cancel_mode): OpenSSL's normalize historically folded the
+    capy-category form into stream_truncated, so only socket_cancel reproduced
+    that bug, while WolfSSL swallowed either form. cond::canceled matches both.
+
+    The test is deterministic: the client initiates shutdown (sending its own
+    close_notify); the server reads that close_notify (proving the client's
+    write has landed) and then yields via a short delay so the io_context
+    resumes the client past its flush and parks it blocking on the peer read.
+    Only then does the server trigger cancellation, guaranteeing it hits the
+    shutdown *read*. The server never sends its own close_notify and never
+    closes the socket, so the client stays blocked until cancelled.
+*/
+template<typename ClientStreamFactory, typename ServerStreamFactory>
+void
+run_shutdown_cancel_test(
+    io_context& ioc,
+    tls_context client_ctx,
+    tls_context server_ctx,
+    ClientStreamFactory make_client,
+    ServerStreamFactory make_server,
+    shutdown_cancel_mode mode)
+{
+    auto [s1, s2] = corosio::test::make_socket_pair(ioc);
+
+    auto client = make_client(s1, client_ctx);
+    auto server = make_server(s2, server_ctx);
+
+    // Handshake phase
+    auto client_hs = [&client]() -> capy::task<> {
+        auto [ec] = co_await client.handshake(
+            std::remove_reference_t<decltype(client)>::client);
+        BOOST_TEST(!ec);
+    };
+
+    auto server_hs = [&server]() -> capy::task<> {
+        auto [ec] = co_await server.handshake(
+            std::remove_reference_t<decltype(server)>::server);
+        BOOST_TEST(!ec);
+    };
+
+    capy::run_async(ioc.get_executor())(client_hs());
+    capy::run_async(ioc.get_executor())(server_hs());
+
+    ioc.run();
+    ioc.restart();
+
+    // Shutdown cancellation phase
+    std::stop_source stop_src;
+    std::error_code shutdown_ec;
+    bool shutdown_done = false;
+
+    // Failsafe deadline - 2000ms allows headroom for CI with coverage instrumentation
+    std::stop_source failsafe_stop;
+
+    auto client_shutdown = [&client, &shutdown_ec, &shutdown_done,
+                            &failsafe_stop]() -> capy::task<> {
+        auto [ec]     = co_await client.shutdown();
+        shutdown_ec   = ec;
+        shutdown_done = true;
+        failsafe_stop.request_stop();
+    };
+
+    // See the function docstring for why the drain + short delay is needed to
+    // land the cancellation on the shutdown read rather than the close_notify
+    // write.
+    auto server_drain_then_cancel = [&server, &stop_src, &s1,
+                                     mode]() -> capy::task<> {
+        char buf[64];
+        auto [ec, n] =
+            co_await server.read_some(capy::mutable_buffer(buf, sizeof(buf)));
+        (void)ec;
+        (void)n;
+        auto [dec] = co_await corosio::delay(
+            std::chrono::milliseconds(20 * failsafe_scale));
+        (void)dec;
+        if (mode == shutdown_cancel_mode::socket_cancel)
+            s1.cancel();
+        else
+            stop_src.request_stop();
+    };
+
+    bool failsafe_hit  = false;
+    auto failsafe_task = [&failsafe_hit, &shutdown_done, &s1,
+                          &s2]() -> capy::task<> {
+        auto [ec] = co_await corosio::delay(
+            std::chrono::milliseconds(2000 * failsafe_scale));
+        if (!ec && !shutdown_done)
+        {
+            failsafe_hit = true;
+            if (s1.is_open())
+            {
+                s1.cancel();
+                s1.close();
+            }
+            if (s2.is_open())
+            {
+                s2.cancel();
+                s2.close();
+            }
+        }
+    };
+
+    // The client task carries the stop token in both modes; only stop_token
+    // mode requests a stop, so socket_cancel mode is unaffected by it.
+    capy::run_async(ioc.get_executor(), stop_src.get_token())(
+        client_shutdown());
+    capy::run_async(ioc.get_executor())(server_drain_then_cancel());
+    capy::run_async(ioc.get_executor(), failsafe_stop.get_token())(
+        failsafe_task());
+    ioc.run();
+
+    BOOST_TEST(!failsafe_hit); // failsafe timeout should not be hit
+    BOOST_TEST(shutdown_ec == capy::cond::canceled);
+
+    if (s1.is_open())
+        s1.close();
+    if (s2.is_open())
+        s2.close();
+}
+
 /** Run a test for stop token cancellation during write.
 
     Tests that cooperative cancellation via std::stop_token correctly

--- a/test/unit/tls_stream_tests.hpp
+++ b/test/unit/tls_stream_tests.hpp
@@ -342,6 +342,27 @@ testStopTokenCancellation(StreamFactory make_stream)
     }
 }
 
+/** Test cancellation during shutdown (cppalliance/corosio#301).
+
+    Exercises both cancellation representations (stop token and socket cancel),
+    which reach the shutdown read as different error codes; both must surface
+    cond::canceled.
+*/
+template<typename StreamFactory>
+void
+testShutdownCancel(StreamFactory make_stream)
+{
+    for (auto mode : {shutdown_cancel_mode::socket_cancel,
+                      shutdown_cancel_mode::stop_token})
+    {
+        io_context ioc;
+        auto [client_ctx, server_ctx] =
+            make_contexts(context_mode::separate_cert);
+        run_shutdown_cancel_test(
+            ioc, client_ctx, server_ctx, make_stream, make_stream, mode);
+    }
+}
+
 /** Test socket error propagation. */
 template<typename StreamFactory>
 void

--- a/test/unit/wolfssl_stream.cpp
+++ b/test/unit/wolfssl_stream.cpp
@@ -153,6 +153,7 @@ struct wolfssl_stream_test
         test::testTlsShutdown(make_stream, cert_modes);
         test::testStreamTruncated(make_stream, cert_modes);
         test::testStopTokenCancellation(make_stream);
+        test::testShutdownCancel(make_stream);
         test::testSocketErrorPropagation(make_stream);
         test::testCertificateValidation(make_stream);
         test::testSni(make_stream);


### PR DESCRIPTION
…own (#301)

do_shutdown mis-reported a cancelled close_notify read: OpenSSL folded capy::error::canceled into stream_truncated via
normalize_openssl_shutdown_read_error, and WolfSSL silently swallowed the cancel and returned success. Either way the "operation was canceled" feedback was lost.

The root cause is a comparison-style bug: normalize used exact error_code == make_error_code(capy::error::X) checks, which bypass condition equivalence and match only one category representation. Cancellation reaches this code as two distinct codes -- generic std::errc::operation_canceled (stop-token cancels, forced by op_base) and capy-category capy::error::canceled (socket.cancel/io_uring/async_mutex) -- so the exact check caught only the capy form; WolfSSL dropped both.

- openssl: drop canceled from the normalize fold-list so it passes through, and compare the remaining eof branch against capy::cond::eof.
- openssl/wolfssl do_read_some: compare against capy::cond::eof instead of the concrete error code (same latent bug class; eof is single-representation today so behavior-preserving, but exact comparison is fragile).
- wolfssl do_shutdown: propagate a cancelled shutdown read via == capy::cond::canceled (matches both representations) instead of swallowing.
- timeout.hpp: document the result as comparing equal to capy::cond::timeout rather than steering callers toward the exact-code anti-pattern.
- test: new testShutdownCancel / run_shutdown_cancel_test exercising both cancel mechanisms across both backends; deterministically lands the cancel on the shutdown read via a close_notify drain + short yield.