### PR TITLE
refactor: port to capy's io_result tuple alias

### DIFF
--- a/include/boost/corosio/delay.hpp
+++ b/include/boost/corosio/delay.hpp
@@ -182,7 +182,7 @@ public:
     }
 
     /// Return empty on expiry, `error::canceled` if stop won.
-    capy::io_result<> await_resume() noexcept
+    [[nodiscard]] capy::io_result<> await_resume() noexcept
     {
         if(canceled_)
             return {capy::error::canceled};
@@ -312,7 +312,7 @@ public:
     }
 
     /// Return empty on deadline, `error::canceled` if stop won.
-    capy::io_result<> await_resume() noexcept
+    [[nodiscard]] capy::io_result<> await_resume() noexcept
     {
         if(canceled_)
             return {capy::error::canceled};

--- a/include/boost/corosio/detail/op_base.hpp
+++ b/include/boost/corosio/detail/op_base.hpp
@@ -48,7 +48,7 @@ public:
         return token_.stop_requested();
     }
 
-    capy::io_result<std::size_t> await_resume() const noexcept
+    [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
     {
         if (token_.stop_requested())
             return {make_error_code(std::errc::operation_canceled), 0};
@@ -90,7 +90,7 @@ public:
         return token_.stop_requested();
     }
 
-    capy::io_result<> await_resume() const noexcept
+    [[nodiscard]] capy::io_result<> await_resume() const noexcept
     {
         if (token_.stop_requested())
             return {make_error_code(std::errc::operation_canceled)};

--- a/include/boost/corosio/detail/timeout_awaitable.hpp
+++ b/include/boost/corosio/detail/timeout_awaitable.hpp
@@ -238,10 +238,10 @@ struct timeout_awaitable
         // landing in the same window as the deadline firing is
         // reported as a timeout.
         if (fired && !parent &&
-            r.ec == capy::cond::canceled)
+            std::get<0>(r) == capy::cond::canceled)
         {
             std::remove_cvref_t<decltype(r)> t{};
-            t.ec = make_error_code(capy::error::timeout);
+            std::get<0>(t) = make_error_code(capy::error::timeout);
             return t;
         }
         return r;

--- a/include/boost/corosio/detail/timer.hpp
+++ b/include/boost/corosio/detail/timer.hpp
@@ -531,7 +531,7 @@ struct wait_awaitable
     // Cancellation surfaces through w_.ec_: the stop_token path in
     // wait() completes the waiter with error::canceled written to
     // it, so there is no separate token to consult here.
-    capy::io_result<> await_resume() const noexcept
+    [[nodiscard]] capy::io_result<> await_resume() const noexcept
     {
         return {w_.ec_};
     }

--- a/include/boost/corosio/io/io_signal_set.hpp
+++ b/include/boost/corosio/io/io_signal_set.hpp
@@ -51,7 +51,7 @@ class BOOST_COROSIO_DECL io_signal_set : public io_object
             return token_.stop_requested();
         }
 
-        capy::io_result<int> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<int> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {capy::error::canceled, 0};

--- a/include/boost/corosio/local_stream_acceptor.hpp
+++ b/include/boost/corosio/local_stream_acceptor.hpp
@@ -111,7 +111,7 @@ class BOOST_COROSIO_DECL local_stream_acceptor : public io_object
             return token_.stop_requested();
         }
 
-        capy::io_result<local_stream_socket> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<local_stream_socket> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled),
@@ -154,7 +154,7 @@ class BOOST_COROSIO_DECL local_stream_acceptor : public io_object
             return token_.stop_requested();
         }
 
-        capy::io_result<> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled)};

--- a/include/boost/corosio/native/native_local_datagram_socket.hpp
+++ b/include/boost/corosio/native/native_local_datagram_socket.hpp
@@ -116,7 +116,7 @@ class native_local_datagram_socket : public local_datagram_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), 0};
@@ -161,7 +161,7 @@ class native_local_datagram_socket : public local_datagram_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), 0};
@@ -197,7 +197,7 @@ class native_local_datagram_socket : public local_datagram_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled)};
@@ -233,7 +233,7 @@ class native_local_datagram_socket : public local_datagram_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled)};
@@ -274,7 +274,7 @@ class native_local_datagram_socket : public local_datagram_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), 0};
@@ -316,7 +316,7 @@ class native_local_datagram_socket : public local_datagram_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), 0};

