### PR TITLE
Add non-throwing overloads for `stream_file` methods

### DIFF
--- a/include/boost/corosio/stream_file.hpp
+++ b/include/boost/corosio/stream_file.hpp
@@ -163,6 +163,18 @@ public:
         std::filesystem::path const& path,
         file_base::flags mode = file_base::read_only);
 
+    /** Open a file.
+
+        @param path The filesystem path to open.
+        @param mode Bitmask of @ref file_base::flags specifying
+            access mode and creation behavior.
+        @param ec Output error code.
+    */
+    void open(
+        std::filesystem::path const& path,
+        file_base::flags mode,
+        std::error_code& ec);
+
     /** Close the file.
 
         Releases file resources. Any pending operations complete
@@ -203,6 +215,12 @@ public:
     */
     std::uint64_t size() const;
 
+    /** Return the file size in bytes.
+
+        @param ec Output error code.
+    */
+    std::uint64_t size(std::error_code& ec) const;
+
     /** Resize the file to @p new_size bytes.
 
         @param new_size The new file size.
@@ -210,11 +228,24 @@ public:
     */
     void resize(std::uint64_t new_size);
 
+    /** Resize the file to @p new_size bytes.
+
+        @param new_size The new file size.
+        @param ec Output error code.
+    */
+    void resize(std::uint64_t new_size, std::error_code& ec);
+
     /** Synchronize file data to stable storage.
 
         @throws std::system_error on failure.
     */
     void sync_data();
+
+    /** Synchronize file data to stable storage.
+
+        @param ec Output error code.
+    */
+    void sync_data(std::error_code& ec);
 
     /** Synchronize file data and metadata to stable storage.
 
@@ -222,14 +253,31 @@ public:
     */
     void sync_all();
 
+    /** Synchronize file data and metadata to stable storage.
+
+        @param ec Output error code.
+    */
+    void sync_all(std::error_code& ec);
+
     /** Release ownership of the native handle.
 
         The file object becomes not-open. The caller is
         responsible for closing the returned handle.
 
         @return The native file descriptor or handle.
+        @throws std::system_error on failure.
     */
     native_handle_type release();
+
+    /** Release ownership of the native handle.
+
+        The file object becomes not-open. The caller is
+        responsible for closing the returned handle.
+
+        @param ec Output error code.
+        @return The native file descriptor or handle.
+    */
+    native_handle_type release(std::error_code& ec);
 
     /** Adopt an existing native handle.
 
@@ -237,7 +285,6 @@ public:
         The file object takes ownership of the handle.
 
         @param handle The native file descriptor or handle.
-        @throws std::system_error on failure.
     */
     void assign(native_handle_type handle);
 
@@ -251,6 +298,18 @@ public:
     std::uint64_t
     seek(std::int64_t offset,
          file_base::seek_basis origin = file_base::seek_set);
+
+    /** Move the file position.
+
+        @param offset Signed offset from @p origin.
+        @param origin The reference point for the seek.
+        @param ec Output error code.
+        @return The new absolute position.
+    */
+    std::uint64_t
+    seek(std::int64_t offset,
+         file_base::seek_basis origin,
+	 std::error_code& ec);
 
 protected:
     /// Default-construct (for derived types that initialize io_object directly).