--- a/include/boost/corosio/native/native_local_stream_acceptor.hpp
+++ b/include/boost/corosio/native/native_local_stream_acceptor.hpp
@@ -94,7 +94,7 @@ class native_local_stream_acceptor : public local_stream_acceptor
             return token_.stop_requested();
         }
 
-        capy::io_result<> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled)};
@@ -131,7 +131,7 @@ class native_local_stream_acceptor : public local_stream_acceptor
             return token_.stop_requested();
         }
 
-        capy::io_result<> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled)};
@@ -167,7 +167,7 @@ class native_local_stream_acceptor : public local_stream_acceptor
             return token_.stop_requested();
         }
 
-        capy::io_result<native_local_stream_socket<Backend>>
+        [[nodiscard]] capy::io_result<native_local_stream_socket<Backend>>
         await_resume() const noexcept
         {
             if (token_.stop_requested())

--- a/include/boost/corosio/native/native_local_stream_socket.hpp
+++ b/include/boost/corosio/native/native_local_stream_socket.hpp
@@ -105,7 +105,7 @@ class native_local_stream_socket : public local_stream_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), 0};
@@ -143,7 +143,7 @@ class native_local_stream_socket : public local_stream_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), 0};
@@ -178,7 +178,7 @@ class native_local_stream_socket : public local_stream_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled)};
@@ -214,7 +214,7 @@ class native_local_stream_socket : public local_stream_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled)};

--- a/include/boost/corosio/native/native_random_access_file.hpp
+++ b/include/boost/corosio/native/native_random_access_file.hpp
@@ -110,7 +110,7 @@ class native_random_access_file : public random_access_file
             return token_.stop_requested();
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), 0};
@@ -152,7 +152,7 @@ class native_random_access_file : public random_access_file
             return token_.stop_requested();
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), 0};

--- a/include/boost/corosio/native/native_resolver.hpp
+++ b/include/boost/corosio/native/native_resolver.hpp
@@ -85,7 +85,7 @@ class native_resolver : public resolver
             return token_.stop_requested();
         }
 
-        capy::io_result<resolver_results> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<resolver_results> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), {}};
@@ -126,7 +126,7 @@ class native_resolver : public resolver
             return token_.stop_requested();
         }
 
-        capy::io_result<reverse_resolver_result> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<reverse_resolver_result> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), {}};

--- a/include/boost/corosio/native/native_signal_set.hpp
+++ b/include/boost/corosio/native/native_signal_set.hpp
@@ -74,7 +74,7 @@ class native_signal_set : public signal_set
             return token_.stop_requested();
         }
 
-        capy::io_result<int> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<int> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {capy::error::canceled, 0};

--- a/include/boost/corosio/native/native_stream_file.hpp
+++ b/include/boost/corosio/native/native_stream_file.hpp
@@ -106,7 +106,7 @@ class native_stream_file : public stream_file
             return token_.stop_requested();
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), 0};
@@ -144,7 +144,7 @@ class native_stream_file : public stream_file
             return token_.stop_requested();
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), 0};

--- a/include/boost/corosio/native/native_tcp_acceptor.hpp
+++ b/include/boost/corosio/native/native_tcp_acceptor.hpp
@@ -87,7 +87,7 @@ class native_tcp_acceptor : public tcp_acceptor
             return token_.stop_requested();
         }
 
-        capy::io_result<> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled)};
@@ -123,7 +123,7 @@ class native_tcp_acceptor : public tcp_acceptor
             return token_.stop_requested();
         }
 
-        capy::io_result<> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled)};
@@ -160,7 +160,7 @@ class native_tcp_acceptor : public tcp_acceptor
             return token_.stop_requested();
         }
 
-        capy::io_result<tcp_socket> await_resume() noexcept
+        [[nodiscard]] capy::io_result<tcp_socket> await_resume() noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled),

--- a/include/boost/corosio/native/native_tcp_socket.hpp
+++ b/include/boost/corosio/native/native_tcp_socket.hpp
@@ -104,7 +104,7 @@ class native_tcp_socket : public tcp_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), 0};
@@ -141,7 +141,7 @@ class native_tcp_socket : public tcp_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), 0};
@@ -175,7 +175,7 @@ class native_tcp_socket : public tcp_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled)};
@@ -209,7 +209,7 @@ class native_tcp_socket : public tcp_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled)};

--- a/include/boost/corosio/native/native_udp_socket.hpp
+++ b/include/boost/corosio/native/native_udp_socket.hpp
@@ -115,7 +115,7 @@ class native_udp_socket : public udp_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), 0};
@@ -160,7 +160,7 @@ class native_udp_socket : public udp_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), 0};
@@ -195,7 +195,7 @@ class native_udp_socket : public udp_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled)};
@@ -229,7 +229,7 @@ class native_udp_socket : public udp_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled)};
@@ -270,7 +270,7 @@ class native_udp_socket : public udp_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), 0};
@@ -312,7 +312,7 @@ class native_udp_socket : public udp_socket
             return token_.stop_requested();
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), 0};

--- a/include/boost/corosio/random_access_file.hpp
+++ b/include/boost/corosio/random_access_file.hpp
@@ -163,7 +163,7 @@ public:
             return false;
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             return {ec_, bytes_};
         }
@@ -204,7 +204,7 @@ public:
             return false;
         }
 
-        capy::io_result<std::size_t> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<std::size_t> await_resume() const noexcept
         {
             return {ec_, bytes_};
         }

--- a/include/boost/corosio/resolver.hpp
+++ b/include/boost/corosio/resolver.hpp
@@ -218,7 +218,7 @@ class BOOST_COROSIO_DECL resolver : public io_object
             return token_.stop_requested();
         }
 
-        capy::io_result<resolver_results> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<resolver_results> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), {}};
@@ -257,7 +257,7 @@ class BOOST_COROSIO_DECL resolver : public io_object
             return token_.stop_requested();
         }
 
-        capy::io_result<reverse_resolver_result> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<reverse_resolver_result> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled), {}};

--- a/include/boost/corosio/tcp_acceptor.hpp
+++ b/include/boost/corosio/tcp_acceptor.hpp
@@ -117,7 +117,7 @@ class BOOST_COROSIO_DECL tcp_acceptor : public io_object
             return token_.stop_requested();
         }
 
-        capy::io_result<> await_resume() const noexcept
+        [[nodiscard]] capy::io_result<> await_resume() const noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled)};
@@ -155,7 +155,7 @@ class BOOST_COROSIO_DECL tcp_acceptor : public io_object
             return token_.stop_requested();
         }
 