--- a/src/corosio/src/stream_file.cpp
+++ b/src/corosio/src/stream_file.cpp
@@ -51,6 +51,7 @@ stream_file::open(
     file_base::flags mode,
     std::error_code& ec)
 {
+    ec.clear();
     if (is_open())
         close();
     auto& svc = static_cast<detail::file_service&>(h_.service());
@@ -102,6 +103,7 @@ stream_file::size() const
 std::uint64_t
 stream_file::size(std::error_code& ec) const
 {
+    ec.clear();
     if (!is_open())
         ec = make_error_code(std::errc::bad_file_descriptor);
     return get().size();
@@ -121,6 +123,7 @@ stream_file::resize(std::uint64_t new_size)
 void
 stream_file::resize(std::uint64_t new_size, std::error_code& ec)
 {
+    ec.clear();
     if (!is_open())
         ec = make_error_code(std::errc::bad_file_descriptor);
     get().resize(new_size);
@@ -159,6 +162,7 @@ stream_file::sync_all()
 void
 stream_file::sync_all(std::error_code& ec)
 {
+    ec.clear();
     if (!is_open())
         ec = make_error_code(std::errc::bad_file_descriptor);
     get().sync_all();
@@ -178,6 +182,7 @@ stream_file::release()
 native_handle_type
 stream_file::release(std::error_code& ec)
 {
+    ec.clear();
     if (!is_open())
         ec = make_error_code(std::errc::bad_file_descriptor);
     return get().release();
@@ -207,6 +212,7 @@ std::uint64_t
 stream_file::seek(
     std::int64_t offset, file_base::seek_basis origin, std::error_code& ec)
 {
+    ec.clear();
     if (!is_open())
         ec = make_error_code(std::errc::bad_file_descriptor);
     return get().seek(offset, origin);

--- a/src/corosio/src/stream_file.cpp
+++ b/src/corosio/src/stream_file.cpp
@@ -49,16 +49,12 @@ void
 stream_file::open(
     std::filesystem::path const& path,
     file_base::flags mode,
-    std::error_code& oec)
+    std::error_code& ec)
 {
     if (is_open())
         close();
-    auto& svc          = static_cast<detail::file_service&>(h_.service());
-    std::error_code ec = svc.open_file(get(), path, mode);
-    if (oec)
-    {
-        oec = ec;
-    }
+    auto& svc = static_cast<detail::file_service&>(h_.service());
+    ec        = svc.open_file(get(), path, mode);
 }
 
 void

--- a/src/corosio/src/stream_file.cpp
+++ b/src/corosio/src/stream_file.cpp
@@ -10,6 +10,7 @@
 #include <boost/corosio/stream_file.hpp>
 #include <boost/corosio/detail/except.hpp>
 #include <boost/corosio/detail/platform.hpp>
+#include <system_error>
 
 #if BOOST_COROSIO_HAS_IOCP
 #include <boost/corosio/native/detail/iocp/win_file_service.hpp>
@@ -34,15 +35,30 @@ stream_file::stream_file(capy::execution_context& ctx)
 }
 
 void
+stream_file::open(std::filesystem::path const& path, file_base::flags mode)
+{
+    std::error_code ec;
+    open(path, mode, ec);
+    if (ec)
+    {
+        detail::throw_system_error(ec, "stream_file::open");
+    }
+}
+
+void
 stream_file::open(
-    std::filesystem::path const& path, file_base::flags mode)
+    std::filesystem::path const& path,
+    file_base::flags mode,
+    std::error_code& oec)
 {
     if (is_open())
         close();
     auto& svc          = static_cast<detail::file_service&>(h_.service());
     std::error_code ec = svc.open_file(get(), path, mode);
-    if (ec)
-        detail::throw_system_error(ec, "stream_file::open");
+    if (oec)
+    {
+        oec = ec;
+    }
 }
 
 void
@@ -78,50 +94,96 @@ stream_file::native_handle() const noexcept
 std::uint64_t
 stream_file::size() const
 {
+    std::error_code ec;
+    std::uint64_t sz = size(ec);
+    if (ec)
+    {
+        detail::throw_system_error(ec, "stream_file::size");
+    }
+    return sz;
+}
+
+std::uint64_t
+stream_file::size(std::error_code& ec) const
+{
     if (!is_open())
-        detail::throw_system_error(
-            make_error_code(std::errc::bad_file_descriptor),
-            "stream_file::size");
+        ec = make_error_code(std::errc::bad_file_descriptor);
     return get().size();
 }
 
 void
 stream_file::resize(std::uint64_t new_size)
 {
+    std::error_code ec;
+    resize(new_size, ec);
+    if (ec)
+    {
+        detail::throw_system_error(ec, "stream_file::resize");
+    }
+}
+
+void
+stream_file::resize(std::uint64_t new_size, std::error_code& ec)
+{
     if (!is_open())
-        detail::throw_system_error(
-            make_error_code(std::errc::bad_file_descriptor),
-            "stream_file::resize");
+        ec = make_error_code(std::errc::bad_file_descriptor);
     get().resize(new_size);
 }
 
 void
 stream_file::sync_data()
 {
+    std::error_code ec;
+    sync_data(ec);
+    if (ec)
+    {
+        detail::throw_system_error(ec, "stream_file::sync_data");
+    }
+}
+
+void
+stream_file::sync_data(std::error_code& ec)
+{
     if (!is_open())
-        detail::throw_system_error(
-            make_error_code(std::errc::bad_file_descriptor),
-            "stream_file::sync_data");
+        ec = make_error_code(std::errc::bad_file_descriptor);
     get().sync_data();
 }
 
 void
 stream_file::sync_all()
 {
+    std::error_code ec;
+    sync_all(ec);
+    if (ec)
+    {
+        detail::throw_system_error(ec, "stream_file::sync_all");
+    }
+}
+
+void
+stream_file::sync_all(std::error_code& ec)
+{
     if (!is_open())
-        detail::throw_system_error(
-            make_error_code(std::errc::bad_file_descriptor),
-            "stream_file::sync_all");
+        ec = make_error_code(std::errc::bad_file_descriptor);
     get().sync_all();
 }
 
 native_handle_type
 stream_file::release()
 {
+    std::error_code ec;
+    native_handle_type h = release(ec);
+    if (ec)
+    {
+        detail::throw_system_error(ec, "stream_file::release");
+    }
+    return h;
+}
+native_handle_type
+stream_file::release(std::error_code& ec)
+{
     if (!is_open())
-        detail::throw_system_error(
-            make_error_code(std::errc::bad_file_descriptor),
-            "stream_file::release");
+        ec = make_error_code(std::errc::bad_file_descriptor);
     return get().release();
 }
 
@@ -136,10 +198,21 @@ stream_file::assign(native_handle_type handle)
 std::uint64_t
 stream_file::seek(std::int64_t offset, file_base::seek_basis origin)
 {
+    std::error_code ec;
+    std::uint64_t pos = seek(offset, origin, ec);
+    if (ec)
+    {
+        detail::throw_system_error(ec, "stream_file::seek");
+    }
+    return pos;
+}
+
+std::uint64_t
+stream_file::seek(
+    std::int64_t offset, file_base::seek_basis origin, std::error_code& ec)
+{
     if (!is_open())
-        detail::throw_system_error(
-            make_error_code(std::errc::bad_file_descriptor),
-            "stream_file::seek");
+        ec = make_error_code(std::errc::bad_file_descriptor);
     return get().seek(offset, origin);
 }
 


### PR DESCRIPTION
This PR adds non-throwing overloads with the last `std::error_code &` parameter for the following `stream_file` methods:
- `open`
- `size`
- `resize`
- `sync_data`
- `sync_all`
- `seek`

This PR closes #261.