-        capy::io_result<tcp_socket> await_resume() noexcept
+        [[nodiscard]] capy::io_result<tcp_socket> await_resume() noexcept
         {
             if (token_.stop_requested())
                 return {make_error_code(std::errc::operation_canceled),

--- a/include/boost/corosio/test/mocket.hpp
+++ b/include/boost/corosio/test/mocket.hpp
@@ -408,7 +408,7 @@ public:
         return underlying_.await_suspend(std::forward<Args>(args)...);
     }
 
-    capy::io_result<std::size_t> await_resume()
+    [[nodiscard]] capy::io_result<std::size_t> await_resume()
     {
         if (sync_)
             return {ec_, n_};
@@ -509,7 +509,7 @@ public:
         return underlying_.await_suspend(std::forward<Args>(args)...);
     }
 
-    capy::io_result<std::size_t> await_resume()
+    [[nodiscard]] capy::io_result<std::size_t> await_resume()
     {
         if (sync_)
             return {ec_, n_};

--- a/test/doc/snippets/4m_error_handling.cpp
+++ b/test/doc/snippets/4m_error_handling.cpp
@@ -139,12 +139,12 @@ direct_members(
 {
     // tag::direct_members[]
     auto result = co_await sock.connect(endpoint);
-    if (!result.ec)
+    if (!std::get<0>(result))
         std::cout << "Connected successfully\n";
     else
-        std::cerr << "Failed: " << result.ec.message() << "\n";
+        std::cerr << "Failed: " << std::get<0>(result).message() << "\n";
     // end::direct_members[]
-    out = result.ec;
+    out = std::get<0>(result);
 }
 
 capy::task<>
@@ -189,8 +189,8 @@ throw_style(
 {
     // tag::throw_style[]
     auto throw_on_error = [](auto result) {
-        if (result.ec)
-            throw std::system_error(result.ec);
+        if (std::get<0>(result))
+            throw std::system_error(std::get<0>(result));
         return result;
     };
 
@@ -406,9 +406,9 @@ struct error_handling_test
         // Typed result (resolve)
         io_result<resolver_results> r3;  // Contains: ec, results
         // end::result_shapes[]
-        BOOST_TEST(!r1.ec);
-        BOOST_TEST(!r2.ec);
-        BOOST_TEST(!r3.ec);
+        BOOST_TEST(!std::get<0>(r1));
+        BOOST_TEST(!std::get<0>(r2));
+        BOOST_TEST(!std::get<0>(r3));
     }
 
     void

--- a/test/unit/resolver.cpp
+++ b/test/unit/resolver.cpp
@@ -647,7 +647,7 @@ struct resolver_test
             auto result = co_await r_ref.resolve(
                 "127.0.0.1", "80",
                 resolve_flags::numeric_host | resolve_flags::numeric_service);
-            ok_out = !result.ec;
+            ok_out = !std::get<0>(result);
         };
         capy::run_async(ioc.get_executor())(task(r, result_ok));
 
@@ -668,8 +668,8 @@ struct resolver_test
                        std::error_code& ec_out) -> capy::task<> {
             auto result = co_await r_ref.resolve(
                 "not-a-valid-ip", "80", resolve_flags::numeric_host);
-            error_out = static_cast<bool>(result.ec);
-            ec_out    = result.ec;
+            error_out = static_cast<bool>(std::get<0>(result));
+            ec_out    = std::get<0>(result);
         };
         capy::run_async(ioc.get_executor())(task(r, got_error, result_ec));
 

--- a/test/unit/signal_set.cpp
+++ b/test/unit/signal_set.cpp
@@ -599,7 +599,7 @@ struct signal_set_test
             std::raise(SIGINT);
 
             auto result = co_await s_ref.wait();
-            ok_out      = !result.ec;
+            ok_out      = !std::get<0>(result);
         };
         capy::run_async(ioc.get_executor())(task(s, result_ok));
 
@@ -618,8 +618,8 @@ struct signal_set_test
         auto wait_task = [](signal_set& s_ref, bool& ok_out,
                             std::error_code& ec_out) -> capy::task<> {
             auto result = co_await s_ref.wait();
-            ok_out      = !result.ec;
-            ec_out      = result.ec;
+            ok_out      = !std::get<0>(result);
+            ec_out      = std::get<0>(result);
         };
         capy::run_async(ioc.get_executor())(wait_task(s, result_ok, result_ec));
 

--- a/test/unit/timeout.cpp
+++ b/test/unit/timeout.cpp
@@ -58,7 +58,7 @@ struct payload_awaitable
     }
     capy::io_result<int> await_resume() noexcept
     {
-        return {{}, value_};
+        return {std::error_code(), value_};
     }
 };
 
@@ -278,7 +278,7 @@ struct timeout_test
             }
             capy::io_result<int> await_resume() noexcept
             {
-                return {{}, value_};
+                return {std::error_code(), value_};
             }
         };
 


### PR DESCRIPTION
capy's io_result is now an alias for std::tuple<error_code, Ts...>, so the .ec member is gone; held results read the error through std::get<0>. Structured-binding call sites are unchanged. The {{}, n} success shorthand becomes std::error_code() explicitly, since the leading {} also matches allocator_arg_t in libstdc++'s allocator-extended tuple constructors.

The alias cannot carry the type-level [[nodiscard]], so every awaitable whose await_resume returns an io_result marks the function [[nodiscard]] instead, preserving the discarded-error diagnostic for corosio operations.

The TLS engine_result struct keeps its own ec member and is untouched.

Related to cppalliance/capy#266